### PR TITLE
fix: mount .cp/ for federated domain repos

### DIFF
--- a/internal/cli/mount.go
+++ b/internal/cli/mount.go
@@ -19,6 +19,8 @@ type mountDeps struct {
 	clone          mount.CloneFunc
 	confirm        mount.ConfirmFunc
 	resolveVersion func(root string) (string, error)
+	resolveCP      func(root string) string
+	syncCP         mount.CPSyncFunc
 }
 
 // newMountCmd constructs the `gh agentic mount` subcommand with production deps.
@@ -30,6 +32,8 @@ func newMountCmd() *cobra.Command {
 		resolveVersion: func(root string) (string, error) {
 			return resolveMountVersion(root)
 		},
+		resolveCP: resolveFederatedCP,
+		syncCP:    mount.DefaultCPSync,
 	})
 }
 
@@ -45,6 +49,9 @@ func newMountCmdWithDeps(deps mountDeps) *cobra.Command {
 For single topology repos, mounts at the version recorded in .ai-version.
 For federated domain repos, reads AGENTIC_FRAMEWORK_VERSION from the control
 plane and mounts that version — keeping all domain repos in sync automatically.
+Federated domain repos additionally get a read-only .cp/ mount — a sparse
+checkout of the control plane repo's docs/ tracking main — providing
+system-level knowledge.
 
 Use 'project switch version <version>' on the control plane repo to upgrade
 the framework version for the whole federation.
@@ -90,19 +97,33 @@ Use --yes to skip the confirmation prompt when switching versions (for scripts).
 			}
 
 			if aiVersionErr != nil {
-				// No .ai-version — first-time mount.
-				return mount.RunFirstTime(w, root, version, deps.clone)
+				if err := mount.RunFirstTime(w, root, version, deps.clone); err != nil {
+					return err
+				}
+			} else if currentVersion == version {
+				if err := mount.RunRemount(w, root, version, deps.clone); err != nil {
+					return err
+				}
+			} else {
+				confirm := deps.confirm
+				if yes {
+					confirm = nil
+				}
+				if err := mount.RunSwitch(w, root, currentVersion, version, deps.clone, confirm); err != nil {
+					return err
+				}
 			}
 
-			if currentVersion == version {
-				return mount.RunRemount(w, root, version, deps.clone)
+			// Federated domain repos also need the control plane knowledge mount.
+			if deps.resolveCP != nil {
+				if cpNameWithOwner := deps.resolveCP(root); cpNameWithOwner != "" {
+					if err := mount.MountControlPlane(w, root, cpNameWithOwner, deps.syncCP); err != nil {
+						return err
+					}
+				}
 			}
 
-			confirm := deps.confirm
-			if yes {
-				confirm = nil
-			}
-			return mount.RunSwitch(w, root, currentVersion, version, deps.clone, confirm)
+			return nil
 		},
 	}
 
