### PR TITLE
fix: CheckBaseRecipes path typo base/recipes → base/skills

### DIFF
--- a/internal/verify/checks.go
+++ b/internal/verify/checks.go
@@ -173,7 +173,7 @@ func CheckBaseDir(root string, run bootstrap.RunCommandFunc) CheckResult {
 // CheckBaseRecipes verifies that base/skills/*.md files exist and are unmodified.
 // Uses RunCommandFunc for git operations.
 func CheckBaseRecipes(root string, run bootstrap.RunCommandFunc) CheckResult {
-	recipesPath := filepath.Join(root, "base", "recipes")
+	recipesPath := filepath.Join(root, "base", "skills")
 	if _, err := os.Stat(recipesPath); os.IsNotExist(err) {
 		return CheckResult{
 			Name:    "base/skills/*.md unmodified",

--- a/internal/verify/checks_test.go
+++ b/internal/verify/checks_test.go
@@ -209,7 +209,7 @@ func TestCheckBaseDir_Modified_ReturnsFail(t *testing.T) {
 
 func TestCheckBaseRecipes_Present_NoModifications_ReturnsPass(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "base", "recipes"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, "base", "skills"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -237,7 +237,7 @@ func TestCheckBaseRecipes_Missing_ReturnsWarning(t *testing.T) {
 
 func TestCheckBaseRecipes_Modified_ReturnsWarning(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "base", "recipes"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, "base", "skills"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary
`CheckBaseRecipes` was checking `base/recipes/` but the directory is `base/skills/` — so it always reported "directory not found" regardless of the actual state. Fix the path in both the check and the test setup.

## Test plan
- [ ] `go test ./...` passes
- [ ] `gh agentic doctor` on openbss correctly reports `base/skills/` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)