### PR TITLE
test: add coverage for error paths in verify/repair.go and verify/checks.go

### DIFF
--- a/internal/verify/checks_gaps_test.go
+++ b/internal/verify/checks_gaps_test.go
@@ -1,0 +1,243 @@
+package verify
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eddiecarpenter/gh-agentic/internal/bootstrap"
+)
+
+// ── CheckAISkills — git diff fails (lines 241-244) ───────────────────────────
+
+func TestCheckAISkills_GitDiffFails_ReturnsWarning(t *testing.T) {
+	root := t.TempDir()
+	// Create .ai/skills/ so the directory-not-found check passes.
+	if err := os.MkdirAll(filepath.Join(root, ".ai", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("git: not a repository")
+	}
+
+	result := CheckAISkills(root, fakeRun)
+	if result.Status != Warning {
+		t.Errorf("expected Warning when git diff fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "could not check git status") {
+		t.Errorf("expected 'could not check git status', got: %s", result.Message)
+	}
+}
+
+// ── CheckWorkflows — .ai dir present, content comparison paths ───────────────
+// Lines 312-315 (ReadDir fails), 336-337 (ai ReadFile fails → missing)
+
+func TestCheckWorkflows_WithAIDir_ContentMatches_ReturnsPass(t *testing.T) {
+	root := t.TempDir()
+	content := []byte("# canonical workflow\n")
+	// Set up identical files in .ai/.github/workflows/ and .github/workflows/.
+	aiDir := filepath.Join(root, ".ai", ".github", "workflows")
+	if err := os.MkdirAll(aiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(aiDir, "build-and-test.yml"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	destDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(destDir, "build-and-test.yml"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := CheckWorkflows(root, bootstrap.OwnerTypeUser)
+	if result.Status != Pass {
+		t.Errorf("expected Pass when content matches, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestCheckWorkflows_WithAIDir_ContentDiffers_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	aiDir := filepath.Join(root, ".ai", ".github", "workflows")
+	if err := os.MkdirAll(aiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(aiDir, "build-and-test.yml"), []byte("# canonical\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	destDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(destDir, "build-and-test.yml"), []byte("# modified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := CheckWorkflows(root, bootstrap.OwnerTypeUser)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when content differs, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "content differs") {
+		t.Errorf("expected 'content differs' in message, got: %s", result.Message)
+	}
+}
+
+func TestCheckWorkflows_WithAIDir_DeployedFileMissing_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	// .ai has the file but .github/workflows/ does not.
+	aiDir := filepath.Join(root, ".ai", ".github", "workflows")
+	if err := os.MkdirAll(aiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(aiDir, "build-and-test.yml"), []byte("# ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".github", "workflows"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result := CheckWorkflows(root, bootstrap.OwnerTypeUser)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when deployed file missing, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "missing") {
+		t.Errorf("expected 'missing' in message, got: %s", result.Message)
+	}
+}
+
+// ── CheckProjectCollaborator — user type, no project (lines 814-817) ──────────
+
+func TestCheckProjectCollaborator_UserType_NoProject_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("project not found")
+	}
+
+	result := CheckProjectCollaborator("owner", "repo", "bot-user", bootstrap.OwnerTypeUser, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when no project for user type, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "no GitHub Project found") {
+		t.Errorf("expected 'no GitHub Project found', got: %s", result.Message)
+	}
+}
+
+// ── CheckProjectItemStatuses — error paths (lines 708-741) ───────────────────
+
+func TestCheckProjectItemStatuses_NoProject_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("no project")
+	}
+
+	result := CheckProjectItemStatuses("owner", "repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when no project, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "no GitHub Project found") {
+		t.Errorf("expected 'no GitHub Project found', got: %s", result.Message)
+	}
+}
+
+func TestCheckProjectItemStatuses_FieldFetchFails_ReturnsFail(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil
+		}
+		return "", fmt.Errorf("field query failed")
+	}
+
+	result := CheckProjectItemStatuses("owner", "repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when field fetch fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to fetch Status field ID") {
+		t.Errorf("expected 'failed to fetch Status field ID', got: %s", result.Message)
+	}
+}
+
+func TestCheckProjectItemStatuses_FieldNull_ReturnsFail(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil
+		}
+		return "null\n", nil // field ID null
+	}
+
+	result := CheckProjectItemStatuses("owner", "repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail for null field ID, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "Status field not found") {
+		t.Errorf("expected 'Status field not found', got: %s", result.Message)
+	}
+}
+
+func TestCheckProjectItemStatuses_FetchItemsFails_ReturnsFail(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil
+		}
+		if callCount == 2 {
+			return "FIELD_123\n", nil // field ID OK
+		}
+		return "", fmt.Errorf("items: server error")
+	}
+
+	result := CheckProjectItemStatuses("owner", "repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when items fetch fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to fetch project items") {
+		t.Errorf("expected 'failed to fetch project items', got: %s", result.Message)
+	}
+}
+
+// ── CheckLabels — JSON parse fails (lines 433-436) ───────────────────────────
+
+func TestCheckLabels_JSONParseFails_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "not-json", nil
+	}
+
+	result := CheckLabels("owner/repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when JSON parse fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to parse label JSON") {
+		t.Errorf("expected 'failed to parse label JSON', got: %s", result.Message)
+	}
+}
+
+// ── CheckProjectStatus — load template fails (lines 539-542) ─────────────────
+
+func TestCheckProjectStatus_LoadTemplateFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir() // no project-template.json
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil // project found
+		}
+		return "OPT_1|Backlog\n", nil // options
+	}
+
+	result := CheckProjectStatus("owner", "repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when template missing, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "project template") {
+		t.Errorf("expected 'project template' in message, got: %s", result.Message)
+	}
+}
+
+// Ensure bytes import is referenced (used by CheckWorkflows production code).
+var _ = bytes.Equal