@@ -115,38 +136,12 @@ Use --yes to skip the confirmation prompt when switching versions (for scripts).
 // For federated domain repos: reads AGENTIC_FRAMEWORK_VERSION from the control plane.
 // For all other cases: falls back to the local .ai-version.
 func resolveMountVersion(root string) (string, error) {
-	// Try to detect topology from repo context.
-	currentRepo, err := repository.Current()
-	if err != nil {
-		// Not in a GitHub repo — fall back to local .ai-version.
-		return localVersionFallback(root)
-	}
-
-	// Check if this repo is a federated domain repo.
-	topology, _ := project.DefaultGetRepoVariable(currentRepo.Owner, currentRepo.Name, project.TopologyVarName)
-	if topology != "federated" {
-		// Single topology or control plane — use local .ai-version.
-		return localVersionFallback(root)
-	}
-
-	// Federated domain repo — find the control plane and read its version.
-	projectID, err := project.DefaultGetRepoVariable(currentRepo.Owner, currentRepo.Name, project.ProjectVarName)
-	if err != nil || projectID == "" {
-		return localVersionFallback(root)
-	}
-
-	linked, err := project.DefaultFetchLinkedRepos(projectID)
-	if err != nil {
-		return localVersionFallback(root)
-	}
-
-	cp, ok := project.ControlPlaneRepo(linked)
+	cp, ok := detectFederatedCP()
 	if !ok {
 		return localVersionFallback(root)
 	}
 
-	// Parse "owner/repo" from NameWithOwner.
-	parts := strings.SplitN(cp.NameWithOwner, "/", 2)
+	parts := strings.SplitN(cp, "/", 2)
 	if len(parts) != 2 {
 		return localVersionFallback(root)
 	}
@@ -157,6 +152,52 @@ func resolveMountVersion(root string) (string, error) {
 	}
 
 	return cpVersion, nil
+}
+
+// resolveFederatedCP returns the control plane repo (owner/name) for a
+// federated domain repo, or "" for any other topology or on any lookup
+// failure. Callers treat empty as "no .cp/ mount needed".
+func resolveFederatedCP(root string) string {
+	cp, _ := detectFederatedCP()
+	return cp
+}
+
+// detectFederatedCP returns the control plane repo's NameWithOwner when the
+// current working directory is a federated domain repo. Returns ("", false)
+// for single topology, control plane itself, or any lookup failure.
+func detectFederatedCP() (string, bool) {
+	currentRepo, err := repository.Current()
+	if err != nil {
+		return "", false
+	}
+
+	topology, _ := project.DefaultGetRepoVariable(currentRepo.Owner, currentRepo.Name, project.TopologyVarName)
+	if topology != "federated" {
+		return "", false
+	}
+
+	projectID, err := project.DefaultGetRepoVariable(currentRepo.Owner, currentRepo.Name, project.ProjectVarName)
+	if err != nil || projectID == "" {
+		return "", false
+	}
+
+	linked, err := project.DefaultFetchLinkedRepos(projectID)
+	if err != nil {
+		return "", false
+	}
+
+	cp, ok := project.ControlPlaneRepo(linked)
+	if !ok {
+		return "", false
+	}
+
+	// On the control plane repo itself, don't self-mount.
+	currentNameWithOwner := currentRepo.Owner + "/" + currentRepo.Name
+	if strings.EqualFold(cp.NameWithOwner, currentNameWithOwner) {
+		return "", false
+	}
+
+	return cp.NameWithOwner, true
 }
 
 func localVersionFallback(root string) (string, error) {

--- a/internal/cli/mount_test.go
+++ b/internal/cli/mount_test.go
@@ -154,6 +154,113 @@ func TestMountCmd_InvalidTag(t *testing.T) {
 	}
 }
 
