### PR TITLE
feat: deploy .ai/.github/actions/ during sync and bootstrap

### DIFF
--- a/.github/actions/install-ai-tools/action.yml
+++ b/.github/actions/install-ai-tools/action.yml
@@ -1,0 +1,121 @@
+name: Install AI Tools
+description: >
+  Install Goose and Claude Code CLI with caching support.
+  Optionally installs gh CLI for jobs that need it.
+
+inputs:
+  goose-version:
+    description: 'Goose version to install (default: latest)'
+    required: false
+    default: 'latest'
+  claude-cli-version:
+    description: 'Claude Code CLI version to install (default: latest)'
+    required: false
+    default: 'latest'
+  install-gh-cli:
+    description: 'Whether to install gh CLI (default: true)'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update -qq && sudo apt-get install -y bzip2 libgomp1
+
+    - name: Resolve Goose version
+      id: goose-version
+      shell: bash
+      run: |
+        if [ "${{ inputs.goose-version }}" = "latest" ]; then
+          GOOSE_VERSION=$(curl -fsSL https://api.github.com/repos/block/goose/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
+        else
+          GOOSE_VERSION="${{ inputs.goose-version }}"
+        fi
+        echo "version=${GOOSE_VERSION}" >> $GITHUB_OUTPUT
+
+    - name: Resolve Claude CLI version
+      id: claude-version
+      shell: bash
+      run: |
+        if [ "${{ inputs.claude-cli-version }}" = "latest" ]; then
+          CLAUDE_VERSION=$(npm view @anthropic-ai/claude-code version 2>/dev/null || echo "unknown")
+        else
+          CLAUDE_VERSION="${{ inputs.claude-cli-version }}"
+        fi
+        echo "version=${CLAUDE_VERSION}" >> $GITHUB_OUTPUT
+
+    - name: Cache Goose binary
+      id: cache-goose
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
+      with:
+        path: ~/.local/bin/goose
+        key: goose-${{ steps.goose-version.outputs.version }}
+
+    - name: Install Goose
+      if: steps.cache-goose.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p ~/.local/bin
+        GOOSE_VERSION="${{ steps.goose-version.outputs.version }}"
+        curl -fsSL "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-x86_64-unknown-linux-gnu.tar.bz2" -o /tmp/goose.tar.bz2
+        tar -xj -C ~/.local/bin -f /tmp/goose.tar.bz2
+
+    - name: Cache Claude Code CLI
+      id: cache-claude
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
+      with:
+        path: ${{ runner.tool_cache }}/claude-cli
+        key: claude-cli-${{ steps.claude-version.outputs.version }}
+
+    - name: Install Claude Code CLI
+      if: steps.cache-claude.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        npm config set prefix "${{ runner.tool_cache }}/claude-cli"
+        if [ "${{ inputs.claude-cli-version }}" = "latest" ]; then
+          npm install -g @anthropic-ai/claude-code
+        else
+          npm install -g @anthropic-ai/claude-code@${{ inputs.claude-cli-version }}
+        fi
+
+    - name: Restore Claude CLI from cache
+      if: steps.cache-claude.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        npm config set prefix "${{ runner.tool_cache }}/claude-cli"
+
+    - name: Resolve gh CLI version
+      if: inputs.install-gh-cli == 'true'
+      id: gh-version
+      shell: bash
+      run: |
+        GH_VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
+        echo "version=${GH_VERSION}" >> $GITHUB_OUTPUT
+
+    - name: Cache gh CLI
+      if: inputs.install-gh-cli == 'true'
+      id: cache-gh
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
+      with:
+        path: ~/.local/bin/gh
+        key: gh-cli-${{ steps.gh-version.outputs.version }}
+
+    - name: Install gh CLI
+      if: inputs.install-gh-cli == 'true' && steps.cache-gh.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p ~/.local/bin
+        GH_VERSION="${{ steps.gh-version.outputs.version }}"
+        curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
+        tar -xz -C /tmp -f /tmp/gh.tar.gz
+        mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh ~/.local/bin/gh
+
+    - name: Add tools to PATH
+      shell: bash
+      run: |
+        mkdir -p ~/.local/bin
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}/claude-cli/bin" >> $GITHUB_PATH

