### PR TITLE
chore: update README and add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Eddie Carpenter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # gh-agentic
 
+[![Go Version](https://img.shields.io/github/go-mod/go-version/eddiecarpenter/gh-agentic)](go.mod)
+[![Build](https://github.com/eddiecarpenter/gh-agentic/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/eddiecarpenter/gh-agentic/actions/workflows/build-and-test.yml)
+[![Latest Release](https://img.shields.io/github/v/release/eddiecarpenter/gh-agentic)](https://github.com/eddiecarpenter/gh-agentic/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 A GitHub CLI extension that bootstraps and manages agentic software delivery environments.
+It replaces manual shell scripts with deterministic Go commands — creating repos, scaffolding
+projects, configuring GitHub, and keeping template files in sync — so AI agents can focus
+on the work that actually requires reasoning.
 
 ## Install
 
@@ -10,11 +18,12 @@ gh extension install eddiecarpenter/gh-agentic
 
 ## Commands
 
-```bash
-gh agentic bootstrap    # Bootstrap a new agentic environment
-gh agentic inception    # Register a new domain or tool repo
-gh agentic sync         # Sync base/ from the upstream template
-```
+| Command | Description |
+|---|---|
+| `gh agentic bootstrap` | Bootstrap a new agentic environment (Phase 0a) |
+| `gh agentic inception` | Register a new domain or tool repo (Phase 0b) |
+| `gh agentic sync` | Sync `.ai/`, workflows, and recipes from the upstream template |
+| `gh agentic doctor` | Check the local repo for missing or misconfigured agentic files |
 
 ## Prerequisites
 
@@ -23,6 +32,37 @@ gh agentic sync         # Sync base/ from the upstream template
 - [Goose](https://github.com/block/goose)
 
 Claude Code is recommended as the Goose provider but not required.
+
+## Usage
+
+### Bootstrap a new project
+
+Run `gh agentic bootstrap` from any directory. You will be prompted for:
+
+- **Topology** — Embedded (single repo) or Organisation (separate control plane)
+- **Owner** — your personal account or an organisation
+- **Project name** and **description**
+- **Stack** — Go, Java, TypeScript, Python, Rust, or Other
+
+The command creates the GitHub repo, scaffolds the project structure, configures branch
+protection and labels, and prints next steps for starting a Requirements Session with
+your AI agent.
+
+### Sync the template
+
+```bash
+gh agentic sync                     # sync to the latest release
+gh agentic sync --release v1.5.0    # sync to a specific release
+gh agentic sync --list              # list available releases
+gh agentic sync --force             # re-sync even if already up to date
+```
+
+### Check repo health
+
+```bash
+gh agentic doctor          # report missing or misconfigured files
+gh agentic doctor --repair # interactively repair detected issues
+```
 
 ## Upgrade
 
@@ -39,4 +79,8 @@ go build ./...
 go test ./...
 ```
 
-See `docs/PROJECT_BRIEF.md` for full design documentation.
+See [`docs/PROJECT_BRIEF.md`](docs/PROJECT_BRIEF.md) for full design documentation.
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build](https://github.com/eddiecarpenter/gh-agentic/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/eddiecarpenter/gh-agentic/actions/workflows/build-and-test.yml)
 [![Latest Release](https://img.shields.io/github/v/release/eddiecarpenter/gh-agentic)](https://github.com/eddiecarpenter/gh-agentic/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=eddiecarpenter_gh-agentic&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=eddiecarpenter_gh-agentic)
 
 A GitHub CLI extension that bootstraps and manages agentic software delivery environments.
 It replaces manual shell scripts with deterministic Go commands — creating repos, scaffolding

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # gh-agentic
 
-[![Go Version](https://img.shields.io/github/go-mod/go-version/eddiecarpenter/gh-agentic)](go.mod)
 [![Build](https://github.com/eddiecarpenter/gh-agentic/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/eddiecarpenter/gh-agentic/actions/workflows/build-and-test.yml)
 [![Latest Release](https://img.shields.io/github/v/release/eddiecarpenter/gh-agentic)](https://github.com/eddiecarpenter/gh-agentic/releases/latest)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=eddiecarpenter_gh-agentic&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=eddiecarpenter_gh-agentic)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/eddiecarpenter/gh-agentic)](go.mod)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 A GitHub CLI extension that bootstraps and manages agentic software delivery environments.
 It replaces manual shell scripts with deterministic Go commands — creating repos, scaffolding


### PR DESCRIPTION
## Summary

- Rewrites README with accurate content — the old copy still referenced `base/` and was missing the `doctor` command
- Adds usage sections for `sync` flags and `doctor --repair`
- Adds four badges: Go version, build status, latest release, MIT license
- Adds `LICENSE` (MIT, 2025 Eddie Carpenter)

## Test plan

- [ ] Badges render correctly on the GitHub repo page
- [ ] All links in README resolve (go.mod, docs/PROJECT_BRIEF.md, LICENSE, workflow badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)