+func TestMountCmd_FederatedMountsControlPlane(t *testing.T) {
+	root := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(root)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	var cpCalls []string
+	syncCP := func(cpNameWithOwner, destDir string) error {
+		cpCalls = append(cpCalls, cpNameWithOwner)
+		if err := os.MkdirAll(destDir, 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(destDir, "marker"), []byte(cpNameWithOwner), 0o644)
+	}
+
+	deps := mountDeps{
+		fetchReleases: mountFakeReleases(),
+		clone:         mountFakeClone(),
+		resolveVersion: func(root string) (string, error) {
+			return "v2.0.0", nil
+		},
+		resolveCP: func(root string) string { return "org/control-plane" },
+		syncCP:    syncCP,
+	}
+
+	cmd := newMountCmdWithDeps(deps)
+	rootCmd := newRootCmd("dev", "")
+	for _, c := range rootCmd.Commands() {
+		if strings.HasPrefix(c.Use, "mount") {
+			rootCmd.RemoveCommand(c)
+			break
+		}
+	}
+	rootCmd.AddCommand(cmd)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"mount"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	if len(cpCalls) != 1 || cpCalls[0] != "org/control-plane" {
+		t.Errorf("expected one CP sync call for org/control-plane, got %v", cpCalls)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, ".cp", "marker")); os.IsNotExist(err) {
+		t.Error(".cp/marker should exist after federated mount")
+	}
+
+	gitignore, _ := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if !strings.Contains(string(gitignore), ".cp/") {
+		t.Errorf(".gitignore should contain .cp/ entry, got: %s", gitignore)
+	}
+}
+
+func TestMountCmd_NonFederatedSkipsControlPlane(t *testing.T) {
+	root := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(root)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	var cpCalls int
+	syncCP := func(cpNameWithOwner, destDir string) error {
+		cpCalls++
+		return nil
+	}
+
+	deps := mountDeps{
+		fetchReleases: mountFakeReleases(),
+		clone:         mountFakeClone(),
+		resolveVersion: func(root string) (string, error) {
+			return "v2.0.0", nil
+		},
+		resolveCP: func(root string) string { return "" },
+		syncCP:    syncCP,
+	}
+
+	cmd := newMountCmdWithDeps(deps)
+	rootCmd := newRootCmd("dev", "")
+	for _, c := range rootCmd.Commands() {
+		if strings.HasPrefix(c.Use, "mount") {
+			rootCmd.RemoveCommand(c)
+			break
+		}
+	}
+	rootCmd.AddCommand(cmd)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"mount"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v\nOutput:\n%s", err, buf.String())
+	}
+
+	if cpCalls != 0 {
+		t.Errorf("expected no CP sync calls for non-federated repo, got %d", cpCalls)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".cp")); !os.IsNotExist(err) {
+		t.Error(".cp/ should not be created for non-federated repos")
+	}
+}
+
 func TestMountCmd_NoVersionNoAIVersion(t *testing.T) {
 	root := t.TempDir()
 

--- a/internal/mount/controlplane.go
+++ b/internal/mount/controlplane.go
@@ -1,0 +1,118 @@
+package mount
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// CPMountDir is the directory under the repo root where the control plane
+// knowledge is mounted.
+const CPMountDir = ".cp"
+
+// CPBranch is the branch tracked by the .cp/ mount. Knowledge updates on the
+// control plane propagate to every domain repo as soon as they merge to main,
+// so the mount always tracks main rather than a pinned version.
+const CPBranch = "main"
+
+// CPSparsePath is the directory inside the control plane repo whose contents
+// populate the .cp/ mount.
+const CPSparsePath = "docs"
+
+// CPSyncFunc syncs the control plane knowledge mount at destDir from the
+// repo identified by cpNameWithOwner (owner/repo). When destDir does not
+// exist it performs the initial sparse clone; otherwise it refreshes in place.
+type CPSyncFunc func(cpNameWithOwner, destDir string) error
+
+// DefaultCPSync is the production CPSyncFunc. It clones docs/ from the CP
+// repo via a filtered sparse checkout on first run, and fast-forwards main
+// on subsequent runs.
+func DefaultCPSync(cpNameWithOwner, destDir string) error {
+	if cpNameWithOwner == "" {
+		return fmt.Errorf("control plane repo is empty")
+	}
+
+	if _, err := os.Stat(destDir); os.IsNotExist(err) {
+		return sparseCloneCP(cpNameWithOwner, destDir)
+	} else if err != nil {
+		return fmt.Errorf("stat %s: %w", destDir, err)
+	}
+
+	return pullCP(destDir)
+}
+
+// sparseCloneCP creates a new sparse checkout of docs/ at destDir.
+func sparseCloneCP(cpNameWithOwner, destDir string) error {
+	url := "https://github.com/" + cpNameWithOwner + ".git"
+	cmd := exec.Command("git", "clone",
+		"--depth", "1",
+		"--branch", CPBranch,
+		"--filter=blob:none",
+		"--sparse",
+		url, destDir,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git clone failed: %w\n%s", err, strings.TrimSpace(string(out)))
+	}
+
+	if err := runGit(destDir, "sparse-checkout", "set", CPSparsePath); err != nil {
+		return fmt.Errorf("git sparse-checkout set %s: %w", CPSparsePath, err)
+	}
+	return nil
+}
+
+// pullCP refreshes an existing .cp/ checkout by fast-forwarding main.
+func pullCP(destDir string) error {
+	return runGit(destDir, "pull", "--ff-only", "origin", CPBranch)
+}
+
+func runGit(dir string, args ...string) error {
+	full := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", full...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git %s failed: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// MountControlPlane establishes or refreshes the .cp/ mount for a federated
+// domain repo. Network failures are reported as warnings and do not fail the
+// enclosing mount — sessions remain usable offline with slightly-stale CP
+// knowledge.
+func MountControlPlane(w io.Writer, root, cpNameWithOwner string, sync CPSyncFunc) error {
+	if sync == nil {
+		sync = DefaultCPSync
+	}
+
+	destDir := filepath.Join(root, CPMountDir)
+	existed := true
+	if _, err := os.Stat(destDir); os.IsNotExist(err) {
+		existed = false
+	}
+
+	if existed {
+		fmt.Fprintf(w, "  Refreshing control plane knowledge (%s) at .cp/\n", cpNameWithOwner)
+	} else {
+		fmt.Fprintf(w, "  Mounting control plane knowledge (%s) at .cp/\n", cpNameWithOwner)
+	}
+
+	if err := sync(cpNameWithOwner, destDir); err != nil {
+		fmt.Fprintf(w, "  ⚠  .cp/ sync failed — proceeding with existing state: %v\n", err)
+		return nil
+	}
+
+	if err := EnsureCPGitignore(root); err != nil {
+		return fmt.Errorf("updating .gitignore: %w", err)
+	}
+
+	fmt.Fprintln(w, "  ✓ Control plane knowledge mounted at .cp/")
+	return nil
+}
+
+// EnsureCPGitignore ensures that ".cp/" is listed in .gitignore at root.
+func EnsureCPGitignore(root string) error {
+	return ensureGitignoreEntry(root, ".cp/")
+}

--- a/internal/mount/controlplane_test.go
+++ b/internal/mount/controlplane_test.go
@@ -1,0 +1,151 @@
+package mount
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeCPSync writes a marker file at destDir on first call and records calls.
+func fakeCPSync(t *testing.T, calls *[]string) CPSyncFunc {
+	t.Helper()
+	return func(cpNameWithOwner, destDir string) error {
+		*calls = append(*calls, cpNameWithOwner+" -> "+destDir)
+		if err := os.MkdirAll(destDir, 0o755); err != nil {
+			return err
+		}
+		marker := filepath.Join(destDir, "marker")
+		return os.WriteFile(marker, []byte(cpNameWithOwner), 0o644)
+	}
+}
+
+func TestMountControlPlane_FirstTime(t *testing.T) {
+	root := t.TempDir()
+	var buf bytes.Buffer
+	var calls []string
+
+	err := MountControlPlane(&buf, root, "org/cp-repo", fakeCPSync(t, &calls))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 sync call, got %d", len(calls))
+	}
+	if !strings.Contains(calls[0], "org/cp-repo") {
+		t.Errorf("sync call missing repo name: %s", calls[0])
+	}
+
+	if _, err := os.Stat(filepath.Join(root, ".cp", "marker")); err != nil {
+		t.Errorf(".cp/marker should exist: %v", err)
+	}
+
+	gitignore, _ := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if !strings.Contains(string(gitignore), ".cp/") {
+		t.Errorf(".gitignore should contain .cp/, got: %s", gitignore)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Mounting control plane knowledge") {
+		t.Errorf("output should mention mounting, got: %s", out)
+	}
+}
+
+func TestMountControlPlane_Refresh(t *testing.T) {
+	root := t.TempDir()
+	// Pre-create .cp/ to simulate an existing mount.
+	if err := os.MkdirAll(filepath.Join(root, ".cp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var calls []string
+
+	if err := MountControlPlane(&buf, root, "org/cp-repo", fakeCPSync(t, &calls)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Refreshing control plane knowledge") {
+		t.Errorf("output should mention refreshing for existing .cp/, got: %s", out)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 sync call, got %d", len(calls))
+	}
+}
+
+func TestMountControlPlane_SyncFailureIsNonFatal(t *testing.T) {
+	root := t.TempDir()
+	var buf bytes.Buffer
+
+	failing := func(cpNameWithOwner, destDir string) error {
+		return fmt.Errorf("network unreachable")
+	}
+
+	if err := MountControlPlane(&buf, root, "org/cp-repo", failing); err != nil {
+		t.Fatalf("sync failure should be non-fatal, got error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "⚠") || !strings.Contains(out, "network unreachable") {
+		t.Errorf("output should warn about sync failure, got: %s", out)
+	}
+}
+
+func TestEnsureCPGitignore_AddsEntry(t *testing.T) {
+	root := t.TempDir()
+
+	if err := EnsureCPGitignore(root); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if !strings.Contains(string(data), ".cp/") {
+		t.Errorf(".gitignore should contain .cp/, got: %s", data)
+	}
+}
+
+func TestEnsureCPGitignore_Idempotent(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".gitignore")
+
+	if err := os.WriteFile(path, []byte(".ai/\n.cp/\nother\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureCPGitignore(root); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	if count := strings.Count(string(data), ".cp/"); count != 1 {
+		t.Errorf("expected exactly one .cp/ entry, got %d: %s", count, data)
+	}
+}
+
+func TestEnsureCPGitignore_CoexistsWithAIEntry(t *testing.T) {
+	root := t.TempDir()
+
+	if err := EnsureGitignore(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureCPGitignore(root); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, ".gitignore"))
+	s := string(data)
+	if !strings.Contains(s, ".ai/") || !strings.Contains(s, ".cp/") {
+		t.Errorf(".gitignore should contain both entries, got: %s", s)
+	}
+}
+
+func TestDefaultCPSync_EmptyRepoErrors(t *testing.T) {
+	if err := DefaultCPSync("", t.TempDir()); err == nil {
+		t.Fatal("expected error for empty cpNameWithOwner")
+	}
+}

--- a/internal/mount/mount.go
+++ b/internal/mount/mount.go
@@ -96,6 +96,12 @@ func WriteAIVersion(root, version string) error {
 
 // EnsureGitignore ensures that ".ai/" is listed in .gitignore at root.
 func EnsureGitignore(root string) error {
+	return ensureGitignoreEntry(root, ".ai/")
+}
+
+// ensureGitignoreEntry appends entry to .gitignore if it is not already
+// present. The entry is matched line-for-line after trimming whitespace.
+func ensureGitignoreEntry(root, entry string) error {
 	gitignorePath := filepath.Join(root, ".gitignore")
 
 	var content string
@@ -105,17 +111,17 @@ func EnsureGitignore(root string) error {
 	}
 
 	for _, line := range strings.Split(content, "\n") {
-		if strings.TrimSpace(line) == ".ai/" {
+		if strings.TrimSpace(line) == entry {
 			return nil
 		}
 	}
 
-	entry := ".ai/\n"
+	toAppend := entry + "\n"
 	if content != "" && !strings.HasSuffix(content, "\n") {
-		entry = "\n" + entry
+		toAppend = "\n" + toAppend
 	}
 
-	return os.WriteFile(gitignorePath, []byte(content+entry), 0o644)
+	return os.WriteFile(gitignorePath, []byte(content+toAppend), 0o644)
 }
 
 // versionTagPattern matches @vX.Y.Z version tags in uses: lines for


### PR DESCRIPTION
## Summary
- `gh agentic mount` now also establishes (or refreshes) a read-only `.cp/` mount for federated domain repos — sparse checkout of the control plane repo's `docs/` tracking `main`
- Closes the gap between [concepts/knowledge-plane.md](concepts/knowledge-plane.md) (which documents `.cp/` as expected) and the actual mount behaviour, which only handled `.ai/`
- Network failures during `.cp/` sync are non-fatal — a warning is printed and the existing state is left in place so sessions remain usable offline

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] New unit tests cover: first-time CP mount, refresh on existing `.cp/`, non-fatal sync failure, `.gitignore` idempotency, federated CLI path mounts `.cp/`, non-federated CLI path skips `.cp/`
- [ ] Manual verification on a real federated domain repo (run `gh agentic mount` and confirm `.cp/docs/` is populated and `.gitignore` contains `.cp/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)