### PR TITLE
fix: suppress residual error echo in doctor output

### DIFF
--- a/cmd/gh-agentic/main.go
+++ b/cmd/gh-agentic/main.go
@@ -16,7 +16,9 @@ var version = "dev"
 
 func main() {
 	if err := cli.Execute(version); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		if err != cli.ErrSilent {
+			fmt.Fprintln(os.Stderr, err)
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -130,7 +130,7 @@ func newDoctorCmd() *cobra.Command {
 
 			if err := verify.RunVerify(w, checks, repairFn); err != nil {
 				fmt.Fprintln(w, "  Run 'gh agentic doctor --repair' to attempt automatic fixes.")
-				return err
+				return ErrSilent
 			}
 			return nil
 		},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,8 +4,15 @@
 package cli
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 )
+
+// ErrSilent is returned by subcommands that have already printed a
+// user-friendly error message. main.go checks for it and exits non-zero
+// without printing anything further.
+var ErrSilent = errors.New("silent exit")
 
 // newRootCmd constructs a fresh root cobra command. Called by Execute and in
 // tests so that each invocation starts from a clean command tree.


### PR DESCRIPTION
## Summary
- Adds `ErrSilent` sentinel to the `cli` package
- `doctor` returns `ErrSilent` after printing its own failure message
- `main.go` checks for `ErrSilent` and exits non-zero without printing anything
- Eliminates the bare `3 warnings, 6 failures remain` line at the end of output

## Test plan
- [ ] `go test ./...` passes
- [ ] `gh agentic doctor` on a failing workspace shows clean output ending with the repair hint only — no bare error text

🤖 Generated with [Claude Code](https://claude.com/claude-code)