--- a/internal/bootstrap/runner.go
+++ b/internal/bootstrap/runner.go
@@ -97,6 +97,10 @@ func RunSteps(
 			label: "Deploying sync workflows",
 			fn:    func() error { return DeploySyncWorkflows(w, cfg, state, run) },
 		},
+		{
+			label: "Deploying composite actions",
+			fn:    func() error { return DeployCompositeActions(w, state, run) },
+		},
 	}
 
 	for _, s := range steps {

--- a/internal/bootstrap/steps.go
+++ b/internal/bootstrap/steps.go
@@ -860,6 +860,70 @@ func DeploySyncWorkflows(w io.Writer, cfg BootstrapConfig, state *StepState, run
 	return nil
 }
 
+// DeployCompositeActions copies composite action directories from .ai/.github/actions/
+// into the bootstrapped repo's .github/actions/ directory. Deploys for all account
+// types (personal and org). Missing source directory is silently skipped.
+func DeployCompositeActions(w io.Writer, state *StepState, run RunCommandFunc) error {
+	sourceDir := filepath.Join(state.ClonePath, ".ai", ".github", "actions")
+	destDir := filepath.Join(state.ClonePath, ".github", "actions")
+
+	if _, err := os.Stat(sourceDir); os.IsNotExist(err) {
+		fmt.Fprintln(w, "  "+ui.Muted.Render("· No composite actions to deploy"))
+		return nil
+	}
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("creating .github/actions/: %w", err)
+	}
+
+	// Walk source and mirror into destination.
+	if err := filepath.WalkDir(sourceDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(destDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", rel, err)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("getting info for %s: %w", rel, err)
+		}
+		return os.WriteFile(dstPath, data, info.Mode())
+	}); err != nil {
+		return fmt.Errorf("deploying composite actions: %w", err)
+	}
+
+	// Stage the deployed actions.
+	if out, err := runInDir(run, state.ClonePath, "git", "add", ".github/actions/"); err != nil {
+		fmt.Fprintln(w, "  "+ui.RenderWarning("Could not stage composite actions: "+strings.TrimSpace(out)))
+		return nil
+	}
+
+	// Commit.
+	if out, err := runInDir(run, state.ClonePath, "git", "commit", "-m", "chore: deploy composite GitHub Actions"); err != nil {
+		fmt.Fprintln(w, "  "+ui.RenderWarning("Could not commit composite actions: "+strings.TrimSpace(out)))
+		return nil
+	}
+
+	// Push — skip for existing repos (branch push + PR handled by OpenBootstrapPR).
+	if !state.ExistingRepo {
+		if out, err := runInDir(run, state.ClonePath, "git", "push", "origin", "main"); err != nil {
+			fmt.Fprintln(w, "  "+ui.RenderWarning("Could not push composite actions: "+strings.TrimSpace(out)))
+		}
+	}
+
+	return nil
+}
+
 // --------------------------------------------------------------------------------------
 // Step 9 — PrintSummary + Goose launch
 // --------------------------------------------------------------------------------------