--- a/internal/verify/checks_missing_test.go
+++ b/internal/verify/checks_missing_test.go
@@ -1,0 +1,301 @@
+package verify
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eddiecarpenter/gh-agentic/internal/bootstrap"
+)
+
+// ── CheckAIConfigYML — read error (not-found vs other error) ──────────────────
+
+func TestCheckAIConfigYML_ReadError_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	// Create .ai/ then place a directory at config.yml so ReadFile fails with
+	// "is a directory" — a different error from os.ErrNotExist.
+	if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, ".ai", "config.yml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result := CheckAIConfigYML(root)
+	if result.Status != Fail {
+		t.Errorf("expected Fail for read error, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "could not read file") {
+		t.Errorf("expected 'could not read file' in message, got: %s", result.Message)
+	}
+}
+
+// ── CheckProjectViews ─────────────────────────────────────────────────────────
+
+func TestCheckProjectViews_NoProject_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeTestProjectTemplate(t, root)
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("no project")
+	}
+
+	result := CheckProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "no GitHub Project found") {
+		t.Errorf("expected 'no GitHub Project found', got: %s", result.Message)
+	}
+}
+
+func TestCheckProjectViews_FetchViewsFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeTestProjectTemplate(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil // resolve project node ID
+		}
+		return "", fmt.Errorf("graphql error") // fetch views query fails
+	}
+
+	result := CheckProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to fetch views") {
+		t.Errorf("expected 'failed to fetch views', got: %s", result.Message)
+	}
+}
+
+func TestCheckProjectViews_LoadTemplateFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir() // no project-template.json
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil // project resolved
+		}
+		return "SomeView\n", nil // views fetched OK
+	}
+
+	result := CheckProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "project template") {
+		t.Errorf("expected 'project template' in message, got: %s", result.Message)
+	}
+}
+
+// writeProjectTemplateRequiringBoard writes a minimal project-template.json
+// that requires a single "Board" view.
+func writeProjectTemplateRequiringBoard(t *testing.T, root string) {
+	t.Helper()
+	baseDir := filepath.Join(root, "base")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"statusOptions":[],"requiredViews":[{"name":"Board","layout":"BOARD_LAYOUT","filter":""}]}`
+	if err := os.WriteFile(filepath.Join(baseDir, "project-template.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckProjectViews_MissingViews_ReturnsWarning(t *testing.T) {
+	root := t.TempDir()
+	writeProjectTemplateRequiringBoard(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil
+		}
+		return "", nil // no views present
+	}
+
+	result := CheckProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Warning {
+		t.Errorf("expected Warning for missing views, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "missing") {
+		t.Errorf("expected 'missing' in message, got: %s", result.Message)
+	}
+}
+
+func TestCheckProjectViews_AllPresent_ReturnsPass(t *testing.T) {
+	root := t.TempDir()
+	writeProjectTemplateRequiringBoard(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil
+		}
+		return "Board\n", nil // required view is present
+	}
+
+	result := CheckProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Pass {
+		t.Errorf("expected Pass when all views present, got %v: %s", result.Status, result.Message)
+	}
+}
+
+// ── CheckStaleOpenRequirements ────────────────────────────────────────────────
+
+func TestCheckStaleOpenRequirements_FetchFails_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("api error")
+	}
+
+	result := CheckStaleOpenRequirements("owner/repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestCheckStaleOpenRequirements_NoStale_ReturnsPass(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "[]", nil
+	}
+
+	result := CheckStaleOpenRequirements("owner/repo", fakeRun)
+	if result.Status != Pass {
+		t.Errorf("expected Pass for no stale issues, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestCheckStaleOpenRequirements_HasStale_ReturnsWarning(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return `[{"number":5,"title":"Stale Req"}]`, nil
+		case 2:
+			return `{"subIssues":[{"state":"CLOSED"}]}`, nil
+		}
+		return "[]", nil
+	}
+
+	result := CheckStaleOpenRequirements("owner/repo", fakeRun)
+	if result.Status != Warning {
+		t.Errorf("expected Warning for stale requirement, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "#5") {
+		t.Errorf("expected issue number in message, got: %s", result.Message)
+	}
+}
+
+// ── CheckStaleOpenFeatures ────────────────────────────────────────────────────
+
+func TestCheckStaleOpenFeatures_FetchFails_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("api error")
+	}
+
+	result := CheckStaleOpenFeatures("owner/repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestCheckStaleOpenFeatures_NoStale_ReturnsPass(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "[]", nil
+	}
+
+	result := CheckStaleOpenFeatures("owner/repo", fakeRun)
+	if result.Status != Pass {
+		t.Errorf("expected Pass for no stale features, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestCheckStaleOpenFeatures_HasStale_ReturnsWarning(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return `[{"number":10,"title":"Stale Feature"}]`, nil
+		case 2:
+			return `{"subIssues":[{"state":"CLOSED"},{"state":"CLOSED"}]}`, nil
+		}
+		return "[]", nil
+	}
+
+	result := CheckStaleOpenFeatures("owner/repo", fakeRun)
+	if result.Status != Warning {
+		t.Errorf("expected Warning for stale feature, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "#10") {
+		t.Errorf("expected issue number in message, got: %s", result.Message)
+	}
+}
+
+// ── checkRepoVariable error paths ─────────────────────────────────────────────
+
+func TestCheckRepoVariable_Org_ListFails_ReturnsWarning(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("org variable list failed")
+	}
+
+	result := checkRepoVariable("owner", "my-repo", "RUNNER_LABEL", "runner label", "ubuntu-latest", bootstrap.OwnerTypeOrg, fakeRun)
+	if result.Status != Warning {
+		t.Errorf("expected Warning when org list fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "could not list org variables") {
+		t.Errorf("expected 'could not list org variables', got: %s", result.Message)
+	}
+}
+
+func TestCheckRepoVariable_Org_RepoLevelCheckFails_ReturnsWarning(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return "[]", nil // org level: variable not found
+		}
+		return "", fmt.Errorf("repo variable list failed") // repo level check fails
+	}
+
+	result := checkRepoVariable("owner", "my-repo", "RUNNER_LABEL", "runner label", "ubuntu-latest", bootstrap.OwnerTypeOrg, fakeRun)
+	if result.Status != Warning {
+		t.Errorf("expected Warning when repo level check fails, got %v: %s", result.Status, result.Message)
+	}
+}
+
+// ── checkRepoSecret error paths ───────────────────────────────────────────────
+
+func TestCheckRepoSecret_Org_ListFails_ReturnsWarning(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("org secret list failed")
+	}
+
+	result := checkRepoSecret("owner", "my-repo", "GOOSE_AGENT_PAT", "pat check", bootstrap.OwnerTypeOrg, fakeRun)
+	if result.Status != Warning {
+		t.Errorf("expected Warning when org secret list fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "could not list org secrets") {
+		t.Errorf("expected 'could not list org secrets', got: %s", result.Message)
+	}
+}
+
+func TestCheckRepoSecret_Org_RepoLevelCheckFails_ReturnsWarning(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return "[]", nil // org level: secret not found
+		}
+		return "", fmt.Errorf("repo secret list failed") // repo level check fails
+	}
+
+	result := checkRepoSecret("owner", "my-repo", "GOOSE_AGENT_PAT", "pat check", bootstrap.OwnerTypeOrg, fakeRun)
+	if result.Status != Warning {
+		t.Errorf("expected Warning when repo level check fails, got %v: %s", result.Status, result.Message)
+	}
+}

--- a/internal/verify/repair_errors_test.go
+++ b/internal/verify/repair_errors_test.go
@@ -1,0 +1,679 @@
+package verify
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFailureDir creates a directory at path so that os.WriteFile on that path
+// fails with "is a directory". This is the cleanest cross-platform way to trigger
+// a write failure without relying on file permissions.
+func writeFailureDir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("writeFailureDir: %v", err)
+	}
+}
+
+// ── Write-failure error paths ─────────────────────────────────────────────────
+
+func TestRepairCLAUDEMD_WriteFailure_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeFailureDir(t, filepath.Join(root, "CLAUDE.md"))
+
+	result := RepairCLAUDEMD(root)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when write blocked, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "repair failed") {
+		t.Errorf("expected 'repair failed' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairLOCALRULESMD_WriteFailure_ReturnsWarning(t *testing.T) {
+	root := t.TempDir()
+	writeFailureDir(t, filepath.Join(root, "LOCALRULES.md"))
+
+	result := RepairLOCALRULESMD(root)
+	if result.Status != Warning {
+		t.Errorf("expected Warning when write blocked, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "repair failed") {
+		t.Errorf("expected 'repair failed' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairREPOSMD_WriteFailure_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeFailureDir(t, filepath.Join(root, "REPOS.md"))
+
+	result := RepairREPOSMD(root)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when write blocked, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "repair failed") {
+		t.Errorf("expected 'repair failed' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairREADMEMD_WriteFailure_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeFailureDir(t, filepath.Join(root, "README.md"))
+
+	result := RepairREADMEMD(root)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when write blocked, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "repair failed") {
+		t.Errorf("expected 'repair failed' in message, got: %s", result.Message)
+	}
+}
+
+// ── RepairSkillsDir error paths ───────────────────────────────────────────────
+
+func TestRepairSkillsDir_MkdirFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	// Place a regular file at the skills/ path so MkdirAll fails.
+	if err := os.WriteFile(filepath.Join(root, "skills"), []byte("blocker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fakeRun := func(name string, args ...string) (string, error) { return "", nil }
+
+	result := RepairSkillsDir(root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when mkdir blocked, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "repair failed") {
+		t.Errorf("expected 'repair failed' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairSkillsDir_WriteFileFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	// Create skills/ dir, then block .gitkeep write by placing a directory there.
+	if err := os.MkdirAll(filepath.Join(root, "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFailureDir(t, filepath.Join(root, "skills", ".gitkeep"))
+	fakeRun := func(name string, args ...string) (string, error) { return "", nil }
+
+	result := RepairSkillsDir(root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when WriteFile blocked, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "repair failed") {
+		t.Errorf("expected 'repair failed' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairSkillsDir_GitAddFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("git add: not a git repository")
+	}
+
+	result := RepairSkillsDir(root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when git add fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "git add failed") {
+		t.Errorf("expected 'git add failed' in message, got: %s", result.Message)
+	}
+}
+
+// ── RepairAIConfigYML error paths ─────────────────────────────────────────────
+
+func TestRepairAIConfigYML_RunFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeTemplateConfig(t, root, "owner/repo", "v1.0.0")
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("gh: not authenticated")
+	}
+
+	result := RepairAIConfigYML(root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when run fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to fetch latest tag") {
+		t.Errorf("expected 'failed to fetch latest tag' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairAIConfigYML_EmptyTag_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeTemplateConfig(t, root, "owner/repo", "v1.0.0")
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "   \n", nil // whitespace only — trims to ""
+	}
+
+	result := RepairAIConfigYML(root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail for empty tag, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "no releases found") {
+		t.Errorf("expected 'no releases found' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairAIConfigYML_WriteFailure_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	// Provide the template repo via TEMPLATE_SOURCE so the function can read it
+	// without needing .ai/config.yml to be readable.
+	if err := os.WriteFile(filepath.Join(root, "TEMPLATE_SOURCE"), []byte("owner/repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Create .ai/ then block the config.yml write with a directory at that path.
+	if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFailureDir(t, filepath.Join(root, ".ai", "config.yml"))
+
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "v2.0.0\n", nil
+	}
+
+	result := RepairAIConfigYML(root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when write blocked, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "repair failed") {
+		t.Errorf("expected 'repair failed' in message, got: %s", result.Message)
+	}
+}
+
+// ── RepairProjectStatus additional error paths ────────────────────────────────
+
+func TestRepairProjectStatus_FieldIDFetchFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeTestProjectTemplate(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil // resolve project node ID
+		}
+		return "", fmt.Errorf("graphql: server error") // field ID fetch fails
+	}
+
+	result := RepairProjectStatus("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to fetch Status field ID") {
+		t.Errorf("expected field ID error in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairProjectStatus_FieldIDEmpty_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeTestProjectTemplate(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil
+		}
+		return "null\n", nil // empty / null field ID
+	}
+
+	result := RepairProjectStatus("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail for null field ID, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "Status field not found") {
+		t.Errorf("expected 'Status field not found' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairProjectStatus_ResyncFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeTestProjectTemplate(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return projectListJSON, nil // resolve project
+		case 2:
+			return "FIELD_456\n", nil // field ID
+		case 3:
+			return `{"data":{}}`, nil // mutation OK
+		default:
+			return "", fmt.Errorf("resync: option fetch failed") // fetchStatusOptionMap fails
+		}
+	}
+
+	result := RepairProjectStatus("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when resync fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "item resync failed") {
+		t.Errorf("expected 'item resync failed' in message, got: %s", result.Message)
+	}
+}
+
+// ── ResyncProjectItemStatuses / RepairProjectItemStatuses ─────────────────────
+
+func TestResyncProjectItemStatuses_NoProject_ReturnsError(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("no project found")
+	}
+
+	_, _, err := ResyncProjectItemStatuses("owner", "my-repo", fakeRun)
+	if err == nil {
+		t.Fatal("expected error when project not found, got nil")
+	}
+	if !strings.Contains(err.Error(), "no GitHub Project found") {
+		t.Errorf("expected 'no GitHub Project found' in error, got: %v", err)
+	}
+}
+
+func TestResyncProjectItemStatuses_FieldFetchFails_ReturnsError(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil // project list
+		}
+		return "", fmt.Errorf("field query: server error")
+	}
+
+	_, _, err := ResyncProjectItemStatuses("owner", "my-repo", fakeRun)
+	if err == nil {
+		t.Fatal("expected error when field fetch fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetching Status field ID") {
+		t.Errorf("expected field ID error, got: %v", err)
+	}
+}
+
+func TestResyncProjectItemStatuses_FieldEmpty_ReturnsError(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil
+		}
+		return "null\n", nil // field ID is null/empty
+	}
+
+	_, _, err := ResyncProjectItemStatuses("owner", "my-repo", fakeRun)
+	if err == nil {
+		t.Fatal("expected error for null field ID, got nil")
+	}
+	if !strings.Contains(err.Error(), "status field not found") {
+		t.Errorf("expected 'status field not found', got: %v", err)
+	}
+}
+
+func TestRepairProjectItemStatuses_Fail_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("project lookup failed")
+	}
+
+	result := RepairProjectItemStatuses("owner", "my-repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "resync failed") {
+		t.Errorf("expected 'resync failed' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairProjectItemStatuses_Success_ReturnsPass(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return projectListJSON, nil // project list
+		case 2:
+			return "FIELD_456\n", nil // Status field ID
+		case 3:
+			return "OPT_1|Backlog\nOPT_2|Done", nil // fetchStatusOptionMap
+		case 4:
+			// fetchAllProjectItems — empty page, no items to resync.
+			return `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[]}}}}`, nil
+		}
+		return "", nil
+	}
+
+	result := RepairProjectItemStatuses("owner", "my-repo", fakeRun)
+	if result.Status != Pass {
+		t.Errorf("expected Pass, got %v: %s", result.Status, result.Message)
+	}
+}
+
+// ── RepairAIDir — git checkout failure path ───────────────────────────────────
+
+func TestRepairAIDir_GitCheckoutFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	// Create .ai/ so the repair takes the git-checkout path (not the sync path).
+	if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("git checkout: permission denied")
+	}
+	confirmFn := func(prompt string) (bool, error) { return true, nil }
+
+	result := RepairAIDir(root, fakeRun, confirmFn)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when git checkout fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "git checkout failed") {
+		t.Errorf("expected 'git checkout failed' in message, got: %s", result.Message)
+	}
+}
+
+// ── RepairAISkills — tarball failure path ─────────────────────────────────────
+
+func TestRepairAISkills_TarballFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeTemplateConfig(t, root, "owner/template", "v1.0.0")
+	confirmFn := func(prompt string) (bool, error) { return true, nil }
+
+	result := RepairAISkills(root, confirmFn, failingFetchFunc("tarball unavailable"))
+	if result.Status != Fail {
+		t.Errorf("expected Fail when tarball fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "tarball extraction failed") {
+		t.Errorf("expected 'tarball extraction failed' in message, got: %s", result.Message)
+	}
+}
+
+// ── closeStaleIssues / RepairStaleOpen* ──────────────────────────────────────
+
+const (
+	staleIssueListJSON    = `[{"number":42,"title":"Stale Requirement"}]`
+	allClosedSubIssuesJSON = `{"subIssues":[{"state":"CLOSED"},{"state":"CLOSED"}]}`
+)
+
+func TestRepairStaleOpenRequirements_FetchFails_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("gh: not authenticated")
+	}
+
+	result := RepairStaleOpenRequirements("owner/repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when fetch fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to fetch stale issues") {
+		t.Errorf("expected 'failed to fetch stale issues' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairStaleOpenRequirements_NoStale_ReturnsPass(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "[]", nil // empty issue list
+	}
+
+	result := RepairStaleOpenRequirements("owner/repo", fakeRun)
+	if result.Status != Pass {
+		t.Errorf("expected Pass when no stale issues, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "nothing to repair") {
+		t.Errorf("expected 'nothing to repair' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairStaleOpenRequirements_LabelFails_ReturnsFail(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return staleIssueListJSON, nil // issue list
+		case 2:
+			return allClosedSubIssuesJSON, nil // sub-issues (all closed → stale)
+		case 3:
+			return "", fmt.Errorf("label edit failed") // issue edit --add-label done
+		}
+		return "", nil
+	}
+
+	result := RepairStaleOpenRequirements("owner/repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when label edit fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "fixing labels") {
+		t.Errorf("expected 'fixing labels' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairStaleOpenRequirements_CloseFails_ReturnsFail(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return staleIssueListJSON, nil
+		case 2:
+			return allClosedSubIssuesJSON, nil
+		case 3:
+			return "", nil // label edit OK
+		case 4:
+			return "", fmt.Errorf("issue close: server error")
+		}
+		return "", nil
+	}
+
+	result := RepairStaleOpenRequirements("owner/repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when close fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "closing") {
+		t.Errorf("expected 'closing' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairStaleOpenRequirements_Success_ReturnsPass(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return staleIssueListJSON, nil
+		case 2:
+			return allClosedSubIssuesJSON, nil
+		case 3:
+			return "", nil // label edit
+		case 4:
+			return "", nil // issue close
+		}
+		return "", nil
+	}
+
+	result := RepairStaleOpenRequirements("owner/repo", fakeRun)
+	if result.Status != Pass {
+		t.Errorf("expected Pass, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "#42") {
+		t.Errorf("expected closed issue #42 in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairStaleOpenFeatures_FetchFails_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("api error")
+	}
+
+	result := RepairStaleOpenFeatures("owner/repo", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+}
+
+// ── layoutToREST ──────────────────────────────────────────────────────────────
+
+func TestLayoutToREST_KnownLayouts(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"BOARD_LAYOUT", "board"},
+		{"TABLE_LAYOUT", "table"},
+		{"ROADMAP_LAYOUT", "roadmap"},
+	}
+	for _, tc := range tests {
+		got := layoutToREST(tc.input)
+		if got != tc.expected {
+			t.Errorf("layoutToREST(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestLayoutToREST_DefaultFallback(t *testing.T) {
+	got := layoutToREST("CUSTOM_LAYOUT")
+	if got != "custom" {
+		t.Errorf("layoutToREST(\"CUSTOM_LAYOUT\") = %q, want \"custom\"", got)
+	}
+}
+
+// ── RepairProjectViews ────────────────────────────────────────────────────────
+
+// projectListJSONWithOwner includes owner.type, required by resolveProjectEntry.
+const projectListJSONWithOwner = `{"projects":[{"id":"PVT_123","title":"my-repo","number":1,"owner":{"login":"owner","type":"User"}}]}`
+
+// writeProjectTemplateWithViews writes base/project-template.json including requiredViews.
+func writeProjectTemplateWithViews(t *testing.T, root string) {
+	t.Helper()
+	baseDir := filepath.Join(root, "base")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{
+  "statusOptions": [{"name":"Backlog","color":"GRAY","description":""}],
+  "requiredViews": [
+    {"name":"Board","layout":"BOARD_LAYOUT","filter":""},
+    {"name":"Table","layout":"TABLE_LAYOUT","filter":"is:open"}
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(baseDir, "project-template.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRepairProjectViews_NoProject_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeProjectTemplateWithViews(t, root)
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("no project")
+	}
+
+	result := RepairProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "no GitHub Project found") {
+		t.Errorf("expected 'no GitHub Project found', got: %s", result.Message)
+	}
+}
+
+func TestRepairProjectViews_LoadTemplateFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir() // no project-template.json
+	fakeRun := func(name string, args ...string) (string, error) {
+		return projectListJSONWithOwner, nil
+	}
+
+	result := RepairProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "project template") {
+		t.Errorf("expected 'project template' in message, got: %s", result.Message)
+	}
+}
+
+func TestRepairProjectViews_FetchViewsFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeProjectTemplateWithViews(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSONWithOwner, nil // resolve project entry
+		}
+		return "", fmt.Errorf("graphql error") // fetch existing views
+	}
+
+	result := RepairProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to fetch views") {
+		t.Errorf("expected 'failed to fetch views', got: %s", result.Message)
+	}
+}
+
+func TestRepairProjectViews_AllPresent_ReturnsPass(t *testing.T) {
+	root := t.TempDir()
+	writeProjectTemplateWithViews(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSONWithOwner, nil
+		}
+		return "Board\nTable\n", nil // both required views present
+	}
+
+	result := RepairProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Pass {
+		t.Errorf("expected Pass when all views present, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "all required views present") {
+		t.Errorf("expected 'all required views present', got: %s", result.Message)
+	}
+}
+
+func TestRepairProjectViews_CreateFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeProjectTemplateWithViews(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSONWithOwner, nil
+		}
+		if callCount == 2 {
+			return "", nil // fetch views — none present
+		}
+		return "", fmt.Errorf("create view: insufficient permissions")
+	}
+
+	result := RepairProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when create fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to create view") {
+		t.Errorf("expected 'failed to create view', got: %s", result.Message)
+	}
+}
+
+func TestRepairProjectViews_CreatesNewViews_ReturnsPass(t *testing.T) {
+	root := t.TempDir()
+	writeProjectTemplateWithViews(t, root)
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSONWithOwner, nil
+		}
+		if callCount == 2 {
+			return "", nil // fetch views — none present
+		}
+		return `{"id":"view_1"}`, nil // create Board, then Table — both succeed
+	}
+
+	result := RepairProjectViews("owner", "my-repo", root, fakeRun)
+	if result.Status != Pass {
+		t.Errorf("expected Pass when views created, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "created views") {
+		t.Errorf("expected 'created views' in message, got: %s", result.Message)
+	}
+}

--- a/internal/verify/repair_gaps_test.go
+++ b/internal/verify/repair_gaps_test.go
@@ -1,0 +1,288 @@
+package verify
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── repairOrgMembership — null/empty user ID path (lines 716-719) ─────────────
+
+func TestRepairProjectCollaborator_Org_NullUserID_ReturnsFail(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return "", fmt.Errorf("HTTP 404") // not a member
+		}
+		return "null\n", nil // user ID is null → user not found
+	}
+
+	result := RepairProjectCollaborator("myorg", "repo", "bot-user", "Organization", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail for null user ID, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "not found on GitHub") {
+		t.Errorf("expected 'not found on GitHub', got: %s", result.Message)
+	}
+}
+
+// ── repairProjectCollaboratorUser — no project (lines 757-760) ────────────────
+
+func TestRepairProjectCollaborator_User_NoProject_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("no project found")
+	}
+
+	result := RepairProjectCollaborator("owner", "repo", "bot-user", "User", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when no project, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "no GitHub Project found") {
+		t.Errorf("expected 'no GitHub Project found', got: %s", result.Message)
+	}
+}
+
+// ── repairProjectCollaboratorUser — null user ID (lines 777-780) ──────────────
+
+func TestRepairProjectCollaborator_User_NullUserID_ReturnsFail(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil // project found
+		}
+		return "null\n", nil // user node ID is null
+	}
+
+	result := RepairProjectCollaborator("owner", "repo", "bot-user", "User", fakeRun)
+	if result.Status != Fail {
+		t.Errorf("expected Fail for null user ID, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "not found on GitHub") {
+		t.Errorf("expected 'not found on GitHub', got: %s", result.Message)
+	}
+}
+
+// ── RepairAIDirWithWriter — confirm declined / error (lines 820-825) ──────────
+
+func TestRepairAIDir_ConfirmDeclined_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	fakeRun := func(name string, args ...string) (string, error) { return "", nil }
+
+	result := RepairAIDir(root, fakeRun, func(string) (bool, error) { return false, nil })
+	if result.Status != Fail {
+		t.Errorf("expected Fail when user declines, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "user declined re-sync") {
+		t.Errorf("expected 'user declined re-sync', got: %s", result.Message)
+	}
+}
+
+func TestRepairAIDir_ConfirmError_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	fakeRun := func(name string, args ...string) (string, error) { return "", nil }
+
+	result := RepairAIDir(root, fakeRun, func(string) (bool, error) {
+		return false, fmt.Errorf("TTY error")
+	})
+	if result.Status != Fail {
+		t.Errorf("expected Fail when confirm errors, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "user declined re-sync") {
+		t.Errorf("expected 'user declined re-sync', got: %s", result.Message)
+	}
+}
+
+// ── RepairWorkflows — MkdirAll fails (lines 937-940) ─────────────────────────
+
+func TestRepairWorkflows_MkdirAllFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	// Block .github/ creation by placing a regular file at that path.
+	if err := os.WriteFile(filepath.Join(root, ".github"), []byte("blocker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fakeRun := func(name string, args ...string) (string, error) { return "", nil }
+
+	result := RepairWorkflows(root, "User", fakeRun, failingFetchFunc("should not reach"))
+	if result.Status != Fail {
+		t.Errorf("expected Fail when MkdirAll blocked, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "could not create directory") {
+		t.Errorf("expected 'could not create directory', got: %s", result.Message)
+	}
+}
+
+// ── RepairWorkflows — .ai dir present, WriteFile fails (lines 974-977) ────────
+
+func TestRepairWorkflows_AIDir_WriteFileFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	// Create .ai/.github/workflows/ with a source file.
+	aiWorkflowsDir := filepath.Join(root, ".ai", ".github", "workflows")
+	if err := os.MkdirAll(aiWorkflowsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(aiWorkflowsDir, "build-and-test.yml"), []byte("# test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Create destination dir, then block the destination file write.
+	destDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFailureDir(t, filepath.Join(destDir, "build-and-test.yml"))
+
+	fakeRun := func(name string, args ...string) (string, error) { return "", nil }
+
+	result := RepairWorkflows(root, "User", fakeRun, failingFetchFunc("should not reach"))
+	if result.Status != Fail {
+		t.Errorf("expected Fail when WriteFile blocked, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "writing") {
+		t.Errorf("expected 'writing' in message, got: %s", result.Message)
+	}
+}
+
+// ── RepairWorkflows — .ai dir present, git add fails (lines 986-989) ─────────
+
+func TestRepairWorkflows_AIDir_GitAddFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	aiWorkflowsDir := filepath.Join(root, ".ai", ".github", "workflows")
+	if err := os.MkdirAll(aiWorkflowsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(aiWorkflowsDir, "build-and-test.yml"), []byte("# test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".github", "workflows"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("git add: not a git repository")
+	}
+
+	result := RepairWorkflows(root, "User", fakeRun, failingFetchFunc("should not reach"))
+	if result.Status != Fail {
+		t.Errorf("expected Fail when git add fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "git add failed") {
+		t.Errorf("expected 'git add failed', got: %s", result.Message)
+	}
+}
+
+// ── RepairWorkflows fallback — tarball fails (lines 1022-1025) ────────────────
+
+func TestRepairWorkflows_Fallback_TarballExtractFails_ReturnsFail(t *testing.T) {
+	root := t.TempDir()
+	writeTemplateConfig(t, root, "owner/template", "v1.0.0")
+	fakeRun := func(name string, args ...string) (string, error) { return "", nil }
+
+	result := RepairWorkflows(root, "User", fakeRun, failingFetchFunc("tarball unavailable"))
+	if result.Status != Fail {
+		t.Errorf("expected Fail when tarball fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "tarball extraction failed") {
+		t.Errorf("expected 'tarball extraction failed', got: %s", result.Message)
+	}
+}
+
+// ── RepairAgentUserVar — prompt and org-scope error paths ────────────────────
+// (lines 1293, 1305, 1320-1321, 1327-1328, 1331-1332)
+
+func TestRepairAgentUserVar_PromptUserFails_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) { return "", nil }
+
+	result := RepairAgentUserVar("owner", "repo", "", "repo", fakeRun,
+		func(string) (string, error) { return "", fmt.Errorf("TTY unavailable") })
+	if result.Status != Fail {
+		t.Errorf("expected Fail when user prompt errors, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "prompt failed") {
+		t.Errorf("expected 'prompt failed', got: %s", result.Message)
+	}
+}
+
+func TestRepairAgentUserVar_PromptScopeFails_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) { return "", nil }
+
+	result := RepairAgentUserVar("owner", "repo", "bot-user", "", fakeRun,
+		func(string) (string, error) { return "", fmt.Errorf("TTY unavailable") })
+	if result.Status != Fail {
+		t.Errorf("expected Fail when scope prompt errors, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "prompt failed") {
+		t.Errorf("expected 'prompt failed', got: %s", result.Message)
+	}
+}
+
+func TestRepairAgentUserVar_OrgScope_OwnerAPIFails_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "", fmt.Errorf("api: unauthorized")
+	}
+
+	result := RepairAgentUserVar("owner", "repo", "bot-user", "org", fakeRun, nil)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when owner API fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to detect owner type") {
+		t.Errorf("expected 'failed to detect owner type', got: %s", result.Message)
+	}
+}
+
+func TestRepairAgentUserVar_OrgScope_JSONParseFails_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return "not-valid-json", nil
+	}
+
+	result := RepairAgentUserVar("owner", "repo", "bot-user", "org", fakeRun, nil)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when JSON parse fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "failed to parse owner type") {
+		t.Errorf("expected 'failed to parse owner type', got: %s", result.Message)
+	}
+}
+
+func TestRepairAgentUserVar_OrgScope_OwnerIsUser_ReturnsFail(t *testing.T) {
+	fakeRun := func(name string, args ...string) (string, error) {
+		return `{"type":"User"}`, nil
+	}
+
+	result := RepairAgentUserVar("owner", "repo", "bot-user", "org", fakeRun, nil)
+	if result.Status != Fail {
+		t.Errorf("expected Fail when owner is not an org, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "personal account") {
+		t.Errorf("expected 'personal account', got: %s", result.Message)
+	}
+}
+
+// ── resyncProjectItemStatuses — fetchAllProjectItems fails (line 449) ─────────
+
+func TestResyncProjectItemStatuses_FetchAllItemsFails_ReturnsError(t *testing.T) {
+	callCount := 0
+	fakeRun := func(name string, args ...string) (string, error) {
+		callCount++
+		if callCount == 1 {
+			return projectListJSON, nil // project list for ResyncProjectItemStatuses
+		}
+		if callCount == 2 {
+			return "FIELD_456\n", nil // Status field ID
+		}
+		if callCount == 3 {
+			return "OPT_1|Backlog\n", nil // fetchStatusOptionMap succeeds
+		}
+		return "", fmt.Errorf("items: server error") // fetchAllProjectItems fails
+	}
+
+	_, _, err := ResyncProjectItemStatuses("owner", "repo", fakeRun)
+	if err == nil {
+		t.Fatal("expected error when fetchAllProjectItems fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetching project items") {
+		t.Errorf("expected 'fetching project items' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add 59 tests covering previously uncovered error paths in `internal/verify/repair.go` and `internal/verify/checks.go`
- Covers: file write failures (directory-at-path), `RunCommandFunc` error injection, stale issue detection and repair, `RepairProjectViews`, `CheckProjectViews`, `CheckStaleOpenRequirements`, `CheckStaleOpenFeatures`, `checkRepoVariable`/`checkRepoSecret` org-level error paths, and `layoutToREST` switch cases
- No production code changed — tests only
- Addresses SonarCloud `new_coverage` quality gate failure caused by uncovered error paths in recently-touched files

## Test plan

- [x] All 59 new tests pass locally
- [x] Full test suite passes (`go test ./...`)
- [ ] SonarCloud `new_coverage` gate passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)