### PR TITLE
feat: read template config from .ai/config.yml, delete legacy files after sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cli/go-gh/v2 v2.13.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/mod v0.17.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -44,5 +45,4 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/bootstrap/template.go
+++ b/internal/bootstrap/template.go
@@ -38,10 +38,17 @@ func (t *ProjectTemplate) ResolvedStatusOptions() []StatusOption {
 	return t.StatusField.Options
 }
 
-// LoadProjectTemplate reads and parses base/project-template.json from the given root directory.
+// LoadProjectTemplate reads and parses .ai/project-template.json from the given root directory.
+// Falls back to base/project-template.json for repos not yet migrated to v1.5.0+.
 // Returns structured data or a descriptive error if the file is missing or malformed.
+//
+// TODO(deprecated): remove base/ fallback in next major version.
 func LoadProjectTemplate(root string) (*ProjectTemplate, error) {
-	path := filepath.Join(root, "base", "project-template.json")
+	path := filepath.Join(root, ".ai", "project-template.json")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// TODO(deprecated): remove in next major version — base/ fallback for pre-v1.5.0 repos.
+		path = filepath.Join(root, "base", "project-template.json")
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading project template %s: %w", path, err)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -83,10 +83,9 @@ func runDoctor(w io.Writer, in io.Reader, cfg doctorConfig) error {
 	// All checks in pipeline order.
 	checks := []verify.CheckFunc{
 		func() verify.CheckResult { return verify.CheckCLAUDEMD(cfg.root) },
-		func() verify.CheckResult { return verify.CheckAGENTSLocalMD(cfg.root) },
+		func() verify.CheckResult { return verify.CheckLOCALRULESMD(cfg.root) },
 		func() verify.CheckResult { return verify.CheckSkillsDir(cfg.root) },
-		func() verify.CheckResult { return verify.CheckTEMPLATESOURCE(cfg.root) },
-		func() verify.CheckResult { return verify.CheckTEMPLATEVERSION(cfg.root) },
+		func() verify.CheckResult { return verify.CheckAIConfigYML(cfg.root) },
 		func() verify.CheckResult { return verify.CheckREPOSMD(cfg.root) },
 		func() verify.CheckResult { return verify.CheckREADMEMD(cfg.root) },
 		func() verify.CheckResult { return verify.CheckOldLayout(cfg.root) },
@@ -125,14 +124,12 @@ func runDoctor(w io.Writer, in io.Reader, cfg doctorConfig) error {
 			switch result.Name {
 			case "CLAUDE.md exists":
 				r = verify.RepairCLAUDEMD(cfg.root)
-			case "AGENTS.local.md exists":
-				r = verify.RepairAGENTSLocalMD(cfg.root)
+			case "LOCALRULES.md exists":
+				r = verify.RepairLOCALRULESMD(cfg.root)
 			case "skills/ directory exists":
 				r = verify.RepairSkillsDir(cfg.root, run)
-			case "TEMPLATE_SOURCE exists":
-				r = verify.RepairTEMPLATESOURCE(cfg.root, textConfirm)
-			case "TEMPLATE_VERSION exists":
-				r = verify.RepairTEMPLATEVERSION(cfg.root, run)
+			case ".ai/config.yml exists":
+				r = verify.RepairAIConfigYML(cfg.root, run)
 			case "REPOS.md exists":
 				r = verify.RepairREPOSMD(cfg.root)
 			case "README.md exists":
@@ -229,16 +226,16 @@ func newDoctorCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 
-			// Resolve repo root. If TEMPLATE_SOURCE is not found (repo predates
-			// the extension), fall back to cwd — TEMPLATE_SOURCE missing will
-			// surface as a failed check that --repair can fix.
+			// Resolve repo root. If .ai/config.yml is not found (repo predates
+			// the extension or has not been synced), fall back to cwd — the
+			// missing config will surface as a failed check that --repair can fix.
 			root, err := findRepoRoot()
 			if err != nil {
 				root, err = os.Getwd()
 				if err != nil {
 					return fmt.Errorf("resolving working directory: %w", err)
 				}
-				fmt.Fprintln(w, "  "+ui.RenderWarning("TEMPLATE_SOURCE not found — using current directory as root"))
+				fmt.Fprintln(w, "  "+ui.RenderWarning(".ai/config.yml not found — using current directory as root"))
 				fmt.Fprintln(w)
 			}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -44,8 +44,8 @@ func setupDoctorFakeRepo(t *testing.T) *testutil.FakeRepo {
 	// .ai/skills/ must contain at least one .md for CheckAISkills.
 	repo.Write(filepath.Join(".ai", "skills", "dev-session.md"), "# skill\n")
 
-	// base/project-template.json for CheckProjectStatus (LoadProjectTemplate still reads from base/).
-	repo.Write(filepath.Join("base", "project-template.json"), `{
+	// .ai/project-template.json for CheckProjectStatus.
+	repo.Write(filepath.Join(".ai", "project-template.json"), `{
   "statusOptions": [
     {"name": "Backlog",        "color": "GRAY",   "description": "Prioritised, ready to start"},
     {"name": "Scoping",        "color": "PURPLE", "description": "Requirement or feature being scoped"},
@@ -198,9 +198,9 @@ func TestRunDoctor_MissingCLAUDEMD(t *testing.T) {
 	}
 }
 
-func TestRunDoctor_MissingAGENTSLocalMD(t *testing.T) {
+func TestRunDoctor_MissingLOCALRULESMD(t *testing.T) {
 	repo := setupDoctorFakeRepo(t)
-	repo.Remove("AGENTS.local.md")
+	repo.Remove("LOCALRULES.md")
 	mock := newMockRunner(t)
 
 	var buf bytes.Buffer
@@ -215,19 +215,21 @@ func TestRunDoctor_MissingAGENTSLocalMD(t *testing.T) {
 	}
 
 	err := runDoctor(&buf, strings.NewReader(""), cfg)
-	if err == nil {
-		t.Fatal("expected error for missing AGENTS.local.md, got nil")
-	}
 
 	output := buf.String()
-	if !strings.Contains(output, "AGENTS.local.md") {
-		t.Errorf("expected AGENTS.local.md mentioned in output, got:\n%s", output)
+	if !strings.Contains(output, "LOCALRULES.md") {
+		t.Errorf("expected LOCALRULES.md mentioned in output, got:\n%s", output)
+	}
+
+	// Missing LOCALRULES.md is a Warning — should not be a hard failure.
+	if err != nil && err != ErrSilent {
+		t.Errorf("expected nil or ErrSilent, got: %v", err)
 	}
 }
 
-func TestRunDoctor_MissingTEMPLATESOURCE(t *testing.T) {
+func TestRunDoctor_MissingAIConfigYML(t *testing.T) {
 	repo := setupDoctorFakeRepo(t)
-	repo.Remove("TEMPLATE_SOURCE")
+	repo.Remove(filepath.Join(".ai", "config.yml"))
 	mock := newMockRunner(t)
 
 	var buf bytes.Buffer
@@ -241,18 +243,15 @@ func TestRunDoctor_MissingTEMPLATESOURCE(t *testing.T) {
 		yes:          false,
 	}
 
-	// TEMPLATE_SOURCE missing is a Warning, not a Fail in some checks.
-	// The test verifies the output mentions TEMPLATE_SOURCE.
 	err := runDoctor(&buf, strings.NewReader(""), cfg)
 
 	output := buf.String()
-	if !strings.Contains(output, "TEMPLATE_SOURCE") {
-		t.Errorf("expected TEMPLATE_SOURCE mentioned in output, got:\n%s", output)
+	if !strings.Contains(output, "config.yml") {
+		t.Errorf("expected config.yml mentioned in output, got:\n%s", output)
 	}
 
-	// If there is an error, it should be ErrSilent (already printed).
-	if err != nil && err != ErrSilent {
-		t.Errorf("expected nil or ErrSilent, got: %v", err)
+	if err == nil {
+		t.Error("expected error for missing .ai/config.yml, got nil")
 	}
 }
 
@@ -293,9 +292,9 @@ func TestRunDoctor_RepairYes_RestoreCLAUDEMD(t *testing.T) {
 	}
 }
 
-func TestRunDoctor_RepairYes_RestoreAGENTSLocalMD(t *testing.T) {
+func TestRunDoctor_RepairYes_RestoreLOCALRULESMD(t *testing.T) {
 	repo := setupDoctorFakeRepo(t)
-	repo.Remove("AGENTS.local.md")
+	repo.Remove("LOCALRULES.md")
 	mock := newMockRunner(t)
 
 	var buf bytes.Buffer
@@ -311,10 +310,10 @@ func TestRunDoctor_RepairYes_RestoreAGENTSLocalMD(t *testing.T) {
 
 	err := runDoctor(&buf, strings.NewReader(""), cfg)
 
-	// After repair, AGENTS.local.md should exist on disk.
-	agentsPath := filepath.Join(repo.Root, "AGENTS.local.md")
-	if _, statErr := os.Stat(agentsPath); os.IsNotExist(statErr) {
-		t.Error("expected AGENTS.local.md to be restored by repair, but file does not exist")
+	// After repair, LOCALRULES.md should exist on disk.
+	localRulesPath := filepath.Join(repo.Root, "LOCALRULES.md")
+	if _, statErr := os.Stat(localRulesPath); os.IsNotExist(statErr) {
+		t.Error("expected LOCALRULES.md to be restored by repair, but file does not exist")
 	}
 
 	output := buf.String()

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -46,7 +46,7 @@ func newSyncCmdWithDeps(deps syncDeps) *cobra.Command {
 		Use:   "sync",
 		Short: "Sync .ai/ from the upstream template",
 		Long: "Syncs the .ai/ directory from the upstream agentic-development template.\n" +
-			"Reads TEMPLATE_SOURCE and TEMPLATE_VERSION to determine what to sync.\n" +
+			"Reads .ai/config.yml to determine the template source and current version.\n" +
 			"Shows release notes and asks for confirmation before staging.\n" +
 			"By default, changes are staged but not committed.\n" +
 			"Pass --commit to automatically commit after staging.\n" +
@@ -106,8 +106,10 @@ func newSyncCmdWithDeps(deps syncDeps) *cobra.Command {
 }
 
 // findRepoRoot walks up from the current working directory until it finds a
-// directory containing TEMPLATE_SOURCE, which indicates the agentic repo root.
-// Returns an error if not run inside an agentic repo.
+// directory containing .ai/config.yml, which indicates the agentic repo root.
+// Falls back to TEMPLATE_SOURCE for repos not yet migrated to v1.5.0+.
+//
+// TODO(deprecated): remove TEMPLATE_SOURCE fallback in next major version.
 func findRepoRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -115,14 +117,19 @@ func findRepoRoot() (string, error) {
 	}
 
 	for {
+		// Primary: .ai/config.yml (v1.5.0+).
+		if _, err := os.Stat(filepath.Join(dir, ".ai", "config.yml")); err == nil {
+			return dir, nil
+		}
+
+		// TODO(deprecated): remove in next major version — TEMPLATE_SOURCE fallback for pre-v1.5.0 repos.
 		if _, err := os.Stat(filepath.Join(dir, "TEMPLATE_SOURCE")); err == nil {
 			return dir, nil
 		}
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			// Reached filesystem root without finding TEMPLATE_SOURCE.
-			return "", fmt.Errorf("not inside an agentic repo (no TEMPLATE_SOURCE found)")
+			return "", fmt.Errorf("not inside an agentic repo (no .ai/config.yml found)")
 		}
 		dir = parent
 	}

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -23,6 +23,7 @@ func setupFakeTarball(t *testing.T, baseContent string) func() {
 	t.Helper()
 	files := map[string]string{
 		".ai/RULEBOOK.md": baseContent,
+		".ai/config.yml":  "template: eddiecarpenter/ai-native-delivery\nversion: v0.0.0\n",
 	}
 
 	prev := sync.SetFetchTarballFn(func(repo, version string) (io.ReadCloser, error) {
@@ -104,8 +105,8 @@ func TestSyncCmd_HelpText(t *testing.T) {
 		t.Errorf("help should mention '.ai/', got: %s", output)
 	}
 
-	if !strings.Contains(output, "TEMPLATE_SOURCE") {
-		t.Errorf("help should mention 'TEMPLATE_SOURCE', got: %s", output)
+	if !strings.Contains(output, "config.yml") {
+		t.Errorf("help should mention 'config.yml', got: %s", output)
 	}
 }
 
@@ -249,7 +250,7 @@ func TestSyncCmd_CommitFlagRegistration(t *testing.T) {
 func TestSyncCmd_ForceFlagResyncs(t *testing.T) {
 	repo := testutil.NewFakeRepo(t)
 	defer setupFakeTarball(t, "force-synced content")()
-	// FakeRepo has TEMPLATE_VERSION=v1.0.0, FakeRelease also returns v1.0.0.
+	// FakeRepo has .ai/config.yml version=v1.0.0, FakeRelease also returns v1.0.0.
 
 	origDir, err := os.Getwd()
 	if err != nil {

--- a/internal/sync/model.go
+++ b/internal/sync/model.go
@@ -1,5 +1,5 @@
 // Package sync implements the business logic for gh agentic sync.
-// It syncs the base/ directory from the upstream agentic-development template.
+// It syncs the .ai/ directory from the upstream agentic-development template.
 package sync
 
 import (
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // SyncConfig holds all state needed to execute a template sync.
@@ -24,34 +26,67 @@ type SyncConfig struct {
 	RepoRoot string
 }
 
-// ReadTemplateSource reads and trims the TEMPLATE_SOURCE file from the given repo root.
-// Returns the GitHub repo slug (e.g. "eddiecarpenter/ai-native-delivery").
+// AIConfig represents the contents of .ai/config.yml.
+type AIConfig struct {
+	Template string `yaml:"template"`
+	Version  string `yaml:"version"`
+}
+
+// ReadAIConfig reads and parses .ai/config.yml from the given repo root.
+func ReadAIConfig(root string) (AIConfig, error) {
+	data, err := os.ReadFile(filepath.Join(root, ".ai", "config.yml"))
+	if err != nil {
+		return AIConfig{}, err
+	}
+	var cfg AIConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return AIConfig{}, fmt.Errorf("parsing .ai/config.yml: %w", err)
+	}
+	return cfg, nil
+}
+
+// ReadTemplateSource reads the template repo slug from .ai/config.yml.
+// Falls back to TEMPLATE_SOURCE for repos that have not yet been migrated.
+//
+// TODO(deprecated): remove TEMPLATE_SOURCE fallback in next major version — .ai/config.yml is the source of truth.
 func ReadTemplateSource(root string) (string, error) {
+	if cfg, err := ReadAIConfig(root); err == nil {
+		if value := strings.TrimSpace(cfg.Template); value != "" {
+			return value, nil
+		}
+	}
+
+	// TODO(deprecated): remove in next major version — TEMPLATE_SOURCE fallback for pre-v1.5.0 repos.
 	data, err := os.ReadFile(filepath.Join(root, "TEMPLATE_SOURCE"))
 	if err != nil {
 		return "", fmt.Errorf("reading TEMPLATE_SOURCE: %w", err)
 	}
-
 	value := strings.TrimSpace(string(data))
 	if value == "" {
 		return "", fmt.Errorf("TEMPLATE_SOURCE is empty")
 	}
-
 	return value, nil
 }
 
-// ReadTemplateVersion reads and trims the TEMPLATE_VERSION file from the given repo root.
-// Returns the semver tag (e.g. "v0.1.0").
+// ReadTemplateVersion reads the current template version from .ai/config.yml.
+// Falls back to TEMPLATE_VERSION for repos that have not yet been migrated.
+//
+// TODO(deprecated): remove TEMPLATE_VERSION fallback in next major version — .ai/config.yml is the source of truth.
 func ReadTemplateVersion(root string) (string, error) {
+	if cfg, err := ReadAIConfig(root); err == nil {
+		if value := strings.TrimSpace(cfg.Version); value != "" {
+			return value, nil
+		}
+	}
+
+	// TODO(deprecated): remove in next major version — TEMPLATE_VERSION fallback for pre-v1.5.0 repos.
 	data, err := os.ReadFile(filepath.Join(root, "TEMPLATE_VERSION"))
 	if err != nil {
 		return "", fmt.Errorf("reading TEMPLATE_VERSION: %w", err)
 	}
-
 	value := strings.TrimSpace(string(data))
 	if value == "" {
 		return "", fmt.Errorf("TEMPLATE_VERSION is empty")
 	}
-
 	return value, nil
 }

--- a/internal/sync/model_test.go
+++ b/internal/sync/model_test.go
@@ -6,134 +6,139 @@ import (
 	"testing"
 )
 
-func TestReadTemplateSource(t *testing.T) {
-	tests := []struct {
-		name      string
-		content   *string // nil means don't create the file
-		want      string
-		wantError bool
-	}{
-		{
-			name:    "valid content",
-			content: strPtr("eddiecarpenter/ai-native-delivery"),
-			want:    "eddiecarpenter/ai-native-delivery",
-		},
-		{
-			name:    "content with whitespace",
-			content: strPtr("  eddiecarpenter/ai-native-delivery  \n"),
-			want:    "eddiecarpenter/ai-native-delivery",
-		},
-		{
-			name:      "missing file",
-			content:   nil,
-			wantError: true,
-		},
-		{
-			name:      "empty file",
-			content:   strPtr(""),
-			wantError: true,
-		},
-		{
-			name:      "whitespace only",
-			content:   strPtr("   \n  "),
-			wantError: true,
-		},
+// writeConfigYML writes a minimal .ai/config.yml into root.
+func writeConfigYML(t *testing.T, root, template, version string) {
+	t.Helper()
+	dir := filepath.Join(root, ".ai")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("setup: mkdir .ai: %v", err)
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			root := t.TempDir()
-
-			if tc.content != nil {
-				err := os.WriteFile(filepath.Join(root, "TEMPLATE_SOURCE"), []byte(*tc.content), 0o644)
-				if err != nil {
-					t.Fatalf("setup: %v", err)
-				}
-			}
-
-			got, err := ReadTemplateSource(root)
-
-			if tc.wantError {
-				if err == nil {
-					t.Fatalf("expected error, got %q", got)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
-			}
-		})
+	content := "template: " + template + "\nversion: " + version + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("setup: write config.yml: %v", err)
 	}
 }
 
+func TestReadTemplateSource(t *testing.T) {
+	t.Run("reads from config.yml", func(t *testing.T) {
+		root := t.TempDir()
+		writeConfigYML(t, root, "eddiecarpenter/ai-native-delivery", "v1.0.0")
+		got, err := ReadTemplateSource(root)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "eddiecarpenter/ai-native-delivery" {
+			t.Errorf("got %q, want %q", got, "eddiecarpenter/ai-native-delivery")
+		}
+	})
+
+	t.Run("config.yml takes precedence over TEMPLATE_SOURCE", func(t *testing.T) {
+		root := t.TempDir()
+		writeConfigYML(t, root, "eddiecarpenter/ai-native-delivery", "v1.0.0")
+		if err := os.WriteFile(filepath.Join(root, "TEMPLATE_SOURCE"), []byte("old/repo"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		got, err := ReadTemplateSource(root)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "eddiecarpenter/ai-native-delivery" {
+			t.Errorf("config.yml should win: got %q", got)
+		}
+	})
+
+	// TODO(deprecated): remove fallback tests in next major version when TEMPLATE_SOURCE is dropped.
+	t.Run("fallback: reads from TEMPLATE_SOURCE when config.yml absent", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "TEMPLATE_SOURCE"), []byte("eddiecarpenter/ai-native-delivery"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		got, err := ReadTemplateSource(root)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "eddiecarpenter/ai-native-delivery" {
+			t.Errorf("got %q, want %q", got, "eddiecarpenter/ai-native-delivery")
+		}
+	})
+
+	t.Run("error when neither config.yml nor TEMPLATE_SOURCE present", func(t *testing.T) {
+		root := t.TempDir()
+		_, err := ReadTemplateSource(root)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("error when config.yml present but template field empty and TEMPLATE_SOURCE absent", func(t *testing.T) {
+		root := t.TempDir()
+		writeConfigYML(t, root, "", "v1.0.0")
+		_, err := ReadTemplateSource(root)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
 func TestReadTemplateVersion(t *testing.T) {
-	tests := []struct {
-		name      string
-		content   *string // nil means don't create the file
-		want      string
-		wantError bool
-	}{
-		{
-			name:    "valid content",
-			content: strPtr("v0.1.0"),
-			want:    "v0.1.0",
-		},
-		{
-			name:    "content with whitespace",
-			content: strPtr("  v0.2.0  \n"),
-			want:    "v0.2.0",
-		},
-		{
-			name:      "missing file",
-			content:   nil,
-			wantError: true,
-		},
-		{
-			name:      "empty file",
-			content:   strPtr(""),
-			wantError: true,
-		},
-		{
-			name:      "whitespace only",
-			content:   strPtr("  \t\n"),
-			wantError: true,
-		},
-	}
+	t.Run("reads from config.yml", func(t *testing.T) {
+		root := t.TempDir()
+		writeConfigYML(t, root, "eddiecarpenter/ai-native-delivery", "v1.5.0")
+		got, err := ReadTemplateVersion(root)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "v1.5.0" {
+			t.Errorf("got %q, want %q", got, "v1.5.0")
+		}
+	})
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			root := t.TempDir()
+	t.Run("config.yml takes precedence over TEMPLATE_VERSION", func(t *testing.T) {
+		root := t.TempDir()
+		writeConfigYML(t, root, "eddiecarpenter/ai-native-delivery", "v1.5.0")
+		if err := os.WriteFile(filepath.Join(root, "TEMPLATE_VERSION"), []byte("v0.0.1"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		got, err := ReadTemplateVersion(root)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "v1.5.0" {
+			t.Errorf("config.yml should win: got %q", got)
+		}
+	})
 
-			if tc.content != nil {
-				err := os.WriteFile(filepath.Join(root, "TEMPLATE_VERSION"), []byte(*tc.content), 0o644)
-				if err != nil {
-					t.Fatalf("setup: %v", err)
-				}
-			}
+	// TODO(deprecated): remove fallback tests in next major version when TEMPLATE_VERSION is dropped.
+	t.Run("fallback: reads from TEMPLATE_VERSION when config.yml absent", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "TEMPLATE_VERSION"), []byte("v0.1.0"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		got, err := ReadTemplateVersion(root)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "v0.1.0" {
+			t.Errorf("got %q, want %q", got, "v0.1.0")
+		}
+	})
 
-			got, err := ReadTemplateVersion(root)
+	t.Run("error when neither config.yml nor TEMPLATE_VERSION present", func(t *testing.T) {
+		root := t.TempDir()
+		_, err := ReadTemplateVersion(root)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
 
-			if tc.wantError {
-				if err == nil {
-					t.Fatalf("expected error, got %q", got)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
-			}
-		})
-	}
+	t.Run("error when config.yml present but version field empty and TEMPLATE_VERSION absent", func(t *testing.T) {
+		root := t.TempDir()
+		writeConfigYML(t, root, "eddiecarpenter/ai-native-delivery", "")
+		_, err := ReadTemplateVersion(root)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
 }
 
 // strPtr returns a pointer to the given string. Helper for table-driven tests.

--- a/internal/sync/runner.go
+++ b/internal/sync/runner.go
@@ -307,9 +307,16 @@ func RunSync(
 		return err
 	}
 
-	// Step 9: Update version.
-	if err := spinner(w, "Updating TEMPLATE_VERSION", func() error {
+	// Step 9: Update .ai/config.yml with the new version.
+	if err := spinner(w, "Updating .ai/config.yml", func() error {
 		return UpdateVersion(repoRoot, cfg.LatestVersion)
+	}); err != nil {
+		return err
+	}
+
+	// Step 9b: Remove legacy TEMPLATE_SOURCE and TEMPLATE_VERSION files.
+	if err := spinner(w, "Removing legacy version files", func() error {
+		return DeleteLegacyVersionFiles(repoRoot)
 	}); err != nil {
 		return err
 	}

--- a/internal/sync/runner_test.go
+++ b/internal/sync/runner_test.go
@@ -101,20 +101,32 @@ func tarballRunner(mock *testutil.MockRunner) func(string, ...string) (string, e
 }
 
 // defaultTarballSetup sets up fetchTarballFn with a tarball containing
-// .ai/RULEBOOK.md with the given content. Returns a cleanup function.
+// .ai/RULEBOOK.md and .ai/config.yml with the given content. Returns a cleanup function.
 func defaultTarballSetup(t *testing.T, baseContent string) func() {
 	t.Helper()
 	return tarballFetchSetup(t, map[string]string{
 		".ai/RULEBOOK.md": baseContent,
+		".ai/config.yml":  "template: eddiecarpenter/ai-native-delivery\nversion: v0.0.0\n",
 	})
 }
 
+// readConfigVersion reads the version field from .ai/config.yml in the given root.
+func readConfigVersion(t *testing.T, root string) string {
+	t.Helper()
+	cfg, err := ReadAIConfig(root)
+	if err != nil {
+		t.Fatalf("reading .ai/config.yml: %v", err)
+	}
+	return strings.TrimSpace(cfg.Version)
+}
+
 // workflowTarballSetup sets up fetchTarballFn with a tarball containing
-// .ai/RULEBOOK.md and workflow files under .ai/.github/workflows/.
+// .ai/RULEBOOK.md, .ai/config.yml, and workflow files under .ai/.github/workflows/.
 func workflowTarballSetup(t *testing.T, baseContent string, workflows []string) func() {
 	t.Helper()
 	files := map[string]string{
 		".ai/RULEBOOK.md": baseContent,
+		".ai/config.yml":  "template: eddiecarpenter/ai-native-delivery\nversion: v0.0.0\n",
 	}
 	for _, wf := range workflows {
 		files[".ai/.github/workflows/"+wf] = "workflow: " + wf
@@ -123,11 +135,12 @@ func workflowTarballSetup(t *testing.T, baseContent string, workflows []string) 
 }
 
 // recipeTarballSetup sets up fetchTarballFn with a tarball containing
-// .ai/RULEBOOK.md, optional workflows, and recipe files under .goose/recipes/.
+// .ai/RULEBOOK.md, .ai/config.yml, optional workflows, and recipe files under .goose/recipes/.
 func recipeTarballSetup(t *testing.T, baseContent string, workflows []string, recipes []string) func() {
 	t.Helper()
 	files := map[string]string{
 		".ai/RULEBOOK.md": baseContent,
+		".ai/config.yml":  "template: eddiecarpenter/ai-native-delivery\nversion: v0.0.0\n",
 	}
 	for _, wf := range workflows {
 		files[".ai/.github/workflows/"+wf] = "workflow: " + wf
@@ -213,20 +226,17 @@ func TestRunSync_ConfirmAndStageOnly(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "v2.0.0" {
-		t.Errorf("TEMPLATE_VERSION = %q, want v2.0.0", string(data))
+	got := readConfigVersion(t, repo.Root)
+	if got != "v2.0.0" {
+		t.Errorf(".ai/config.yml version = %q, want v2.0.0", got)
 	}
 
-	data, err = os.ReadFile(filepath.Join(repo.Root, ".ai", "RULEBOOK.md"))
+	rulebook, err := os.ReadFile(filepath.Join(repo.Root, ".ai", "RULEBOOK.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != "updated content" {
-		t.Errorf(".ai/RULEBOOK.md = %q, want 'updated content'", data)
+	if string(rulebook) != "updated content" {
+		t.Errorf(".ai/RULEBOOK.md = %q, want 'updated content'", rulebook)
 	}
 
 	output := buf.String()
@@ -267,20 +277,17 @@ func TestRunSync_ConfirmAndCommit(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "v2.0.0" {
-		t.Errorf("TEMPLATE_VERSION = %q, want v2.0.0", string(data))
+	got := readConfigVersion(t, repo.Root)
+	if got != "v2.0.0" {
+		t.Errorf(".ai/config.yml version = %q, want v2.0.0", got)
 	}
 
-	data, err = os.ReadFile(filepath.Join(repo.Root, ".ai", "RULEBOOK.md"))
+	rulebook, err := os.ReadFile(filepath.Join(repo.Root, ".ai", "RULEBOOK.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != "updated content" {
-		t.Errorf(".ai/RULEBOOK.md = %q, want 'updated content'", data)
+	if string(rulebook) != "updated content" {
+		t.Errorf(".ai/RULEBOOK.md = %q, want 'updated content'", rulebook)
 	}
 
 	output := buf.String()
@@ -348,13 +355,10 @@ func TestRunSync_DeclineThenAccept(t *testing.T) {
 		t.Errorf("expected clearScreen called 4 times (notes+decline+notes+results), got %d", clearCalls)
 	}
 
-	// Install still completed — TEMPLATE_VERSION updated.
-	data, err := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "v2.0.0" {
-		t.Errorf("TEMPLATE_VERSION = %q, want v2.0.0", string(data))
+	// Install still completed — .ai/config.yml updated.
+	got := readConfigVersion(t, repo.Root)
+	if got != "v2.0.0" {
+		t.Errorf(".ai/config.yml version = %q, want v2.0.0", got)
 	}
 
 	mock.AssertExpectations(t)
@@ -525,12 +529,9 @@ func TestRunSync_ForceResyncsWhenUpToDate(t *testing.T) {
 		t.Errorf(".ai/RULEBOOK.md = %q, want 're-synced content'", data)
 	}
 
-	data, err = os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "v1.0.0" {
-		t.Errorf("TEMPLATE_VERSION = %q, want v1.0.0", string(data))
+	got := readConfigVersion(t, repo.Root)
+	if got != "v1.0.0" {
+		t.Errorf(".ai/config.yml version = %q, want v1.0.0", got)
 	}
 
 	mock.AssertExpectations(t)
@@ -539,6 +540,19 @@ func TestRunSync_ForceResyncsWhenUpToDate(t *testing.T) {
 func TestRunSync_BaseMissing_RestoresOnConfirm(t *testing.T) {
 	repo := testutil.NewFakeRepo(t)
 	defer defaultTarballSetup(t, "restored content")()
+
+	// Write legacy TEMPLATE_SOURCE and TEMPLATE_VERSION at root before removing .ai/ —
+	// simulates a pre-v1.5.0 repo where metadata was stored in root-level files rather
+	// than .ai/config.yml. After removing .ai/, ReadTemplateSource/ReadTemplateVersion
+	// fall back to these files via the deprecated path.
+	if err := os.WriteFile(filepath.Join(repo.Root, "TEMPLATE_SOURCE"),
+		[]byte("eddiecarpenter/ai-native-delivery\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"),
+		[]byte("v1.0.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := os.RemoveAll(filepath.Join(repo.Root, ".ai")); err != nil {
 		t.Fatal(err)
@@ -627,12 +641,9 @@ func TestRunSync_YesAutoConfirms(t *testing.T) {
 		t.Errorf("expected confirm prompt %q, got %q", "Install v2.0.0?", confirmPrompt)
 	}
 
-	data, err := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "v2.0.0" {
-		t.Errorf("TEMPLATE_VERSION = %q, want v2.0.0", string(data))
+	got := readConfigVersion(t, repo.Root)
+	if got != "v2.0.0" {
+		t.Errorf(".ai/config.yml version = %q, want v2.0.0", got)
 	}
 
 	output := buf.String()
@@ -878,12 +889,9 @@ func TestRunSync_MultipleReleases_CallsSelectFunc(t *testing.T) {
 	}
 
 	// Verify the selected version (v1.5.0) was used.
-	data, err := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "v1.5.0" {
-		t.Errorf("TEMPLATE_VERSION = %q, want v1.5.0", string(data))
+	got := readConfigVersion(t, repo.Root)
+	if got != "v1.5.0" {
+		t.Errorf(".ai/config.yml version = %q, want v1.5.0", got)
 	}
 
 	output := buf.String()
@@ -981,13 +989,10 @@ func TestRunSync_ListMode_DisplaysReleases(t *testing.T) {
 		t.Errorf("expected release notes in output, got: %s", output)
 	}
 
-	// Verify no sync was performed — TEMPLATE_VERSION unchanged.
-	data, err := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "v1.0.0" {
-		t.Errorf("TEMPLATE_VERSION changed during --list: %q", string(data))
+	// Verify no sync was performed — .ai/config.yml version unchanged.
+	got := readConfigVersion(t, repo.Root)
+	if got != "v1.0.0" {
+		t.Errorf(".ai/config.yml changed during --list: %q", got)
 	}
 
 	mock.AssertExpectations(t)
@@ -1061,12 +1066,9 @@ func TestRunSync_ReleaseTag_SyncsToSpecificVersion(t *testing.T) {
 	}
 
 	// Verify the specified version was used.
-	data, err := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "v1.5.0" {
-		t.Errorf("TEMPLATE_VERSION = %q, want v1.5.0", string(data))
+	got := readConfigVersion(t, repo.Root)
+	if got != "v1.5.0" {
+		t.Errorf(".ai/config.yml version = %q, want v1.5.0", got)
 	}
 
 	output := buf.String()
@@ -1114,12 +1116,9 @@ func TestRunSync_ReleaseTag_NotFound(t *testing.T) {
 	}
 
 	// Verify no sync was performed.
-	data, err := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "v1.0.0" {
-		t.Errorf("TEMPLATE_VERSION should be unchanged: %q", string(data))
+	got := readConfigVersion(t, repo.Root)
+	if got != "v1.0.0" {
+		t.Errorf(".ai/config.yml version should be unchanged: %q", got)
 	}
 
 	mock.AssertExpectations(t)
@@ -1383,22 +1382,19 @@ func TestRunSync_EmptyTarballURL_FailsBeforeModification(t *testing.T) {
 		t.Errorf("error should mention missing tarball URL: %v", err)
 	}
 
-	// Verify no files were modified — TEMPLATE_VERSION should still be v1.0.0.
-	data, readErr := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
-	if strings.TrimSpace(string(data)) != "v1.0.0" {
-		t.Errorf("TEMPLATE_VERSION should be unchanged: %q", string(data))
+	// Verify no files were modified — .ai/config.yml version should still be v1.0.0.
+	got := readConfigVersion(t, repo.Root)
+	if got != "v1.0.0" {
+		t.Errorf(".ai/config.yml version should be unchanged: %q", got)
 	}
 
 	// Verify .ai/RULEBOOK.md is unchanged.
-	data, readErr = os.ReadFile(filepath.Join(repo.Root, ".ai", "RULEBOOK.md"))
+	rulebook, readErr := os.ReadFile(filepath.Join(repo.Root, ".ai", "RULEBOOK.md"))
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	if string(data) != "# RULEBOOK.md\n" {
-		t.Errorf(".ai/RULEBOOK.md should be unchanged: %q", string(data))
+	if string(rulebook) != "# RULEBOOK.md\n" {
+		t.Errorf(".ai/RULEBOOK.md should be unchanged: %q", string(rulebook))
 	}
 
 	mock.AssertExpectations(t)
@@ -1449,13 +1445,10 @@ func TestRunSync_TarballFetchFailure_RestoresBackup(t *testing.T) {
 		t.Errorf(".ai/RULEBOOK.md should be restored to original: %q", string(data))
 	}
 
-	// Verify TEMPLATE_VERSION is unchanged.
-	data, readErr = os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_VERSION"))
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
-	if strings.TrimSpace(string(data)) != "v1.0.0" {
-		t.Errorf("TEMPLATE_VERSION should be unchanged: %q", string(data))
+	// Verify .ai/config.yml version is unchanged.
+	got := readConfigVersion(t, repo.Root)
+	if got != "v1.0.0" {
+		t.Errorf(".ai/config.yml version should be unchanged: %q", got)
 	}
 
 	mock.AssertExpectations(t)

--- a/internal/sync/steps.go
+++ b/internal/sync/steps.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/eddiecarpenter/gh-agentic/internal/bootstrap"
 	"github.com/eddiecarpenter/gh-agentic/internal/fsutil"
 	"github.com/eddiecarpenter/gh-agentic/internal/tarball"
@@ -404,11 +406,42 @@ func ShowDiff(repoRoot string, run bootstrap.RunCommandFunc) (string, error) {
 	return out, nil
 }
 
-// UpdateVersion writes the new version string to TEMPLATE_VERSION.
+// UpdateVersion writes the new version into .ai/config.yml, preserving the
+// existing template field. TEMPLATE_VERSION is no longer written — use
+// DeleteLegacyVersionFiles to remove it after staging.
 func UpdateVersion(repoRoot, version string) error {
-	path := filepath.Join(repoRoot, "TEMPLATE_VERSION")
-	if err := os.WriteFile(path, []byte(version+"\n"), 0o644); err != nil {
-		return fmt.Errorf("writing TEMPLATE_VERSION: %w", err)
+	cfg, err := ReadAIConfig(repoRoot)
+	if err != nil {
+		// config.yml not yet present — fall back to reading the template source.
+		// TODO(deprecated): remove TEMPLATE_SOURCE fallback in next major version.
+		source, srcErr := ReadTemplateSource(repoRoot)
+		if srcErr != nil {
+			return fmt.Errorf("reading template source for config.yml: %w", srcErr)
+		}
+		cfg.Template = source
+	}
+	cfg.Version = version
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshalling .ai/config.yml: %w", err)
+	}
+	configPath := filepath.Join(repoRoot, ".ai", "config.yml")
+	if err := os.WriteFile(configPath, data, 0o644); err != nil {
+		return fmt.Errorf("writing .ai/config.yml: %w", err)
+	}
+	return nil
+}
+
+// DeleteLegacyVersionFiles removes TEMPLATE_SOURCE and TEMPLATE_VERSION from
+// the repo root if they exist. These files were superseded by .ai/config.yml
+// in v1.5.0.
+func DeleteLegacyVersionFiles(repoRoot string) error {
+	for _, name := range []string{"TEMPLATE_SOURCE", "TEMPLATE_VERSION"} {
+		path := filepath.Join(repoRoot, name)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing %s: %w", name, err)
+		}
 	}
 	return nil
 }
@@ -423,10 +456,16 @@ func WritePostSyncMD(repoRoot string, releaseBody string) error {
 	return nil
 }
 
-// StageSync stages .ai/, .github/workflows/, CLAUDE.md, AGENTS.md, TEMPLATE_VERSION,
-// .goose/recipes/, and POST_SYNC.md for commit.
+// StageSync stages all sync changes for commit. Removes legacy TEMPLATE_SOURCE
+// and TEMPLATE_VERSION from git tracking (they are superseded by .ai/config.yml),
+// then stages .ai/, .github/workflows/, CLAUDE.md, AGENTS.md, .goose/recipes/,
+// and POST_SYNC.md.
 func StageSync(repoRoot string, run bootstrap.RunCommandFunc) error {
-	if out, err := runInDir(run, repoRoot, "git", "add", ".ai/", "CLAUDE.md", "AGENTS.md", "TEMPLATE_VERSION", ".github/workflows/", ".goose/recipes/", "POST_SYNC.md"); err != nil {
+	// Remove legacy files from git tracking — ignore if already gone.
+	if out, err := runInDir(run, repoRoot, "git", "rm", "--ignore-unmatch", "--cached", "TEMPLATE_SOURCE", "TEMPLATE_VERSION"); err != nil {
+		return fmt.Errorf("git rm legacy files: %w\n%s", err, strings.TrimSpace(out))
+	}
+	if out, err := runInDir(run, repoRoot, "git", "add", ".ai/", "CLAUDE.md", "AGENTS.md", ".github/workflows/", ".goose/recipes/", "POST_SYNC.md"); err != nil {
 		return fmt.Errorf("git add: %w\n%s", err, strings.TrimSpace(out))
 	}
 	return nil

--- a/internal/sync/steps_test.go
+++ b/internal/sync/steps_test.go
@@ -1269,19 +1269,65 @@ func TestShowDiff(t *testing.T) {
 }
 
 func TestUpdateVersion(t *testing.T) {
-	t.Run("writes version", func(t *testing.T) {
+	t.Run("writes version to config.yml", func(t *testing.T) {
 		root := t.TempDir()
+		// Pre-create .ai/config.yml so UpdateVersion can read the template field.
+		if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".ai", "config.yml"),
+			[]byte("template: owner/template\nversion: v0.1.0\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
 		err := UpdateVersion(root, "v0.2.0")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		data, err := os.ReadFile(filepath.Join(root, "TEMPLATE_VERSION"))
+		// Verify .ai/config.yml was updated.
+		data, err := os.ReadFile(filepath.Join(root, ".ai", "config.yml"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if strings.TrimSpace(string(data)) != "v0.2.0" {
-			t.Errorf("got %q, want %q", string(data), "v0.2.0\n")
+		cfg, parseErr := ReadAIConfig(root)
+		if parseErr != nil {
+			t.Fatalf("re-reading config.yml: %v (raw: %s)", parseErr, data)
+		}
+		if cfg.Version != "v0.2.0" {
+			t.Errorf("version = %q, want %q", cfg.Version, "v0.2.0")
+		}
+		if cfg.Template != "owner/template" {
+			t.Errorf("template = %q, want %q", cfg.Template, "owner/template")
+		}
+	})
+
+	t.Run("falls back to TEMPLATE_SOURCE when config.yml absent", func(t *testing.T) {
+		root := t.TempDir()
+		// Only TEMPLATE_SOURCE exists — no .ai/config.yml yet.
+		if err := os.WriteFile(filepath.Join(root, "TEMPLATE_SOURCE"),
+			[]byte("owner/fallback\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// .ai/ dir must exist for WriteFile to succeed.
+		if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		err := UpdateVersion(root, "v0.3.0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cfg, parseErr := ReadAIConfig(root)
+		if parseErr != nil {
+			t.Fatalf("reading config.yml after update: %v", parseErr)
+		}
+		if cfg.Version != "v0.3.0" {
+			t.Errorf("version = %q, want %q", cfg.Version, "v0.3.0")
+		}
+		if cfg.Template != "owner/fallback" {
+			t.Errorf("template = %q, want %q", cfg.Template, "owner/fallback")
 		}
 	})
 }
@@ -1355,39 +1401,66 @@ func TestStageSync(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if len(calls) != 1 {
-			t.Fatalf("expected 1 call, got %d: %v", len(calls), calls)
+		// Expect 2 calls: git rm (legacy files) + git add.
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls, got %d: %v", len(calls), calls)
+		}
+
+		// Verify git rm was called to remove legacy files.
+		if !strings.Contains(calls[0], "git") || !strings.Contains(calls[0], "rm") {
+			t.Errorf("expected git rm call: %s", calls[0])
+		}
+		if !strings.Contains(calls[0], "TEMPLATE_SOURCE") {
+			t.Errorf("expected TEMPLATE_SOURCE in git rm: %s", calls[0])
+		}
+		if !strings.Contains(calls[0], "TEMPLATE_VERSION") {
+			t.Errorf("expected TEMPLATE_VERSION in git rm: %s", calls[0])
 		}
 
 		// Verify git add was called with the right paths.
-		if !strings.Contains(calls[0], "git") || !strings.Contains(calls[0], "add") {
-			t.Errorf("expected git add call: %s", calls[0])
+		if !strings.Contains(calls[1], "git") || !strings.Contains(calls[1], "add") {
+			t.Errorf("expected git add call: %s", calls[1])
 		}
-		if !strings.Contains(calls[0], ".ai/") {
-			t.Errorf("expected .ai/ in git add: %s", calls[0])
+		if !strings.Contains(calls[1], ".ai/") {
+			t.Errorf("expected .ai/ in git add: %s", calls[1])
 		}
-		if !strings.Contains(calls[0], "CLAUDE.md") {
-			t.Errorf("expected CLAUDE.md in git add: %s", calls[0])
+		if !strings.Contains(calls[1], "CLAUDE.md") {
+			t.Errorf("expected CLAUDE.md in git add: %s", calls[1])
 		}
-		if !strings.Contains(calls[0], "AGENTS.md") {
-			t.Errorf("expected AGENTS.md in git add: %s", calls[0])
+		if !strings.Contains(calls[1], "AGENTS.md") {
+			t.Errorf("expected AGENTS.md in git add: %s", calls[1])
 		}
-		if !strings.Contains(calls[0], "TEMPLATE_VERSION") {
-			t.Errorf("expected TEMPLATE_VERSION in git add: %s", calls[0])
+		if !strings.Contains(calls[1], ".github/workflows/") {
+			t.Errorf("expected .github/workflows/ in git add: %s", calls[1])
 		}
-		if !strings.Contains(calls[0], ".github/workflows/") {
-			t.Errorf("expected .github/workflows/ in git add: %s", calls[0])
+		if !strings.Contains(calls[1], ".goose/recipes/") {
+			t.Errorf("expected .goose/recipes/ in git add: %s", calls[1])
 		}
-		if !strings.Contains(calls[0], ".goose/recipes/") {
-			t.Errorf("expected .goose/recipes/ in git add: %s", calls[0])
-		}
-		if !strings.Contains(calls[0], "POST_SYNC.md") {
-			t.Errorf("expected POST_SYNC.md in git add: %s", calls[0])
+		if !strings.Contains(calls[1], "POST_SYNC.md") {
+			t.Errorf("expected POST_SYNC.md in git add: %s", calls[1])
 		}
 	})
 
-	t.Run("add error", func(t *testing.T) {
+	t.Run("git rm error", func(t *testing.T) {
 		run := fakeRun("error", fmt.Errorf("exit 1"))
+		err := StageSync("/repo", run)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "git rm") {
+			t.Errorf("error should mention git rm: %v", err)
+		}
+	})
+
+	t.Run("git add error", func(t *testing.T) {
+		callCount := 0
+		run := func(name string, args ...string) (string, error) {
+			callCount++
+			if callCount == 1 {
+				return "", nil // git rm succeeds
+			}
+			return "error", fmt.Errorf("exit 1") // git add fails
+		}
 		err := StageSync("/repo", run)
 		if err == nil {
 			t.Fatal("expected error")
@@ -1416,23 +1489,28 @@ func TestCommitSync(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if len(calls) != 3 {
-			t.Fatalf("expected 3 calls, got %d: %v", len(calls), calls)
+		if len(calls) != 4 {
+			t.Fatalf("expected 4 calls, got %d: %v", len(calls), calls)
+		}
+
+		// Verify git rm was called to remove legacy files.
+		if !strings.Contains(calls[0], "git") || !strings.Contains(calls[0], "rm") {
+			t.Errorf("first call should be git rm: %s", calls[0])
 		}
 
 		// Verify git add was called.
-		if !strings.Contains(calls[0], "git") || !strings.Contains(calls[0], "add") {
-			t.Errorf("first call should be git add: %s", calls[0])
+		if !strings.Contains(calls[1], "git") || !strings.Contains(calls[1], "add") {
+			t.Errorf("second call should be git add: %s", calls[1])
 		}
 
 		// Verify git diff --cached --quiet was called.
-		if !strings.Contains(calls[1], "diff") || !strings.Contains(calls[1], "--cached") {
-			t.Errorf("second call should be git diff --cached: %s", calls[1])
+		if !strings.Contains(calls[2], "diff") || !strings.Contains(calls[2], "--cached") {
+			t.Errorf("third call should be git diff --cached: %s", calls[2])
 		}
 
 		// Verify git commit was called with correct message.
-		if !strings.Contains(calls[2], "commit") || !strings.Contains(calls[2], "sync .ai/, workflows, and recipes") {
-			t.Errorf("third call should be git commit with updated message: %s", calls[2])
+		if !strings.Contains(calls[3], "commit") || !strings.Contains(calls[3], "sync .ai/, workflows, and recipes") {
+			t.Errorf("fourth call should be git commit with updated message: %s", calls[3])
 		}
 	})
 
@@ -1450,8 +1528,8 @@ func TestCommitSync(t *testing.T) {
 			t.Fatalf("expected nil when nothing to commit, got: %v", err)
 		}
 
-		if len(calls) != 2 {
-			t.Fatalf("expected 2 calls (add + diff check), got %d: %v", len(calls), calls)
+		if len(calls) != 3 {
+			t.Fatalf("expected 3 calls (git rm + add + diff check), got %d: %v", len(calls), calls)
 		}
 	})
 

--- a/internal/tarball/tarball.go
+++ b/internal/tarball/tarball.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // FetchFunc downloads a tarball for the given repo and version tag.
@@ -59,10 +61,28 @@ type command interface {
 // newCommand creates a real exec.Cmd. Overridden in tests.
 var newCommand = newRealCommand
 
-// ReadTemplateConfig reads TEMPLATE_SOURCE and TEMPLATE_VERSION from the
-// given repo root directory. Returns an error if either file is missing
-// or empty.
+// ReadTemplateConfig reads the template repo and version. Primary source is
+// .ai/config.yml; falls back to TEMPLATE_SOURCE and TEMPLATE_VERSION for
+// repos not yet migrated to v1.5.0+.
+//
+// TODO(deprecated): remove TEMPLATE_SOURCE/TEMPLATE_VERSION fallback in next major version — .ai/config.yml is the source of truth.
 func ReadTemplateConfig(root string) (repo, version string, err error) {
+	// Primary: read from .ai/config.yml.
+	if data, readErr := os.ReadFile(filepath.Join(root, ".ai", "config.yml")); readErr == nil {
+		var cfg struct {
+			Template string `yaml:"template"`
+			Version  string `yaml:"version"`
+		}
+		if parseErr := yaml.Unmarshal(data, &cfg); parseErr == nil {
+			repo = strings.TrimSpace(cfg.Template)
+			version = strings.TrimSpace(cfg.Version)
+			if repo != "" && version != "" {
+				return repo, version, nil
+			}
+		}
+	}
+
+	// TODO(deprecated): remove in next major version — TEMPLATE_SOURCE/TEMPLATE_VERSION fallback for pre-v1.5.0 repos.
 	sourceData, err := os.ReadFile(filepath.Join(root, "TEMPLATE_SOURCE"))
 	if err != nil {
 		return "", "", fmt.Errorf("TEMPLATE_SOURCE missing: %w", err)

--- a/internal/testutil/fake_repo.go
+++ b/internal/testutil/fake_repo.go
@@ -9,9 +9,8 @@ import (
 )
 
 // FakeRepo is a minimal agentic repo in a temp directory, suitable for
-// integration tests. It includes standard agentic files (TEMPLATE_SOURCE,
-// TEMPLATE_VERSION, CLAUDE.md, etc.) and is initialised as a git repository
-// with at least one commit.
+// integration tests. It includes standard agentic files (.ai/config.yml,
+// CLAUDE.md, etc.) and is initialised as a git repository with at least one commit.
 type FakeRepo struct {
 	// Root is the absolute path to the temp directory.
 	Root string
@@ -37,14 +36,14 @@ func NewFakeRepo(t *testing.T) *FakeRepo {
 
 	// Write standard agentic repo files.
 	files := map[string]string{
-		"TEMPLATE_SOURCE": "eddiecarpenter/ai-native-delivery",
-		"TEMPLATE_VERSION": "v1.0.0",
-		"CLAUDE.md":        "# CLAUDE.md\n",
-		"AGENTS.local.md":  "# AGENTS.local.md\n",
-		"REPOS.md":         "# REPOS.md\n",
-		"README.md":        "# README\n",
-		".ai/RULEBOOK.md":  "# RULEBOOK.md\n",
-		"skills/.gitkeep":  "",
+		".ai/config.yml":  "template: eddiecarpenter/ai-native-delivery\nversion: v1.0.0\n",
+		".ai/RULEBOOK.md": "# RULEBOOK.md\n",
+		"CLAUDE.md":       "# CLAUDE.md\n",
+		"AGENTS.md":       "@.ai/RULEBOOK.md\n@LOCALRULES.md\n",
+		"LOCALRULES.md":   "# LOCALRULES.md\n",
+		"REPOS.md":        "# REPOS.md\n",
+		"README.md":       "# README\n",
+		"skills/.gitkeep": "",
 	}
 
 	for path, content := range files {

--- a/internal/testutil/fake_repo_test.go
+++ b/internal/testutil/fake_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -11,13 +12,13 @@ func TestNewFakeRepo_CreatesStandardFiles(t *testing.T) {
 	repo := NewFakeRepo(t)
 
 	expectedFiles := []string{
-		"TEMPLATE_SOURCE",
-		"TEMPLATE_VERSION",
+		".ai/config.yml",
+		".ai/RULEBOOK.md",
 		"CLAUDE.md",
-		"AGENTS.local.md",
+		"AGENTS.md",
+		"LOCALRULES.md",
 		"REPOS.md",
 		"README.md",
-		".ai/RULEBOOK.md",
 	}
 
 	for _, f := range expectedFiles {
@@ -56,15 +57,18 @@ func TestNewFakeRepo_HasAtLeastOneCommit(t *testing.T) {
 	}
 }
 
-func TestNewFakeRepo_TemplateSourceContent(t *testing.T) {
+func TestNewFakeRepo_ConfigYMLContent(t *testing.T) {
 	repo := NewFakeRepo(t)
 
-	content, err := os.ReadFile(filepath.Join(repo.Root, "TEMPLATE_SOURCE"))
+	content, err := os.ReadFile(filepath.Join(repo.Root, ".ai", "config.yml"))
 	if err != nil {
-		t.Fatalf("read TEMPLATE_SOURCE: %v", err)
+		t.Fatalf("read .ai/config.yml: %v", err)
 	}
-	if string(content) != "eddiecarpenter/ai-native-delivery" {
-		t.Fatalf("unexpected TEMPLATE_SOURCE: %q", string(content))
+	if !strings.Contains(string(content), "eddiecarpenter/ai-native-delivery") {
+		t.Fatalf("unexpected .ai/config.yml content: %q", string(content))
+	}
+	if !strings.Contains(string(content), "v1.0.0") {
+		t.Fatalf(".ai/config.yml missing version: %q", string(content))
 	}
 }
 

--- a/internal/verify/checks.go
+++ b/internal/verify/checks.go
@@ -28,19 +28,19 @@ func CheckCLAUDEMD(root string) CheckResult {
 	}
 }
 
-// CheckAGENTSLocalMD verifies that AGENTS.local.md exists in the repo root.
+// CheckLOCALRULESMD verifies that LOCALRULES.md exists in the repo root.
 // Returns Warning if the file is missing (it can be restored as a skeleton).
-func CheckAGENTSLocalMD(root string) CheckResult {
-	path := filepath.Join(root, "AGENTS.local.md")
+func CheckLOCALRULESMD(root string) CheckResult {
+	path := filepath.Join(root, "LOCALRULES.md")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return CheckResult{
-			Name:    "AGENTS.local.md exists",
+			Name:    "LOCALRULES.md exists",
 			Status:  Warning,
 			Message: "file not found — will restore minimal skeleton",
 		}
 	}
 	return CheckResult{
-		Name:   "AGENTS.local.md exists",
+		Name:   "LOCALRULES.md exists",
 		Status: Pass,
 	}
 }
@@ -64,42 +64,35 @@ func CheckSkillsDir(root string) CheckResult {
 	}
 }
 
-// CheckTEMPLATESOURCE verifies that TEMPLATE_SOURCE exists in the repo root.
-// Returns Warning if the file is missing (requires user input to repair).
-//
-// Deprecated: TEMPLATE_SOURCE is replaced by .ai/config.yml.
-// TODO(deprecated): remove in next major version
-func CheckTEMPLATESOURCE(root string) CheckResult {
-	path := filepath.Join(root, "TEMPLATE_SOURCE")
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+// CheckAIConfigYML verifies that .ai/config.yml exists and contains a non-empty
+// template and version field. Returns Fail if the file is missing or malformed.
+func CheckAIConfigYML(root string) CheckResult {
+	path := filepath.Join(root, ".ai", "config.yml")
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
 		return CheckResult{
-			Name:    "TEMPLATE_SOURCE exists",
-			Status:  Warning,
-			Message: "file not found — value must be provided",
-		}
-	}
-	return CheckResult{
-		Name:   "TEMPLATE_SOURCE exists",
-		Status: Pass,
-	}
-}
-
-// CheckTEMPLATEVERSION verifies that TEMPLATE_VERSION exists in the repo root.
-// Returns Fail if the file is missing.
-//
-// Deprecated: TEMPLATE_VERSION is replaced by .ai/config.yml.
-// TODO(deprecated): remove in next major version
-func CheckTEMPLATEVERSION(root string) CheckResult {
-	path := filepath.Join(root, "TEMPLATE_VERSION")
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return CheckResult{
-			Name:    "TEMPLATE_VERSION exists",
+			Name:    ".ai/config.yml exists",
 			Status:  Fail,
-			Message: "file not found",
+			Message: "file not found — run 'gh agentic sync' to restore",
+		}
+	}
+	if err != nil {
+		return CheckResult{
+			Name:    ".ai/config.yml exists",
+			Status:  Fail,
+			Message: "could not read file: " + err.Error(),
+		}
+	}
+	content := string(data)
+	if !strings.Contains(content, "template:") || !strings.Contains(content, "version:") {
+		return CheckResult{
+			Name:    ".ai/config.yml exists",
+			Status:  Fail,
+			Message: "missing template or version field",
 		}
 	}
 	return CheckResult{
-		Name:   "TEMPLATE_VERSION exists",
+		Name:   ".ai/config.yml exists",
 		Status: Pass,
 	}
 }

--- a/internal/verify/checks_test.go
+++ b/internal/verify/checks_test.go
@@ -29,20 +29,20 @@ func TestCheckCLAUDEMD_Missing_ReturnsFail(t *testing.T) {
 	}
 }
 
-func TestCheckAGENTSLocalMD_Present_ReturnsPass(t *testing.T) {
+func TestCheckLOCALRULESMD_Present_ReturnsPass(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "AGENTS.local.md"), []byte("# local"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "LOCALRULES.md"), []byte("# local"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	result := CheckAGENTSLocalMD(root)
+	result := CheckLOCALRULESMD(root)
 	if result.Status != Pass {
 		t.Errorf("expected Pass, got %v: %s", result.Status, result.Message)
 	}
 }
 
-func TestCheckAGENTSLocalMD_Missing_ReturnsWarning(t *testing.T) {
+func TestCheckLOCALRULESMD_Missing_ReturnsWarning(t *testing.T) {
 	root := t.TempDir()
-	result := CheckAGENTSLocalMD(root)
+	result := CheckLOCALRULESMD(root)
 	if result.Status != Warning {
 		t.Errorf("expected Warning, got %v", result.Status)
 	}
@@ -67,41 +67,39 @@ func TestCheckSkillsDir_Absent_ReturnsWarning(t *testing.T) {
 	}
 }
 
-func TestCheckTEMPLATESOURCE_Present_ReturnsPass(t *testing.T) {
+func TestCheckAIConfigYML_Present_ReturnsPass(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "TEMPLATE_SOURCE"), []byte("eddiecarpenter/ai-native-delivery\n"), 0o644); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	result := CheckTEMPLATESOURCE(root)
+	if err := os.WriteFile(filepath.Join(root, ".ai", "config.yml"), []byte("template: eddiecarpenter/ai-native-delivery\nversion: v1.0.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result := CheckAIConfigYML(root)
 	if result.Status != Pass {
 		t.Errorf("expected Pass, got %v: %s", result.Status, result.Message)
 	}
 }
 
-func TestCheckTEMPLATESOURCE_Missing_ReturnsWarning(t *testing.T) {
+func TestCheckAIConfigYML_Missing_ReturnsFail(t *testing.T) {
 	root := t.TempDir()
-	result := CheckTEMPLATESOURCE(root)
-	if result.Status != Warning {
-		t.Errorf("expected Warning, got %v", result.Status)
-	}
-}
-
-func TestCheckTEMPLATEVERSION_Present_ReturnsPass(t *testing.T) {
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "TEMPLATE_VERSION"), []byte("v1.0.0\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	result := CheckTEMPLATEVERSION(root)
-	if result.Status != Pass {
-		t.Errorf("expected Pass, got %v: %s", result.Status, result.Message)
-	}
-}
-
-func TestCheckTEMPLATEVERSION_Missing_ReturnsFail(t *testing.T) {
-	root := t.TempDir()
-	result := CheckTEMPLATEVERSION(root)
+	result := CheckAIConfigYML(root)
 	if result.Status != Fail {
 		t.Errorf("expected Fail, got %v", result.Status)
+	}
+}
+
+func TestCheckAIConfigYML_MalformedMissingFields_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".ai", "config.yml"), []byte("# empty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result := CheckAIConfigYML(root)
+	if result.Status != Fail {
+		t.Errorf("expected Fail for missing fields, got %v", result.Status)
 	}
 }
 
@@ -152,9 +150,7 @@ func TestFileChecks_TableDriven(t *testing.T) {
 		missingState CheckStatus
 	}{
 		{"CLAUDE.md", "CLAUDE.md", CheckCLAUDEMD, Fail},
-		{"AGENTS.local.md", "AGENTS.local.md", CheckAGENTSLocalMD, Warning},
-		{"TEMPLATE_SOURCE", "TEMPLATE_SOURCE", CheckTEMPLATESOURCE, Warning},
-		{"TEMPLATE_VERSION", "TEMPLATE_VERSION", CheckTEMPLATEVERSION, Fail},
+		{"LOCALRULES.md", "LOCALRULES.md", CheckLOCALRULESMD, Warning},
 		{"REPOS.md", "REPOS.md", CheckREPOSMD, Fail},
 		{"README.md", "README.md", CheckREADMEMD, Fail},
 	}

--- a/internal/verify/repair.go
+++ b/internal/verify/repair.go
@@ -20,15 +20,11 @@ type ConfirmFunc func(prompt string) (string, error)
 // standardCLAUDEMD is the standard content for CLAUDE.md.
 const standardCLAUDEMD = `# CLAUDE.md
 
-This project uses AGENTS.md as the single source of truth for agent instructions.
-All development rules, workflows, and session protocols are defined there.
-
-@.ai/RULEBOOK.md
-@AGENTS.local.md
+@AGENTS.md
 `
 
-// skeletonAGENTSLocalMD is the minimal skeleton for AGENTS.local.md.
-const skeletonAGENTSLocalMD = `# AGENTS.local.md — Local Overrides
+// skeletonLOCALRULESMD is the minimal skeleton for LOCALRULES.md.
+const skeletonLOCALRULESMD = `# LOCALRULES.md — Local Overrides
 
 This file contains project-specific rules and overrides that extend or
 supersede the global protocol defined in ` + "`.ai/RULEBOOK.md`" + `.
@@ -36,10 +32,6 @@ supersede the global protocol defined in ` + "`.ai/RULEBOOK.md`" + `.
 This file is never overwritten by a template sync.
 
 ---
-
-## Template Source
-
-<!-- TODO: Add template source -->
 
 ## Project
 
@@ -71,7 +63,7 @@ See ` + "`docs/PROJECT_BRIEF.md`" + ` for project context.
 ## Agent sessions
 
 This repo uses the [agentic development framework](https://github.com/eddiecarpenter/ai-native-delivery).
-See ` + "`.ai/RULEBOOK.md`" + ` and ` + "`AGENTS.local.md`" + ` for session protocols.
+See ` + "`.ai/RULEBOOK.md`" + ` and ` + "`LOCALRULES.md`" + ` for session protocols.
 `
 
 // RepairCLAUDEMD restores CLAUDE.md with standard content.
@@ -90,18 +82,18 @@ func RepairCLAUDEMD(root string) CheckResult {
 	}
 }
 
-// RepairAGENTSLocalMD restores AGENTS.local.md with a minimal skeleton.
-func RepairAGENTSLocalMD(root string) CheckResult {
-	path := filepath.Join(root, "AGENTS.local.md")
-	if err := os.WriteFile(path, []byte(skeletonAGENTSLocalMD), 0o644); err != nil {
+// RepairLOCALRULESMD restores LOCALRULES.md with a minimal skeleton.
+func RepairLOCALRULESMD(root string) CheckResult {
+	path := filepath.Join(root, "LOCALRULES.md")
+	if err := os.WriteFile(path, []byte(skeletonLOCALRULESMD), 0o644); err != nil {
 		return CheckResult{
-			Name:    "AGENTS.local.md exists",
+			Name:    "LOCALRULES.md exists",
 			Status:  Warning,
 			Message: fmt.Sprintf("repair failed: %v", err),
 		}
 	}
 	return CheckResult{
-		Name:   "AGENTS.local.md exists",
+		Name:   "LOCALRULES.md exists",
 		Status: Pass,
 	}
 }
@@ -143,77 +135,40 @@ func RepairSkillsDir(root string, run bootstrap.RunCommandFunc) CheckResult {
 	}
 }
 
-// RepairTEMPLATESOURCE prompts the user for the template source value and writes it.
-// confirmFn is injected so tests can substitute a fake implementation.
-func RepairTEMPLATESOURCE(root string, confirmFn ConfirmFunc) CheckResult {
-	if confirmFn == nil {
-		return CheckResult{
-			Name:    "TEMPLATE_SOURCE exists",
-			Status:  Warning,
-			Message: "cannot prompt for value — no confirm function provided",
-		}
-	}
-
-	value, err := confirmFn("Enter template source repo (e.g. eddiecarpenter/ai-native-delivery)")
-	if err != nil {
-		return CheckResult{
-			Name:    "TEMPLATE_SOURCE exists",
-			Status:  Warning,
-			Message: fmt.Sprintf("prompt failed: %v", err),
-		}
-	}
-
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return CheckResult{
-			Name:    "TEMPLATE_SOURCE exists",
-			Status:  Warning,
-			Message: "no value provided",
-		}
-	}
-
-	path := filepath.Join(root, "TEMPLATE_SOURCE")
-	if err := os.WriteFile(path, []byte(value+"\n"), 0o644); err != nil {
-		return CheckResult{
-			Name:    "TEMPLATE_SOURCE exists",
-			Status:  Warning,
-			Message: fmt.Sprintf("repair failed: %v", err),
-		}
-	}
-	return CheckResult{
-		Name:   "TEMPLATE_SOURCE exists",
-		Status: Pass,
-	}
-}
-
-// RepairTEMPLATEVERSION fetches the latest tag from the template repo and writes it.
+// RepairAIConfigYML fetches the latest tag from the template repo and writes .ai/config.yml.
 // run is injected so tests can substitute a fake implementation.
-func RepairTEMPLATEVERSION(root string, run bootstrap.RunCommandFunc) CheckResult {
-	// First check if TEMPLATE_SOURCE exists — we need it to fetch the version.
-	sourcePath := filepath.Join(root, "TEMPLATE_SOURCE")
-	data, err := os.ReadFile(sourcePath)
-	if err != nil {
-		return CheckResult{
-			Name:    "TEMPLATE_VERSION exists",
-			Status:  Fail,
-			Message: "cannot determine version — TEMPLATE_SOURCE is missing",
+func RepairAIConfigYML(root string, run bootstrap.RunCommandFunc) CheckResult {
+	// Read existing config to get the template repo slug if available.
+	templateRepo := ""
+	if data, err := os.ReadFile(filepath.Join(root, ".ai", "config.yml")); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if after, ok := strings.CutPrefix(line, "template:"); ok {
+				templateRepo = strings.TrimSpace(after)
+			}
 		}
 	}
 
-	repo := strings.TrimSpace(string(data))
-	if repo == "" {
+	// Fallback: check TEMPLATE_SOURCE (deprecated).
+	// TODO(deprecated): remove in next major version.
+	if templateRepo == "" {
+		if data, err := os.ReadFile(filepath.Join(root, "TEMPLATE_SOURCE")); err == nil {
+			templateRepo = strings.TrimSpace(string(data))
+		}
+	}
+
+	if templateRepo == "" {
 		return CheckResult{
-			Name:    "TEMPLATE_VERSION exists",
+			Name:    ".ai/config.yml exists",
 			Status:  Fail,
-			Message: "TEMPLATE_SOURCE is empty",
+			Message: "cannot determine template repo — repair manually by running 'gh agentic sync'",
 		}
 	}
 
 	// Fetch latest release tag.
-	out, err := run("gh", "release", "list", "--repo", repo, "--limit", "1", "--json", "tagName", "--jq", ".[0].tagName")
+	out, err := run("gh", "release", "list", "--repo", templateRepo, "--limit", "1", "--json", "tagName", "--jq", ".[0].tagName")
 	if err != nil {
 		return CheckResult{
-			Name:    "TEMPLATE_VERSION exists",
+			Name:    ".ai/config.yml exists",
 			Status:  Fail,
 			Message: fmt.Sprintf("failed to fetch latest tag: %v", err),
 		}
@@ -222,23 +177,24 @@ func RepairTEMPLATEVERSION(root string, run bootstrap.RunCommandFunc) CheckResul
 	tag := strings.TrimSpace(out)
 	if tag == "" {
 		return CheckResult{
-			Name:    "TEMPLATE_VERSION exists",
+			Name:    ".ai/config.yml exists",
 			Status:  Fail,
 			Message: "no releases found in template repo",
 		}
 	}
 
-	path := filepath.Join(root, "TEMPLATE_VERSION")
-	if err := os.WriteFile(path, []byte(tag+"\n"), 0o644); err != nil {
+	configPath := filepath.Join(root, ".ai", "config.yml")
+	content := fmt.Sprintf("template: %s\nversion: %s\n", templateRepo, tag)
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
 		return CheckResult{
-			Name:    "TEMPLATE_VERSION exists",
+			Name:    ".ai/config.yml exists",
 			Status:  Fail,
 			Message: fmt.Sprintf("repair failed: %v", err),
 		}
 	}
 
 	return CheckResult{
-		Name:   "TEMPLATE_VERSION exists",
+		Name:   ".ai/config.yml exists",
 		Status: Pass,
 	}
 }

--- a/internal/verify/repair_test.go
+++ b/internal/verify/repair_test.go
@@ -70,105 +70,60 @@ func TestRepairCLAUDEMD_CreatesFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	content := string(data)
-	if !strings.Contains(content, "@.ai/RULEBOOK.md") {
-		t.Error("CLAUDE.md should reference @.ai/RULEBOOK.md")
-	}
-	if !strings.Contains(content, "@AGENTS.local.md") {
-		t.Error("CLAUDE.md should reference @AGENTS.local.md")
+	// In v1.5.0+, CLAUDE.md references AGENTS.md which in turn references .ai/RULEBOOK.md.
+	// CLAUDE.md itself only needs the top-level @AGENTS.md reference.
+	if !strings.Contains(content, "@AGENTS.md") {
+		t.Error("CLAUDE.md should reference @AGENTS.md")
 	}
 }
 
-func TestRepairAGENTSLocalMD_CreatesFile(t *testing.T) {
+func TestRepairLOCALRULESMD_CreatesFile(t *testing.T) {
 	root := t.TempDir()
-	result := RepairAGENTSLocalMD(root)
+	result := RepairLOCALRULESMD(root)
 	if result.Status != Pass {
 		t.Fatalf("expected Pass, got %v: %s", result.Status, result.Message)
 	}
 
-	data, err := os.ReadFile(filepath.Join(root, "AGENTS.local.md"))
+	data, err := os.ReadFile(filepath.Join(root, "LOCALRULES.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	content := string(data)
 	if !strings.Contains(content, "Local Overrides") {
-		t.Error("AGENTS.local.md should contain 'Local Overrides'")
-	}
-	if !strings.Contains(content, "TODO") {
-		t.Error("AGENTS.local.md should contain TODO markers")
+		t.Error("LOCALRULES.md should contain 'Local Overrides'")
 	}
 }
 
-func TestRepairTEMPLATESOURCE_WithConfirm_CreatesFile(t *testing.T) {
+func TestRepairAIConfigYML_Success(t *testing.T) {
 	root := t.TempDir()
-	confirmFn := func(prompt string) (string, error) {
-		return "eddiecarpenter/ai-native-delivery", nil
-	}
-	result := RepairTEMPLATESOURCE(root, confirmFn)
-	if result.Status != Pass {
-		t.Fatalf("expected Pass, got %v: %s", result.Status, result.Message)
-	}
-
-	data, err := os.ReadFile(filepath.Join(root, "TEMPLATE_SOURCE"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(data)) != "eddiecarpenter/ai-native-delivery" {
-		t.Errorf("unexpected content: %s", string(data))
-	}
-}
-
-func TestRepairTEMPLATESOURCE_NilConfirm_ReturnsWarning(t *testing.T) {
-	root := t.TempDir()
-	result := RepairTEMPLATESOURCE(root, nil)
-	if result.Status != Warning {
-		t.Errorf("expected Warning with nil confirm, got %v", result.Status)
-	}
-}
-
-func TestRepairTEMPLATESOURCE_EmptyInput_ReturnsWarning(t *testing.T) {
-	root := t.TempDir()
-	confirmFn := func(prompt string) (string, error) {
-		return "", nil
-	}
-	result := RepairTEMPLATESOURCE(root, confirmFn)
-	if result.Status != Warning {
-		t.Errorf("expected Warning for empty input, got %v", result.Status)
-	}
-}
-
-func TestRepairTEMPLATEVERSION_Success(t *testing.T) {
-	root := t.TempDir()
-	// Write TEMPLATE_SOURCE first — required by the repair.
-	if err := os.WriteFile(filepath.Join(root, "TEMPLATE_SOURCE"), []byte("owner/repo\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeTemplateConfig(t, root, "owner/repo", "v0.0.0")
 
 	fakeRun := func(name string, args ...string) (string, error) {
 		return "v1.2.3\n", nil
 	}
 
-	result := RepairTEMPLATEVERSION(root, fakeRun)
+	result := RepairAIConfigYML(root, fakeRun)
 	if result.Status != Pass {
 		t.Fatalf("expected Pass, got %v: %s", result.Status, result.Message)
 	}
 
-	data, err := os.ReadFile(filepath.Join(root, "TEMPLATE_VERSION"))
+	data, err := os.ReadFile(filepath.Join(root, ".ai", "config.yml"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.TrimSpace(string(data)) != "v1.2.3" {
-		t.Errorf("unexpected version: %s", string(data))
+	if !strings.Contains(string(data), "v1.2.3") {
+		t.Errorf("config.yml should contain new version, got: %s", string(data))
 	}
 }
 
-func TestRepairTEMPLATEVERSION_MissingSource_ReturnsFail(t *testing.T) {
+func TestRepairAIConfigYML_MissingConfig_ReturnsFail(t *testing.T) {
 	root := t.TempDir()
 	fakeRun := func(name string, args ...string) (string, error) {
 		return "", nil
 	}
-	result := RepairTEMPLATEVERSION(root, fakeRun)
+	result := RepairAIConfigYML(root, fakeRun)
 	if result.Status != Fail {
-		t.Errorf("expected Fail without TEMPLATE_SOURCE, got %v", result.Status)
+		t.Errorf("expected Fail without config, got %v", result.Status)
 	}
 }
 
@@ -291,7 +246,7 @@ func TestRepairAISkills_UserDeclines_ReturnsWarning(t *testing.T) {
 
 func TestRepairAISkills_MissingTemplateConfig_ReturnsFail(t *testing.T) {
 	root := t.TempDir()
-	// No TEMPLATE_SOURCE or TEMPLATE_VERSION — should fail.
+	// No .ai/config.yml — should fail.
 	confirmFn := func(prompt string) (bool, error) {
 		return true, nil
 	}
@@ -299,9 +254,6 @@ func TestRepairAISkills_MissingTemplateConfig_ReturnsFail(t *testing.T) {
 	result := RepairAISkills(root, confirmFn, nil)
 	if result.Status != Fail {
 		t.Errorf("expected Fail when template config missing, got %v: %s", result.Status, result.Message)
-	}
-	if !strings.Contains(result.Message, "TEMPLATE_SOURCE") {
-		t.Errorf("message should mention TEMPLATE_SOURCE, got: %s", result.Message)
 	}
 }
 
@@ -336,13 +288,10 @@ func TestRepairGooseRecipes_ExtractsFromTarball(t *testing.T) {
 
 func TestRepairGooseRecipes_MissingConfig_ReturnsFail(t *testing.T) {
 	root := t.TempDir()
-	// No TEMPLATE_SOURCE — repair should fail with a clear message.
+	// No .ai/config.yml — repair should fail with a clear message.
 	result := RepairGooseRecipes(root, nil)
 	if result.Status != Fail {
 		t.Errorf("expected Fail when template config missing, got %v: %s", result.Status, result.Message)
-	}
-	if !strings.Contains(result.Message, "TEMPLATE_SOURCE") {
-		t.Error("message should mention TEMPLATE_SOURCE")
 	}
 }
 
@@ -444,16 +393,13 @@ func TestRepairWorkflows_Fallback_ExtractsFromTarball(t *testing.T) {
 
 func TestRepairWorkflows_Fallback_MissingConfig_ReturnsFail(t *testing.T) {
 	root := t.TempDir()
-	// No .ai/ and no TEMPLATE_SOURCE — should fail.
+	// No .ai/config.yml — should fail.
 	fakeRun := func(name string, args ...string) (string, error) {
 		return "", nil
 	}
 	result := RepairWorkflows(root, bootstrap.OwnerTypeOrg, fakeRun, nil)
 	if result.Status != Fail {
 		t.Errorf("expected Fail when template config missing, got %v: %s", result.Status, result.Message)
-	}
-	if !strings.Contains(result.Message, "TEMPLATE_SOURCE") {
-		t.Errorf("expected TEMPLATE_SOURCE in message, got: %s", result.Message)
 	}
 }
 
@@ -1872,13 +1818,15 @@ func TestRepairClaudeCredentialsManualAction_UserScope_ShowsRepoInstructions(t *
 // Test helpers for tarball-based repairs
 // ──────────────────────────────────────────────────────────────────────────────
 
-// writeTemplateConfig writes TEMPLATE_SOURCE and TEMPLATE_VERSION files.
+// writeTemplateConfig writes .ai/config.yml with template source and version.
 func writeTemplateConfig(t *testing.T, root, source, version string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(root, "TEMPLATE_SOURCE"), []byte(source), 0o644); err != nil {
+	aiDir := filepath.Join(root, ".ai")
+	if err := os.MkdirAll(aiDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, "TEMPLATE_VERSION"), []byte(version), 0o644); err != nil {
+	content := "template: " + source + "\nversion: " + version + "\n"
+	if err := os.WriteFile(filepath.Join(aiDir, "config.yml"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary

- Moves primary source of truth for template source/version from `TEMPLATE_SOURCE`/`TEMPLATE_VERSION` flat files to `.ai/config.yml` (YAML)
- All readers try `.ai/config.yml` first, fall back to old files via deprecated paths tagged `TODO(deprecated)` for future removal
- After a successful sync, legacy files are deleted from disk and removed from git tracking via `git rm --cached`
- All checks, repairs, doctor command, and tests updated to use the new layout
- `gopkg.in/yaml.v3` promoted from indirect to direct dependency

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `go build ./...` — clean build
- [x] `TestUpdateVersion` verifies `.ai/config.yml` is written with correct version and template
- [x] `TestStageSync` verifies `git rm --cached TEMPLATE_SOURCE TEMPLATE_VERSION` is called before `git add`
- [x] Legacy fallback path covered by `TestRunSync_BaseMissing_RestoresOnConfirm`

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)