--- a/internal/sync/steps.go
+++ b/internal/sync/steps.go
@@ -94,9 +94,9 @@ func FetchAndExtractTemplate(tarballURL, repo, version, repoRoot string, workflo
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Extract .ai/ (includes .ai/.github/workflows/), .goose/ (recipes),
-	// and root files (CLAUDE.md, AGENTS.md) so the subsequent deploy steps
-	// can operate on the extracted content.
+	// Extract .ai/ (includes .ai/.github/workflows/ and .ai/.github/actions/),
+	// .goose/ (recipes), and root files (CLAUDE.md, AGENTS.md) so the subsequent
+	// deploy steps can operate on the extracted content.
 	extractPrefixes := []string{".ai/", ".goose/", "CLAUDE.md", "AGENTS.md"}
 	if err := tarball.ExtractFromTemplate(repo, version, tmpDir, extractPrefixes, fetchTarballFn); err != nil {
 		return err
@@ -117,6 +117,11 @@ func FetchAndExtractTemplate(tarballURL, repo, version, repoRoot string, workflo
 		return err
 	}
 
+	// Deploy composite actions from extracted tarball.
+	if err := DeployActions(tmpDir, repoRoot); err != nil {
+		return err
+	}
+
 	// Deploy recipes from extracted tarball.
 	if err := DeployRecipes(tmpDir, repoRoot); err != nil {
 		return err
@@ -125,12 +130,13 @@ func FetchAndExtractTemplate(tarballURL, repo, version, repoRoot string, workflo
 	return nil
 }
 
-// BackupAI copies existing .ai/ and .github/workflows/ to a temp backup
-// location. Returns the backup directory path. The caller is responsible for
-// cleanup.
+// BackupAI copies existing .ai/, .github/workflows/, .github/actions/, and
+// .goose/recipes/ to a temp backup location. Returns the backup directory path.
+// The caller is responsible for cleanup.
 func BackupAI(repoRoot string) (string, error) {
 	aiSrc := filepath.Join(repoRoot, ".ai")
 	workflowsSrc := filepath.Join(repoRoot, ".github", "workflows")
+	actionsSrc := filepath.Join(repoRoot, ".github", "actions")
 	recipesSrc := filepath.Join(repoRoot, ".goose", "recipes")
 
 	aiExists := false
@@ -143,13 +149,18 @@ func BackupAI(repoRoot string) (string, error) {
 		workflowsExist = true
 	}
 
+	actionsExist := false
+	if _, err := os.Stat(actionsSrc); err == nil {
+		actionsExist = true
+	}
+
 	recipesExist := false
 	if _, err := os.Stat(recipesSrc); err == nil {
 		recipesExist = true
 	}
 
 	// Nothing to back up on first sync.
-	if !aiExists && !workflowsExist && !recipesExist {
+	if !aiExists && !workflowsExist && !actionsExist && !recipesExist {
 		return "", nil
 	}
 
@@ -169,6 +180,13 @@ func BackupAI(repoRoot string) (string, error) {
 		if err := fsutil.CopyDir(workflowsSrc, filepath.Join(backupDir, "workflows")); err != nil {
 			_ = os.RemoveAll(backupDir)
 			return "", fmt.Errorf("backing up .github/workflows/: %w", err)
+		}
+	}
+
+	if actionsExist {
+		if err := fsutil.CopyDir(actionsSrc, filepath.Join(backupDir, "actions")); err != nil {
+			_ = os.RemoveAll(backupDir)
+			return "", fmt.Errorf("backing up .github/actions/: %w", err)
 		}
 	}
 
@@ -241,6 +259,54 @@ func DeployWorkflows(tmpDir, repoRoot string, excludeFiles []string) error {
 	}
 
 	return nil
+}
+
+// DeployActions copies composite action directories from the extracted template's
+// .ai/.github/actions/ into the local repo's .github/actions/ using merge semantics:
+// template files overwrite existing copies, project-owned files are preserved,
+// no directories are deleted.
+// Returns nil if the source directory does not exist (template has no actions).
+func DeployActions(tmpDir, repoRoot string) error {
+	src := filepath.Join(tmpDir, ".ai", ".github", "actions")
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		return nil
+	}
+
+	dst := filepath.Join(repoRoot, ".github", "actions")
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return fmt.Errorf("creating .github/actions/: %w", err)
+	}
+
+	// Walk the source tree and mirror it into the destination.
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		dstPath := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0o755)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading action file %s: %w", rel, err)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("getting info for %s: %w", rel, err)
+		}
+		if err := os.WriteFile(dstPath, data, info.Mode()); err != nil {
+			return fmt.Errorf("writing action file %s: %w", rel, err)
+		}
+		return nil
+	})
 }
 
 // DeployRecipes copies .goose/recipes/ from the extracted template into the local
