### PR TITLE
fix: silence Cobra error echo on command failure

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,10 +11,11 @@ import (
 // tests so that each invocation starts from a clean command tree.
 func newRootCmd(version string) *cobra.Command {
 	root := &cobra.Command{
-		Use:     "gh-agentic",
-		Short:   "Agentic software delivery — environment management for gh",
-		Long:    "gh-agentic bootstraps and manages agentic software delivery environments via the GitHub CLI.",
-		Version: version,
+		Use:          "gh-agentic",
+		Short:        "Agentic software delivery — environment management for gh",
+		Long:         "gh-agentic bootstraps and manages agentic software delivery environments via the GitHub CLI.",
+		Version:      version,
+		SilenceErrors: true,
 	}
 	root.AddCommand(newBootstrapCmd())
 	root.AddCommand(newInceptionCmd())


### PR DESCRIPTION
## Summary
- Adds `SilenceErrors: true` to the root command
- Prevents Cobra printing `Error: <msg>` after subcommands have already shown a user-friendly failure message
- Fixes the duplicate error line seen in `gh agentic doctor` output

## Test plan
- [ ] `go test ./...` passes
- [ ] `gh agentic doctor` on a failing workspace shows only the repair hint, no `Error: ...` echo

🤖 Generated with [Claude Code](https://claude.com/claude-code)