### PR TITLE
fix: auth commands incorrectly blocked on single-topology repos

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -33,15 +33,20 @@ func newAuthCmd() *cobra.Command {
 	})
 }
 
-// controlPlaneAuthError prints the control plane block message and returns ErrSilent.
+// controlPlaneAuthError prints the federated-CP block message and returns ErrSilent.
 func controlPlaneAuthError(w interface{ Write([]byte) (int, error) }) error {
-	fmt.Fprintf(w, "  %s  This repo is the control plane — auth commands are for domain repos only.\n", ui.StatusWarning.Render("⚠"))
-	fmt.Fprintf(w, "       The control plane does not run Claude agents and does not need credentials.\n")
+	fmt.Fprintf(w, "  %s  This repo is the federated control plane — auth commands are for repos that run Claude agents.\n", ui.StatusWarning.Render("⚠"))
+	fmt.Fprintf(w, "       A federated control plane does not run Claude agents and does not need credentials.\n")
 	return ErrSilent
 }
 
-// isControlPlane returns true if the current repo is a Single-topology control plane.
-func isControlPlane() bool {
+// isFederatedControlPlane returns true only if this repo is the control plane
+// of a federated setup — the one case where auth commands should be blocked
+// because the repo does not itself run Claude agents.
+//
+// Single-topology repos are also "control planes" structurally, but they do run
+// agents (the repo is CP + code combined), so they should not be blocked.
+func isFederatedControlPlane() bool {
 	deps, err := resolveProjectDeps()
 	if err != nil {
 		return false
@@ -50,10 +55,16 @@ func isControlPlane() bool {
 	if err != nil || projectID == "" {
 		return false
 	}
+	topoVal, _ := deps.GetRepoVariable(deps.Owner, deps.RepoName, project.TopologyVarName)
+	if topoVal != "federated" {
+		return false
+	}
 	linked, err := deps.FetchLinkedRepos(projectID)
 	if err != nil {
 		return false
 	}
+	// In a federated setup, the control plane is the repo that appears in the
+	// project's linked repos (DetectTopology returns TopologySingle for it).
 	return project.DetectTopology(deps.RepoFullName, linked) == project.TopologySingle
 }
 
@@ -119,7 +130,7 @@ without re-logging in, use 'auth refresh' instead.`,
 		Example: `  gh agentic auth login`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
-			if isControlPlane() {
+			if isFederatedControlPlane() {
 				return controlPlaneAuthError(w)
 			}
 			authDeps, err := resolveAuthDeps(deps)
@@ -145,7 +156,7 @@ if your local credentials are missing or expired.`,
 		Example: `  gh agentic auth refresh`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
-			if isControlPlane() {
+			if isFederatedControlPlane() {
 				return controlPlaneAuthError(w)
 			}
 			authDeps, err := resolveAuthDeps(deps)
@@ -172,7 +183,7 @@ CLAUDE_CREDENTIALS_JSON repo secret is set, then report whether they are in sync
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 
-			if isControlPlane() {
+			if isFederatedControlPlane() {
 				return controlPlaneAuthError(w)
 			}
 


### PR DESCRIPTION
## Summary

\`gh agentic auth login/refresh/check\` were wrongly blocked on single-topology repos with:

\`\`\`
⚠  This repo is the control plane — auth commands are for domain repos only.
\`\`\`

Single repos are their own control plane AND their own code repo — they run Claude agents and need credentials.

## Root cause

\`isControlPlane()\` used \`DetectTopology()\`, which returns \`TopologySingle\` for BOTH a real single-topology repo AND a federated control plane. The function couldn't tell them apart.

## Fix

Renamed to \`isFederatedControlPlane()\` and added an explicit \`AGENTIC_TOPOLOGY == "federated"\` gate before the linked-repo check. Now only federated CPs are blocked — the only case where the repo genuinely doesn't run agents.

Error message updated to "federated control plane" for clarity.

## Test plan

- [x] \`gh agentic auth refresh\` works on \`gh-agentic\` (single topology) — confirmed locally
- [ ] \`gh agentic auth refresh\` still blocked on a federated control plane repo
- [ ] \`gh agentic auth refresh\` works on a federated domain repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)