@@ -391,6 +457,18 @@ func ShowDiff(repoRoot string, run bootstrap.RunCommandFunc) (string, error) {
 		out += "\n--- New workflow files ---\n" + wfUntracked
 	}
 
+	// Include .github/actions/ diffs.
+	actionsDiff, _ := runInDir(run, repoRoot, "git", "diff", ".github/actions/")
+	if strings.TrimSpace(actionsDiff) != "" {
+		out += "\n" + actionsDiff
+	}
+
+	// Include untracked action files.
+	actionsUntracked, _ := runInDir(run, repoRoot, "git", "ls-files", "--others", "--exclude-standard", ".github/actions/")
+	if strings.TrimSpace(actionsUntracked) != "" {
+		out += "\n--- New action files ---\n" + actionsUntracked
+	}
+
 	// Include .goose/recipes/ diffs.
 	recipesDiff, _ := runInDir(run, repoRoot, "git", "diff", ".goose/recipes/")
 	if strings.TrimSpace(recipesDiff) != "" {
@@ -458,14 +536,14 @@ func WritePostSyncMD(repoRoot string, releaseBody string) error {
 
 // StageSync stages all sync changes for commit. Removes legacy TEMPLATE_SOURCE
 // and TEMPLATE_VERSION from git tracking (they are superseded by .ai/config.yml),
-// then stages .ai/, .github/workflows/, CLAUDE.md, AGENTS.md, .goose/recipes/,
-// and POST_SYNC.md.
+// then stages .ai/, .github/workflows/, .github/actions/, CLAUDE.md, AGENTS.md,
+// .goose/recipes/, and POST_SYNC.md.
 func StageSync(repoRoot string, run bootstrap.RunCommandFunc) error {
 	// Remove legacy files from git tracking — ignore if already gone.
 	if out, err := runInDir(run, repoRoot, "git", "rm", "--ignore-unmatch", "--cached", "TEMPLATE_SOURCE", "TEMPLATE_VERSION"); err != nil {
 		return fmt.Errorf("git rm legacy files: %w\n%s", err, strings.TrimSpace(out))
 	}
-	if out, err := runInDir(run, repoRoot, "git", "add", ".ai/", "CLAUDE.md", "AGENTS.md", ".github/workflows/", ".goose/recipes/", "POST_SYNC.md"); err != nil {
+	if out, err := runInDir(run, repoRoot, "git", "add", ".ai/", "CLAUDE.md", "AGENTS.md", ".github/workflows/", ".github/actions/", ".goose/recipes/", "POST_SYNC.md"); err != nil {
 		return fmt.Errorf("git add: %w\n%s", err, strings.TrimSpace(out))
 	}
 	return nil
@@ -494,8 +572,8 @@ func CommitSync(repoRoot, repo, version string, run bootstrap.RunCommandFunc) er
 	return nil
 }
 
-// RestoreAI restores .ai/ and .github/workflows/ from a backup created by
-// BackupAI. If backupDir is empty, there was nothing to restore.
+// RestoreAI restores .ai/, .github/workflows/, .github/actions/, and .goose/recipes/
+// from a backup created by BackupAI. If backupDir is empty, there was nothing to restore.
 func RestoreAI(repoRoot, backupDir string) error {
 	if backupDir == "" {
 		return nil
@@ -522,6 +600,18 @@ func RestoreAI(repoRoot, backupDir string) error {
 		}
 		if err := fsutil.CopyDir(workflowsSrc, workflowsDst); err != nil {
 			return fmt.Errorf("restoring .github/workflows/: %w", err)
+		}
+	}
+
+	// Restore .github/actions/ if it was backed up.
+	actionsSrc := filepath.Join(backupDir, "actions")
+	if _, err := os.Stat(actionsSrc); err == nil {
+		actionsDst := filepath.Join(repoRoot, ".github", "actions")
+		if err := os.RemoveAll(actionsDst); err != nil {
+			return fmt.Errorf("removing .github/actions/ for restore: %w", err)
+		}
+		if err := fsutil.CopyDir(actionsSrc, actionsDst); err != nil {
+			return fmt.Errorf("restoring .github/actions/: %w", err)
 		}
 	}
 

--- a/internal/sync/steps_test.go
+++ b/internal/sync/steps_test.go
@@ -1121,6 +1121,16 @@ func TestExtractOwnerFromAgentsLocal_Sync(t *testing.T) {
 }
 
 func TestShowDiff(t *testing.T) {
+	// ShowDiff makes 8 git calls:
+	//   1. git diff .ai/
+	//   2. ls-files .ai/
+	//   3. git diff .github/workflows/
+	//   4. ls-files .github/workflows/
+	//   5. git diff .github/actions/
+	//   6. ls-files .github/actions/
+	//   7. git diff .goose/recipes/
+	//   8. ls-files .goose/recipes/
+
 	t.Run("returns diff output", func(t *testing.T) {
 		responses := []struct {
 			output string
@@ -1128,10 +1138,12 @@ func TestShowDiff(t *testing.T) {
 		}{
 			{output: "diff --git a/.ai/RULEBOOK.md", err: nil}, // git diff .ai/
 			{output: "", err: nil},                              // ls-files .ai/
-			{output: "", err: nil},                             // git diff .github/workflows/
-			{output: "", err: nil},                             // ls-files .github/workflows/
-			{output: "", err: nil},                             // git diff .goose/recipes/
-			{output: "", err: nil},                             // ls-files .goose/recipes/
+			{output: "", err: nil},                              // git diff .github/workflows/
+			{output: "", err: nil},                              // ls-files .github/workflows/
+			{output: "", err: nil},                              // git diff .github/actions/
+			{output: "", err: nil},                              // ls-files .github/actions/
+			{output: "", err: nil},                              // git diff .goose/recipes/
+			{output: "", err: nil},                              // ls-files .goose/recipes/
 		}
 		run := fakeRunMulti(responses)
 
@@ -1149,12 +1161,14 @@ func TestShowDiff(t *testing.T) {
 			output string
 			err    error
 		}{
-			{output: "", err: nil},                   // git diff .ai/
-			{output: ".ai/new-file.md\n", err: nil},  // ls-files .ai/
-			{output: "", err: nil},                   // git diff .github/workflows/
-			{output: "", err: nil},                   // ls-files .github/workflows/
-			{output: "", err: nil},                   // git diff .goose/recipes/
-			{output: "", err: nil},                   // ls-files .goose/recipes/
+			{output: "", err: nil},                  // git diff .ai/
+			{output: ".ai/new-file.md\n", err: nil}, // ls-files .ai/
+			{output: "", err: nil},                  // git diff .github/workflows/
+			{output: "", err: nil},                  // ls-files .github/workflows/
+			{output: "", err: nil},                  // git diff .github/actions/
+			{output: "", err: nil},                  // ls-files .github/actions/
+			{output: "", err: nil},                  // git diff .goose/recipes/
+			{output: "", err: nil},                  // ls-files .goose/recipes/
 		}
 		run := fakeRunMulti(responses)
 
@@ -1176,6 +1190,8 @@ func TestShowDiff(t *testing.T) {
 			{output: "", err: nil},                                      // ls-files .ai/
 			{output: "diff --git a/.github/workflows/ci.yml", err: nil}, // git diff .github/workflows/
 			{output: "", err: nil},                                      // ls-files .github/workflows/
+			{output: "", err: nil},                                      // git diff .github/actions/
+			{output: "", err: nil},                                      // ls-files .github/actions/
 			{output: "", err: nil},                                      // git diff .goose/recipes/
 			{output: "", err: nil},                                      // ls-files .goose/recipes/
 		}
@@ -1199,6 +1215,8 @@ func TestShowDiff(t *testing.T) {
 			{output: "", err: nil},                                     // ls-files .ai/
 			{output: "", err: nil},                                     // git diff .github/workflows/
 			{output: ".github/workflows/new-pipeline.yml\n", err: nil}, // ls-files .github/workflows/
+			{output: "", err: nil},                                     // git diff .github/actions/
+			{output: "", err: nil},                                     // ls-files .github/actions/
 			{output: "", err: nil},                                     // git diff .goose/recipes/
 			{output: "", err: nil},                                     // ls-files .goose/recipes/
 		}
@@ -1213,17 +1231,69 @@ func TestShowDiff(t *testing.T) {
 		}
 	})
 
+	t.Run("includes action diffs", func(t *testing.T) {
+		responses := []struct {
+			output string
+			err    error
+		}{
+			{output: "", err: nil},                                                                 // git diff .ai/
+			{output: "", err: nil},                                                                 // ls-files .ai/
+			{output: "", err: nil},                                                                 // git diff .github/workflows/
+			{output: "", err: nil},                                                                 // ls-files .github/workflows/
+			{output: "diff --git a/.github/actions/install-ai-tools/action.yml", err: nil},        // git diff .github/actions/
+			{output: "", err: nil},                                                                 // ls-files .github/actions/
+			{output: "", err: nil},                                                                 // git diff .goose/recipes/
+			{output: "", err: nil},                                                                 // ls-files .goose/recipes/
+		}
+		run := fakeRunMulti(responses)
+
+		diff, err := ShowDiff("/repo", run)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(diff, ".github/actions/install-ai-tools/action.yml") {
+			t.Errorf("expected action diff, got %q", diff)
+		}
+	})
+
+	t.Run("includes new action files", func(t *testing.T) {
+		responses := []struct {
+			output string
+			err    error
+		}{
+			{output: "", err: nil},                                                        // git diff .ai/
+			{output: "", err: nil},                                                        // ls-files .ai/
+			{output: "", err: nil},                                                        // git diff .github/workflows/
+			{output: "", err: nil},                                                        // ls-files .github/workflows/
+			{output: "", err: nil},                                                        // git diff .github/actions/
+			{output: ".github/actions/install-ai-tools/action.yml\n", err: nil},          // ls-files .github/actions/
+			{output: "", err: nil},                                                        // git diff .goose/recipes/
+			{output: "", err: nil},                                                        // ls-files .goose/recipes/
+		}
+		run := fakeRunMulti(responses)
+
+		diff, err := ShowDiff("/repo", run)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(diff, "New action files") {
+			t.Errorf("expected new action files section, got %q", diff)
+		}
+	})
+
 	t.Run("includes recipe diffs", func(t *testing.T) {
 		responses := []struct {
 			output string
 			err    error
 		}{
-			{output: "", err: nil},                                              // git diff .ai/
-			{output: "", err: nil},                                              // ls-files .ai/
-			{output: "", err: nil},                                              // git diff .github/workflows/
-			{output: "", err: nil},                                              // ls-files .github/workflows/
-			{output: "diff --git a/.goose/recipes/dev.yaml", err: nil},          // git diff .goose/recipes/
-			{output: "", err: nil},                                              // ls-files .goose/recipes/
+			{output: "", err: nil},                                     // git diff .ai/
+			{output: "", err: nil},                                     // ls-files .ai/
+			{output: "", err: nil},                                     // git diff .github/workflows/
+			{output: "", err: nil},                                     // ls-files .github/workflows/
+			{output: "", err: nil},                                     // git diff .github/actions/
+			{output: "", err: nil},                                     // ls-files .github/actions/
+			{output: "diff --git a/.goose/recipes/dev.yaml", err: nil}, // git diff .goose/recipes/
+			{output: "", err: nil},                                     // ls-files .goose/recipes/
 		}
 		run := fakeRunMulti(responses)
 
@@ -1241,12 +1311,14 @@ func TestShowDiff(t *testing.T) {
 			output string
 			err    error
 		}{
-			{output: "", err: nil},                                  // git diff .ai/
-			{output: "", err: nil},                                  // ls-files .ai/
-			{output: "", err: nil},                                  // git diff .github/workflows/
-			{output: "", err: nil},                                  // ls-files .github/workflows/
-			{output: "", err: nil},                                  // git diff .goose/recipes/
-			{output: ".goose/recipes/new-recipe.yaml\n", err: nil},  // ls-files .goose/recipes/
+			{output: "", err: nil},                                 // git diff .ai/
+			{output: "", err: nil},                                 // ls-files .ai/
+			{output: "", err: nil},                                 // git diff .github/workflows/
+			{output: "", err: nil},                                 // ls-files .github/workflows/
+			{output: "", err: nil},                                 // git diff .github/actions/
+			{output: "", err: nil},                                 // ls-files .github/actions/
+			{output: "", err: nil},                                 // git diff .goose/recipes/
+			{output: ".goose/recipes/new-recipe.yaml\n", err: nil}, // ls-files .goose/recipes/
 		}
 		run := fakeRunMulti(responses)
 
@@ -1264,6 +1336,84 @@ func TestShowDiff(t *testing.T) {
 		_, err := ShowDiff("/repo", run)
 		if err == nil {
 			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestDeployActions(t *testing.T) {
+	t.Run("deploys action files from template", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repoRoot := t.TempDir()
+
+		// Create template action structure.
+		actionSrc := filepath.Join(tmpDir, ".ai", ".github", "actions", "install-ai-tools")
+		if err := os.MkdirAll(actionSrc, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(actionSrc, "action.yml"), []byte("name: Install AI Tools\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := DeployActions(tmpDir, repoRoot)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Verify action was deployed.
+		data, err := os.ReadFile(filepath.Join(repoRoot, ".github", "actions", "install-ai-tools", "action.yml"))
+		if err != nil {
+			t.Fatalf(".github/actions/install-ai-tools/action.yml should exist: %v", err)
+		}
+		if string(data) != "name: Install AI Tools\n" {
+			t.Errorf("content = %q, want %q", data, "name: Install AI Tools\n")
+		}
+	})
+
+	t.Run("no-op when source does not exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repoRoot := t.TempDir()
+
+		err := DeployActions(tmpDir, repoRoot)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// .github/actions/ should not have been created.
+		if _, err := os.Stat(filepath.Join(repoRoot, ".github", "actions")); err == nil {
+			t.Error(".github/actions/ should not exist when template has no actions")
+		}
+	})
+
+	t.Run("overwrites existing action file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repoRoot := t.TempDir()
+
+		// Pre-existing action.
+		actionDst := filepath.Join(repoRoot, ".github", "actions", "install-ai-tools")
+		if err := os.MkdirAll(actionDst, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(actionDst, "action.yml"), []byte("old content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Template with updated content.
+		actionSrc := filepath.Join(tmpDir, ".ai", ".github", "actions", "install-ai-tools")
+		if err := os.MkdirAll(actionSrc, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(actionSrc, "action.yml"), []byte("new content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := DeployActions(tmpDir, repoRoot)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, _ := os.ReadFile(filepath.Join(actionDst, "action.yml"))
+		if string(data) != "new content\n" {
+			t.Errorf("content = %q, want %q", data, "new content\n")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `DeployActions` to `internal/sync/steps.go` — deploys `.ai/.github/actions/` → `.github/actions/` (merge semantics: template overwrites, project-owned files preserved)
- Updates `FetchAndExtractTemplate`, `BackupAI`, `StageSync`, `RestoreAI`, and `ShowDiff` to include `.github/actions/` alongside workflows
- Adds `DeployCompositeActions` to `internal/bootstrap/steps.go` and wires it into the bootstrap runner (deploys for all account types)
- Bootstraps `.github/actions/install-ai-tools/action.yml` into this repo — fixes the broken `agentic-pipeline.yml` which already references `./.github/actions/install-ai-tools`

## Test plan

- [x] `go test ./...` — all tests pass
- [x] New `TestDeployActions` sub-tests: deploys files, no-op when absent, overwrites existing
- [x] `TestShowDiff` updated with 8-call response sequences (added actions diff/ls-files)
- [x] `agentic-pipeline.yml` can now resolve `./.github/actions/install-ai-tools`

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)