### PR TITLE
fix: sync exits cleanly when nothing to commit after re-sync

### DIFF
--- a/internal/sync/steps.go
+++ b/internal/sync/steps.go
@@ -93,10 +93,16 @@ func UpdateVersion(repoRoot, version string) error {
 }
 
 // CommitSync stages base/ and TEMPLATE_VERSION, then commits with a descriptive message.
+// If nothing changed after staging, the commit is skipped cleanly.
 func CommitSync(repoRoot, repo, version string, run bootstrap.RunCommandFunc) error {
 	// Stage changes.
 	if out, err := runInDir(run, repoRoot, "git", "add", "base/", "TEMPLATE_VERSION"); err != nil {
 		return fmt.Errorf("git add: %w\n%s", err, strings.TrimSpace(out))
+	}
+
+	// Check if anything is actually staged — exit 0 means no diff (nothing to commit).
+	if _, err := runInDir(run, repoRoot, "git", "diff", "--cached", "--quiet"); err == nil {
+		return nil
 	}
 
 	// Commit.

--- a/internal/sync/steps_test.go
+++ b/internal/sync/steps_test.go
@@ -237,7 +237,12 @@ func TestCommitSync(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		var calls []string
 		run := func(name string, args ...string) (string, error) {
-			calls = append(calls, name+" "+strings.Join(args, " "))
+			joined := name + " " + strings.Join(args, " ")
+			calls = append(calls, joined)
+			// Simulate staged changes: git diff --cached --quiet exits non-zero.
+			if strings.Contains(joined, "diff") && strings.Contains(joined, "--cached") {
+				return "", fmt.Errorf("exit 1")
+			}
 			return "", nil
 		}
 
@@ -246,8 +251,8 @@ func TestCommitSync(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if len(calls) != 2 {
-			t.Fatalf("expected 2 calls, got %d: %v", len(calls), calls)
+		if len(calls) != 3 {
+			t.Fatalf("expected 3 calls, got %d: %v", len(calls), calls)
 		}
 
 		// Verify git add was called.
@@ -255,9 +260,33 @@ func TestCommitSync(t *testing.T) {
 			t.Errorf("first call should be git add: %s", calls[0])
 		}
 
+		// Verify git diff --cached --quiet was called.
+		if !strings.Contains(calls[1], "diff") || !strings.Contains(calls[1], "--cached") {
+			t.Errorf("second call should be git diff --cached: %s", calls[1])
+		}
+
 		// Verify git commit was called with correct message.
-		if !strings.Contains(calls[1], "commit") || !strings.Contains(calls[1], "sync base/") {
-			t.Errorf("second call should be git commit: %s", calls[1])
+		if !strings.Contains(calls[2], "commit") || !strings.Contains(calls[2], "sync base/") {
+			t.Errorf("third call should be git commit: %s", calls[2])
+		}
+	})
+
+	t.Run("nothing to commit", func(t *testing.T) {
+		var calls []string
+		run := func(name string, args ...string) (string, error) {
+			joined := name + " " + strings.Join(args, " ")
+			calls = append(calls, joined)
+			// git diff --cached --quiet exits 0 = nothing staged.
+			return "", nil
+		}
+
+		err := CommitSync("/repo", "owner/template", "v0.2.0", run)
+		if err != nil {
+			t.Fatalf("expected nil when nothing to commit, got: %v", err)
+		}
+
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls (add + diff check), got %d: %v", len(calls), calls)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- When `--force` is used on a repo already at the latest version, `git commit` would fail with "nothing to commit"
- Now checks `git diff --cached --quiet` after staging — skips the commit silently if nothing changed
- Added a `nothing to commit` test case to `TestCommitSync`

## Test plan
- [ ] `go test ./...` passes
- [ ] `gh agentic sync --force --yes` exits cleanly with no error on an up-to-date repo

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)