### PR TITLE
feat: extend 'gh agentic repair' to handle pipeline-side issues

### DIFF
--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
+	"github.com/eddiecarpenter/gh-agentic/internal/auth"
+	"github.com/eddiecarpenter/gh-agentic/internal/doctorv2"
 	"github.com/eddiecarpenter/gh-agentic/internal/project"
 	"github.com/eddiecarpenter/gh-agentic/internal/ui"
 )
@@ -20,9 +23,11 @@ func newRepairCmd() *cobra.Command {
 		Long: `Run all health checks and automatically fix what can be fixed.
 
 Auto-repairs:
-  - Framework not mounted      → mounts the latest version
-  - Missing project board views → recreates views from the template
-  - Topology misconfigured      → sets or corrects topology and framework version
+  - Framework not mounted        → mounts the latest version
+  - Missing project board views  → recreates views from the template
+  - Topology misconfigured       → sets or corrects topology and framework version
+  - .ai/ missing from .gitignore → appends the entry
+  - Workflow version tag drift   → rewrites @vX.Y.Z to match the mounted framework
 
 When topology cannot be determined automatically you will be prompted, or use
 --topology to skip the prompt:
@@ -30,8 +35,8 @@ When topology cannot be determined automatically you will be prompted, or use
   --topology single     standalone repo (control plane and code in one)
   --topology federated  this repo is the control plane for domain repos
 
-Pipeline-side issues (missing secrets, runtime variables, workflow drift) are
-reported with manual remediation steps — they are not auto-repairable.`,
+Variables and secrets cannot be auto-repaired (they need human-supplied values).
+Those failures are surfaced with the exact 'gh' command to run.`,
 		Example: `  gh agentic repair
   gh agentic repair --topology federated`,
 		SilenceUsage: true,
@@ -43,14 +48,14 @@ reported with manual remediation steps — they are not auto-repairable.`,
 
 			w := cmd.OutOrStdout()
 
-			// Phase 1: run checks and attempt all auto-repairs.
-			var result project.RepairResult
+			// Phase 1: project-side checks and auto-repairs.
+			var projectResult project.RepairResult
 			_ = ui.RunWithDynamicSpinner(w, "Running checks...", func(setLabel func(string)) error {
-				result = project.RepairWithProgress(deps, setLabel)
+				projectResult = project.RepairWithProgress(deps, setLabel)
 				return nil
 			})
 
-			needsTopology := result.NeedsTopologyPrompt
+			needsTopology := projectResult.NeedsTopologyPrompt
 			chosenTopology := topologyFlag
 
 			if needsTopology && chosenTopology == "" {
@@ -77,30 +82,64 @@ reported with manual remediation steps — they are not auto-repairable.`,
 			// If --topology was passed directly, force a topology repair even when
 			// the check didn't flag it (covers the "wrong value, undetectable" case).
 			if chosenTopology != "" {
-				var result2 project.RepairResult
+				var topoResult project.RepairResult
 				_ = ui.RunWithDynamicSpinner(w, "Repairing topology variables...", func(setLabel func(string)) error {
-					result2 = project.RepairTopologyWithChoice(deps, chosenTopology)
+					topoResult = project.RepairTopologyWithChoice(deps, chosenTopology)
 					return nil
 				})
-				result.Lines = append(result.Lines, result2.Lines...)
-				result.Repaired += result2.Repaired
-				result.Unrepaired += result2.Unrepaired
+				projectResult.Lines = append(projectResult.Lines, topoResult.Lines...)
+				projectResult.Repaired += topoResult.Repaired
+				projectResult.Unrepaired += topoResult.Unrepaired
 			}
 
+			// Phase 2: pipeline-side checks and auto-repairs.
+			pipelineDeps, pdepsErr := buildPipelineCheckDeps(deps)
+			var pipelineResult doctorv2.RepairResult
+			if pdepsErr == nil {
+				_ = ui.RunWithDynamicSpinner(w, "Running pipeline checks...", func(setLabel func(string)) error {
+					pipelineResult = doctorv2.RepairPipeline(pipelineDeps, setLabel)
+					return nil
+				})
+			}
+
+			// Render combined output.
 			fmt.Fprintln(w, "")
 			fmt.Fprintln(w, "  "+ui.SectionHeading.Render("gh agentic — repair"))
 			fmt.Fprintln(w, "")
-			for _, line := range result.Lines {
+
+			fmt.Fprintln(w, "  "+ui.SectionHeading.Render("Project"))
+			fmt.Fprintln(w, "  "+ui.Divider(48))
+			for _, line := range projectResult.Lines {
 				fmt.Fprintln(w, line)
 			}
 
-			if needsTopology || chosenTopology != "" {
-				fmt.Fprintln(w, "")
-				if result.Unrepaired > 0 {
-					fmt.Fprintf(w, "  %s\n\n", ui.StatusWarning.Render(fmt.Sprintf("%d issue(s) repaired, %d require manual attention", result.Repaired, result.Unrepaired)))
-				} else {
-					fmt.Fprintf(w, "  %s\n\n", ui.StatusOK.Render(fmt.Sprintf("%d issue(s) repaired", result.Repaired)))
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "  "+ui.SectionHeading.Render("Pipeline"))
+			fmt.Fprintln(w, "  "+ui.Divider(48))
+			if pdepsErr != nil {
+				fmt.Fprintf(w, "  %s  Skipped: %v\n", ui.StatusWarning.Render("⚠"), pdepsErr)
+			} else if len(pipelineResult.Lines) == 0 {
+				fmt.Fprintf(w, "  %s  No pipeline issues found\n", ui.StatusOK.Render("✓"))
+			} else {
+				for _, line := range pipelineResult.Lines {
+					fmt.Fprintln(w, line)
 				}
+			}
+
+			totalRepaired := projectResult.Repaired + pipelineResult.Repaired
+			totalUnrepaired := projectResult.Unrepaired + pipelineResult.Unrepaired
+
+			fmt.Fprintln(w, "")
+			switch {
+			case totalRepaired == 0 && totalUnrepaired == 0:
+				fmt.Fprintf(w, "  %s\n\n", ui.StatusOK.Render("Nothing to repair"))
+			case totalUnrepaired > 0:
+				fmt.Fprintf(w, "  %s\n\n",
+					ui.StatusWarning.Render(fmt.Sprintf("%d issue(s) repaired, %d require manual attention",
+						totalRepaired, totalUnrepaired)))
+			default:
+				fmt.Fprintf(w, "  %s\n\n",
+					ui.StatusOK.Render(fmt.Sprintf("%d issue(s) repaired", totalRepaired)))
 			}
 
 			return nil
@@ -109,4 +148,58 @@ reported with manual remediation steps — they are not auto-repairable.`,
 
 	cmd.Flags().StringVar(&topologyFlag, "topology", "", "override topology: 'single' or 'federated'")
 	return cmd
+}
+
+// buildPipelineCheckDeps constructs the doctorv2.CheckDeps used for the
+// pipeline-side health checks, mirroring how `gh agentic check` resolves them.
+func buildPipelineCheckDeps(pdeps project.Deps) (doctorv2.CheckDeps, error) {
+	root, err := os.Getwd()
+	if err != nil {
+		return doctorv2.CheckDeps{}, fmt.Errorf("resolving working directory: %w", err)
+	}
+
+	repoFullName := pdeps.RepoFullName
+	owner := pdeps.Owner
+	repoName := pdeps.RepoName
+
+	ownerType, otErr := auth.DefaultDetectOwnerType(owner)
+	if otErr != nil {
+		ownerType = ""
+	}
+
+	run := pdeps.Run
+	if run == nil {
+		run = auth.DefaultRunCommand
+	}
+
+	projectID, _ := runGetVariable(run, repoFullName, "AGENTIC_PROJECT_ID")
+	topology := ""
+	if projectID != "" {
+		topoVal, _ := runGetVariable(run, repoFullName, "AGENTIC_TOPOLOGY")
+		switch topoVal {
+		case "federated":
+			topology = resolveTopologyMode(run, repoFullName)
+		case "single":
+			topology = "single"
+		default:
+			topology = resolveTopologyMode(run, repoFullName)
+			if topology == "federated-domain" {
+				topology = "single"
+			}
+		}
+	}
+
+	return doctorv2.CheckDeps{
+		Root:         root,
+		RepoFullName: repoFullName,
+		Owner:        owner,
+		RepoName:     repoName,
+		OwnerType:    ownerType,
+		Topology:     topology,
+		ProjectID:    projectID,
+		Run:          run,
+		ReadCreds: func(r auth.RunCommandFunc) ([]byte, error) {
+			return auth.ReadClaudeCredentialsDefault(r)
+		},
+	}, nil
 }

--- a/internal/doctorv2/repair.go
+++ b/internal/doctorv2/repair.go
@@ -1,0 +1,105 @@
+package doctorv2
+
+import (
+	"fmt"
+
+	"github.com/eddiecarpenter/gh-agentic/internal/mount"
+	"github.com/eddiecarpenter/gh-agentic/internal/ui"
+)
+
+// RepairResult holds the outcome of a pipeline-side repair run.
+type RepairResult struct {
+	Lines      []string
+	Repaired   int
+	Unrepaired int
+}
+
+// workflowRepairNames is the set of CheckResult names produced by checkWorkflows
+// that map to a workflow-tag mismatch (auto-fixable via UpdateWorkflowVersions).
+var workflowRepairNames = map[string]bool{
+	"agentic-pipeline.yml": true,
+	"release.yml":          true,
+}
+
+// RepairPipeline runs all pipeline checks and attempts to auto-repair the
+// failures that are mechanically fixable. Failures that require human input
+// (missing variables, missing secrets) are surfaced with their remediation
+// hint but counted as Unrepaired.
+func RepairPipeline(deps CheckDeps, setLabel func(string)) RepairResult {
+	result := RepairResult{}
+
+	if setLabel != nil {
+		setLabel("Running pipeline checks...")
+	}
+	report := RunAllChecksWithProgress(deps, setLabel)
+
+	workflowRepairAttempted := false
+
+	for _, g := range report.Groups {
+		for _, r := range g.Results {
+			if r.Status != Fail {
+				continue
+			}
+
+			switch {
+			case r.Name == "gitignore":
+				if setLabel != nil {
+					setLabel("Repairing: .gitignore...")
+				}
+				if err := mount.EnsureGitignore(deps.Root); err != nil {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Could not add .ai/ to .gitignore: %v",
+							ui.StatusDanger.Render("✗"), err))
+					result.Unrepaired++
+				} else {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  .ai/ added to .gitignore",
+							ui.StatusOK.Render("✓")))
+					result.Repaired++
+				}
+
+			case workflowRepairNames[r.Name]:
+				// Multiple workflow files may all be out of date; one rewrite
+				// pass fixes them all, so dedupe.
+				if workflowRepairAttempted {
+					continue
+				}
+				workflowRepairAttempted = true
+				if setLabel != nil {
+					setLabel("Repairing: workflow version tags...")
+				}
+				version, verr := mount.ReadAIVersionFromGit(deps.Root)
+				if verr != nil || version == "" {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Could not repair workflow versions: framework version unknown",
+							ui.StatusDanger.Render("✗")))
+					result.Unrepaired++
+					continue
+				}
+				if err := mount.UpdateWorkflowVersions(deps.Root, version); err != nil {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Could not update workflow versions: %v",
+							ui.StatusDanger.Render("✗"), err))
+					result.Unrepaired++
+				} else {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Workflow version tags updated to %s",
+							ui.StatusOK.Render("✓"), version))
+					result.Repaired++
+				}
+
+			default:
+				// Not auto-repairable — surface so the user sees what is left.
+				line := fmt.Sprintf("  %s  %s",
+					ui.StatusDanger.Render("✗"), r.Message)
+				if r.Remediation != "" {
+					line += " " + ui.Muted.Render("→ "+r.Remediation)
+				}
+				result.Lines = append(result.Lines, line)
+				result.Unrepaired++
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/doctorv2/repair_test.go
+++ b/internal/doctorv2/repair_test.go
@@ -1,0 +1,141 @@
+package doctorv2
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eddiecarpenter/gh-agentic/internal/auth"
+)
+
+// fakeRunMissingVarsAndSecret simulates `gh` returning empty values for all
+// variables and an empty secret list, so every variable/secret check fails.
+func fakeRunMissingVarsAndSecret(name string, args ...string) (string, error) {
+	if name == "gh" && len(args) > 1 && args[0] == "variable" && args[1] == "get" {
+		return "", nil
+	}
+	if name == "gh" && len(args) > 1 && args[0] == "secret" && args[1] == "list" {
+		return "", nil
+	}
+	return "", nil
+}
+
+// makeRepoNeedingPipelineRepairs builds a repo that:
+//   - has the framework mounted at v2.0.0,
+//   - has NO .gitignore entry for .ai/,
+//   - has workflow files pinned to a stale @v1.0.0 tag,
+//   - has no GH variables or secrets configured.
+func makeRepoNeedingPipelineRepairs(t *testing.T) string {
+	t.Helper()
+	root := setupHealthyRepo(t)
+
+	// Break .gitignore.
+	_ = os.WriteFile(filepath.Join(root, ".gitignore"), []byte("# nothing\n"), 0o644)
+
+	// Break workflow tags (currently @v2.0.0 from setupHealthyRepo).
+	workflowsDir := filepath.Join(root, ".github", "workflows")
+	_ = os.WriteFile(filepath.Join(workflowsDir, "agentic-pipeline.yml"),
+		[]byte("uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline-reusable.yml@v1.0.0"), 0o644)
+	_ = os.WriteFile(filepath.Join(workflowsDir, "release.yml"),
+		[]byte("uses: eddiecarpenter/gh-agentic/.github/workflows/release-reusable.yml@v1.0.0"), 0o644)
+
+	return root
+}
+
+func TestRepairPipeline_FixesGitignoreAndWorkflowTags(t *testing.T) {
+	root := makeRepoNeedingPipelineRepairs(t)
+
+	deps := CheckDeps{
+		Root:         root,
+		RepoFullName: "owner/repo",
+		Owner:        "owner",
+		RepoName:     "repo",
+		OwnerType:    "User",
+		Topology:     "single",
+		Run:          fakeRunMissingVarsAndSecret,
+		ReadCreds: func(run auth.RunCommandFunc) ([]byte, error) {
+			return []byte(`{"token":"abc"}`), nil
+		},
+	}
+
+	result := RepairPipeline(deps, nil)
+
+	// Verify .gitignore was repaired on disk.
+	gi, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		t.Fatalf("reading .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gi), ".ai/") {
+		t.Errorf(".gitignore does not contain .ai/ after repair:\n%s", string(gi))
+	}
+
+	// Verify workflow tags were rewritten to the mounted version (v2.0.0).
+	for _, wf := range []string{"agentic-pipeline.yml", "release.yml"} {
+		data, err := os.ReadFile(filepath.Join(root, ".github", "workflows", wf))
+		if err != nil {
+			t.Fatalf("reading %s: %v", wf, err)
+		}
+		if strings.Contains(string(data), "@v1.0.0") {
+			t.Errorf("%s still pinned to @v1.0.0:\n%s", wf, string(data))
+		}
+		if !strings.Contains(string(data), "@v2.0.0") {
+			t.Errorf("%s missing expected @v2.0.0:\n%s", wf, string(data))
+		}
+	}
+
+	// Two auto-repairs (gitignore + workflows-as-a-batch) expected.
+	if result.Repaired != 2 {
+		t.Errorf("expected 2 repairs, got %d (lines: %v)", result.Repaired, result.Lines)
+	}
+
+	// Variable + secret failures must surface as Unrepaired (not silently dropped).
+	if result.Unrepaired == 0 {
+		t.Errorf("expected unrepaired failures for missing vars/secrets, got 0")
+	}
+
+	// The single workflow fix should produce exactly one workflow line, not two.
+	workflowLines := 0
+	for _, l := range result.Lines {
+		if strings.Contains(l, "Workflow version tags updated") {
+			workflowLines++
+		}
+	}
+	if workflowLines != 1 {
+		t.Errorf("expected one workflow-tags line, got %d", workflowLines)
+	}
+}
+
+func TestRepairPipeline_NoFailures(t *testing.T) {
+	root := setupHealthyRepo(t)
+
+	deps := CheckDeps{
+		Root:         root,
+		RepoFullName: "owner/repo",
+		Owner:        "owner",
+		RepoName:     "repo",
+		OwnerType:    "User",
+		Topology:     "single",
+		Run: func(name string, args ...string) (string, error) {
+			if name == "gh" && len(args) > 1 && args[0] == "variable" && args[1] == "get" {
+				return "configured", nil
+			}
+			if name == "gh" && len(args) > 1 && args[0] == "secret" && args[1] == "list" {
+				return "GOOSE_AGENT_PAT\tUpdated 2026-04-01", nil
+			}
+			return "", nil
+		},
+		ReadCreds: func(run auth.RunCommandFunc) ([]byte, error) {
+			return []byte(`{"token":"abc"}`), nil
+		},
+	}
+
+	result := RepairPipeline(deps, nil)
+
+	if result.Repaired != 0 || result.Unrepaired != 0 {
+		t.Errorf("expected zero repairs and zero failures on healthy repo, got %+v", result)
+	}
+	if len(result.Lines) != 0 {
+		t.Errorf("expected no output lines on healthy repo, got %v", result.Lines)
+	}
+}


### PR DESCRIPTION
## Summary

- `gh agentic repair` now runs the pipeline-side checks in addition to the agentic-project checks. Previously it only acted on the project half and exited with "No agentic project issues found" even when the pipeline section reported failures.
- Auto-repairs added: `.ai/` missing from `.gitignore` (via `mount.EnsureGitignore`) and workflow version-tag drift (via `mount.UpdateWorkflowVersions`, deduped to one rewrite pass when multiple workflows are stale).
- Non-auto-repairable failures (missing variables / secrets) are now surfaced with their `gh variable set` / `gh secret set` remediation commands instead of being silently dropped.
- Output is split into Project / Pipeline sections with a single combined summary line.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] New `TestRepairPipeline_FixesGitignoreAndWorkflowTags` verifies on-disk fixes and that a single workflow-rewrite pass covers multiple stale workflow files
- [x] New `TestRepairPipeline_NoFailures` verifies the healthy-repo path produces no output and no counts
- [x] Manual run against `~/Development/goplay/openbss`: 2 issues auto-repaired (gitignore + workflow tags), 5 var/secret failures surfaced with remediation steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)