### PR TITLE
feat: add --yes flag to sync for non-interactive use

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -14,6 +14,7 @@ import (
 // newSyncCmd constructs the `gh agentic sync` subcommand.
 func newSyncCmd() *cobra.Command {
 	var force bool
+	var yes bool
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -21,7 +22,8 @@ func newSyncCmd() *cobra.Command {
 		Long: "Syncs the base/ directory from the upstream agentic-development template.\n" +
 			"Reads TEMPLATE_SOURCE and TEMPLATE_VERSION to determine what to sync.\n" +
 			"Shows a diff and asks for confirmation before committing.\n" +
-			"Pass --force to re-sync even when already at the latest version.",
+			"Pass --force to re-sync even when already at the latest version.\n" +
+			"Pass --yes to automatically confirm all prompts.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 
@@ -34,19 +36,28 @@ func newSyncCmd() *cobra.Command {
 				}
 			}
 
+			confirmFn := sync.DefaultConfirm
+			if yes {
+				confirmFn = func(prompt string) (bool, error) {
+					fmt.Fprintf(w, "  %s [y/N]: y\n", prompt)
+					return true, nil
+				}
+			}
+
 			return sync.RunSync(
 				w,
 				repoRoot,
 				bootstrap.DefaultRunCommand,
 				sync.DefaultFetchRelease,
 				sync.DefaultSpinner,
-				sync.DefaultConfirm,
+				confirmFn,
 				force,
 			)
 		},
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "re-sync even if already at the latest version")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "automatically confirm all prompts")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary
- Adds `--yes` / `-y` flag to `gh agentic sync` to auto-confirm the apply prompt
- Matches the `--yes` behaviour already present on `doctor`
- Fixes TTY error when sync is invoked from non-interactive contexts (CI, Claude Code Bash tool, Goose)

## Test plan
- [ ] `go test ./...` passes
- [ ] `gh agentic sync --force --yes` runs end-to-end without prompting

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)