### PR TITLE
fix: repair base/ via sync.RunSync directly, fix stale switch case names

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -109,17 +109,17 @@ func newDoctorCmd() *cobra.Command {
 						r = verify.RepairREPOSMD(root)
 					case "README.md exists":
 						r = verify.RepairREADMEMD(root)
-					case "base/ directory integrity":
-						r = verify.RepairBaseDir(root, run, boolConfirm)
-					case "base/skills/ integrity":
+					case "base/ exists and is unmodified":
+						r = verify.RepairBaseDirWithWriter(w, root, run, boolConfirm)
+					case "base/skills/*.md unmodified":
 						r = verify.RepairBaseRecipes(root, run, boolConfirm)
 					case ".goose/recipes/ exists and complete":
 						r = verify.RepairGooseRecipes(root)
 					case ".github/workflows/ exists and complete":
 						r = verify.RepairWorkflows(root)
-					case "GitHub labels configured":
+					case "Standard labels present":
 						r = verify.RepairLabels(repoFullName, run)
-					case "GitHub Project exists":
+					case "GitHub Project linked":
 						r = verify.RepairProject(owner, repoName, run)
 					default:
 						return nil

--- a/internal/verify/repair.go
+++ b/internal/verify/repair.go
@@ -2,12 +2,14 @@ package verify
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/eddiecarpenter/gh-agentic/internal/bootstrap"
+	"github.com/eddiecarpenter/gh-agentic/internal/sync"
 )
 
 // ConfirmFunc prompts the user for a text input and returns the value.
@@ -244,6 +246,11 @@ type BoolConfirmFunc func(prompt string) (bool, error)
 // RepairBaseDir re-syncs base/ from the template after prompting the user.
 // run is injected for git operations, confirmFn for user prompt.
 func RepairBaseDir(root string, run bootstrap.RunCommandFunc, confirmFn BoolConfirmFunc) CheckResult {
+	return RepairBaseDirWithWriter(io.Discard, root, run, confirmFn)
+}
+
+// RepairBaseDirWithWriter is like RepairBaseDir but writes sync output to w.
+func RepairBaseDirWithWriter(w io.Writer, root string, run bootstrap.RunCommandFunc, confirmFn BoolConfirmFunc) CheckResult {
 	if confirmFn != nil {
 		ok, err := confirmFn("base/ has issues — re-sync from template?")
 		if err != nil || !ok {
@@ -257,13 +264,14 @@ func RepairBaseDir(root string, run bootstrap.RunCommandFunc, confirmFn BoolConf
 
 	baseDir := filepath.Join(root, "base")
 	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
-		// base/ has never been synced — run 'gh agentic sync' to populate it.
-		_, runErr := run("gh", "agentic", "sync")
-		if runErr != nil {
+		// base/ has never been synced — call sync.RunSync directly with force=true
+		// and an auto-confirm so it runs non-interactively.
+		autoConfirm := func(_ string) (bool, error) { return true, nil }
+		if syncErr := sync.RunSync(w, root, run, sync.DefaultFetchRelease, sync.DefaultSpinner, autoConfirm, true); syncErr != nil {
 			return CheckResult{
 				Name:    "base/ exists and is unmodified",
 				Status:  Fail,
-				Message: fmt.Sprintf("sync failed: %v", runErr),
+				Message: fmt.Sprintf("sync failed: %v", syncErr),
 			}
 		}
 	} else {

--- a/internal/verify/repair_test.go
+++ b/internal/verify/repair_test.go
@@ -168,6 +168,10 @@ func TestRepairREADMEMD_CreatesFile(t *testing.T) {
 
 func TestRepairBaseDir_UserConfirms_ReturnsPass(t *testing.T) {
 	root := t.TempDir()
+	// Create base/ so the repair takes the git-checkout path (not sync).
+	if err := os.MkdirAll(filepath.Join(root, "base"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	fakeRun := func(name string, args ...string) (string, error) {
 		return "", nil
 	}


### PR DESCRIPTION
## Summary
- `RepairBaseDir`: when `base/` is absent, calls `sync.RunSync` directly with `force=true` and an auto-confirm — avoids the non-interactive subprocess problem of shelling out to `gh agentic sync`
- `doctor.go`: fixes stale switch case names (`"base/ directory integrity"` → `"base/ exists and is unmodified"`, `"base/skills/ integrity"` → `"base/skills/*.md unmodified"`, `"GitHub labels configured"` → `"Standard labels present"`, `"GitHub Project exists"` → `"GitHub Project linked"`) — these never matched so repairs for those checks were silently skipped

## Test plan
- [ ] `go test ./...` passes
- [ ] `gh agentic doctor --repair` on openbss successfully restores `base/` via sync
- [ ] Labels and project repair now actually triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)