### PR TITLE
fix: strip all lifecycle labels when closing feature/requirement issues

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -530,6 +530,9 @@ jobs:
           fi
           gh issue edit ${ISSUE} \
             --repo ${{ github.repository }} \
+            --remove-label "backlog" \
+            --remove-label "in-design" \
+            --remove-label "in-development" \
             --remove-label "in-review" \
             --add-label "done"
 
@@ -680,7 +683,9 @@ jobs:
           echo "All sub-issues closed — closing requirement ${AGENTIC_REPO}#${PARENT}"
           gh issue edit ${PARENT} \
             --repo ${AGENTIC_REPO} \
+            --remove-label "backlog" \
             --remove-label "scoping" \
+            --remove-label "scheduled" \
             --add-label "done"
 
           # Inline project status update — set requirement to "Done"


### PR DESCRIPTION
## Summary

- The feature-complete workflow's two close paths only removed one specific prior label (`in-review` for features, `scoping` for requirements) before adding `done`. Issues closed from any other state kept their prior label alongside `done`.
- Fix: remove every possible lifecycle label in each close path. `gh issue edit --remove-label` is a no-op when the label is absent, so stacking them is safe regardless of the actual current state.

## Observed symptom

After #462 merged:
- [#459](https://github.com/eddiecarpenter/gh-agentic/issues/459) kept `scheduled` + `done` (scoping was completed inline, so the issue went `scoping` → `scheduled` → `done` and never had `scoping` at close).
- [#461](https://github.com/eddiecarpenter/gh-agentic/issues/461) kept `backlog` + `done` (foreground feature — never triggered `in-design` / `in-development` / `in-review`).

Both cleaned by hand. This PR prevents the same drift in future.

## Change

Two `gh issue edit` blocks in `.github/workflows/agentic-pipeline.yml`:

- **Feature close (`backlog`, `in-design`, `in-development`, `in-review`)** — covers all lifecycle states a feature can reach.
- **Requirement close (`backlog`, `scoping`, `scheduled`)** — covers all lifecycle states a requirement can reach.

Five-line diff. No behaviour change other than the intended cleanup.

## Test plan

- [ ] After merge, the next feature that closes via the automated pipeline should end with `feature` + `done` only (no stray lifecycle label), regardless of which state it was in at close.
- [ ] Same for the next requirement closed by the feature-complete cascade.
- [ ] Visual check of the workflow file diff — both `gh issue edit` blocks have the full set of `--remove-label` flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)