### PR TITLE
fix: make 'repair' honest about workflows and interactive about variables

### DIFF
--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -2,13 +2,16 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
 	"github.com/eddiecarpenter/gh-agentic/internal/auth"
 	"github.com/eddiecarpenter/gh-agentic/internal/doctorv2"
+	"github.com/eddiecarpenter/gh-agentic/internal/initv2"
 	"github.com/eddiecarpenter/gh-agentic/internal/project"
 	"github.com/eddiecarpenter/gh-agentic/internal/ui"
 )
@@ -118,11 +121,26 @@ Those failures are surfaced with the exact 'gh' command to run.`,
 			fmt.Fprintln(w, "  "+ui.Divider(48))
 			if pdepsErr != nil {
 				fmt.Fprintf(w, "  %s  Skipped: %v\n", ui.StatusWarning.Render("⚠"), pdepsErr)
-			} else if len(pipelineResult.Lines) == 0 {
+			} else if len(pipelineResult.Lines) == 0 && len(pipelineResult.PendingPrompts) == 0 {
 				fmt.Fprintf(w, "  %s  No pipeline issues found\n", ui.StatusOK.Render("✓"))
 			} else {
 				for _, line := range pipelineResult.Lines {
 					fmt.Fprintln(w, line)
+				}
+			}
+
+			// Phase 3: prompt for missing variables/secrets and apply them.
+			if pdepsErr == nil && len(pipelineResult.PendingPrompts) > 0 {
+				applied, err := promptAndApplyPending(w, pipelineDeps, pipelineResult.PendingPrompts)
+				if err != nil {
+					fmt.Fprintf(w, "\n  %s  Prompt cancelled: %v\n", ui.StatusWarning.Render("⚠"), err)
+					pipelineResult.Unrepaired += len(pipelineResult.PendingPrompts)
+				} else {
+					for _, line := range applied.Lines {
+						fmt.Fprintln(w, line)
+					}
+					pipelineResult.Repaired += applied.Repaired
+					pipelineResult.Unrepaired += applied.Unrepaired
 				}
 			}
 
@@ -202,4 +220,103 @@ func buildPipelineCheckDeps(pdeps project.Deps) (doctorv2.CheckDeps, error) {
 			return auth.ReadClaudeCredentialsDefault(r)
 		},
 	}, nil
+}
+
+// promptAndApplyPending presents one huh form per pending variable/secret,
+// then applies non-empty answers via gh. Each prompt is its own form so the
+// user can Esc out of one without losing the rest. Returns a partial result
+// (Lines + counts) for the caller to merge.
+func promptAndApplyPending(w io.Writer, deps doctorv2.CheckDeps, prompts []doctorv2.PendingPrompt) (doctorv2.RepairResult, error) {
+	res := doctorv2.RepairResult{}
+
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "  %s  %d value(s) need to be set. Leave blank to skip any.\n",
+		ui.Muted.Render("→"), len(prompts))
+	fmt.Fprintln(w, "")
+
+	for _, p := range prompts {
+		value, err := promptValue(p, deps)
+		if err != nil {
+			// User cancelled the form (Ctrl+C / Esc). Bail out — the caller
+			// counts remaining prompts as Unrepaired.
+			return res, err
+		}
+
+		// Empty answer + a non-empty default → use the default.
+		if strings.TrimSpace(value) == "" && p.Default != "" {
+			value = p.Default
+		}
+
+		applyErr := doctorv2.ApplyPendingPrompt(deps.Run, deps.RepoFullName, p, value)
+		res.Lines = append(res.Lines, doctorv2.FormatPromptApplied(p, applyErr))
+		if applyErr != nil {
+			res.Unrepaired++
+		} else {
+			res.Repaired++
+		}
+	}
+
+	return res, nil
+}
+
+// promptValue runs the appropriate huh form for a single pending prompt and
+// returns the user-supplied value. RUNNER_LABEL gets the same select-then-
+// custom flow used by `gh agentic init`; everything else uses a single text
+// input (with password masking for secrets).
+func promptValue(p doctorv2.PendingPrompt, deps doctorv2.CheckDeps) (string, error) {
+	if p.Name == "RUNNER_LABEL" {
+		return promptRunnerLabel(deps)
+	}
+
+	var value string
+	title := p.Name
+	if p.Description != "" {
+		title = p.Name + " — " + p.Description
+	}
+	input := huh.NewInput().Title(title).Value(&value)
+	if p.Default != "" {
+		input = input.Placeholder(p.Default)
+	}
+	if p.Kind == "secret" {
+		input = input.EchoMode(huh.EchoModePassword)
+	}
+	if err := huh.NewForm(huh.NewGroup(input)).Run(); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+// promptRunnerLabel mirrors initv2.collectPipelineConfig's runner picker:
+// a select with sensible candidates, falling through to a custom-label input
+// when "other" is chosen.
+func promptRunnerLabel(deps doctorv2.CheckDeps) (string, error) {
+	value := initv2.DefaultRunnerLabel
+	options := initv2.BuildRunnerOptions(deps.RepoName, deps.Owner)
+
+	selectForm := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("RUNNER_LABEL").
+			Description("The GitHub Actions runner label for the agentic pipeline").
+			Options(options...).
+			Value(&value),
+	))
+	if err := selectForm.Run(); err != nil {
+		return "", err
+	}
+
+	if value != initv2.RunnerOther {
+		return value, nil
+	}
+
+	value = ""
+	customForm := huh.NewForm(huh.NewGroup(
+		huh.NewInput().
+			Title("Custom runner label").
+			Description("Enter your custom GitHub Actions runner label").
+			Value(&value),
+	))
+	if err := customForm.Run(); err != nil {
+		return "", err
+	}
+	return value, nil
 }

--- a/internal/doctorv2/checks.go
+++ b/internal/doctorv2/checks.go
@@ -276,19 +276,25 @@ func checkWorkflows(deps CheckDeps) Group {
 			continue
 		}
 
-		if version != "" && strings.Contains(string(data), "@"+version) {
+		// Only enforce the framework version tag if the workflow actually
+		// references gh-agentic via a 'uses:' line. Inlined workflows (the
+		// current framework template) don't reference gh-agentic at all and
+		// don't need a version tag.
+		referencesFramework := strings.Contains(string(data), "eddiecarpenter/gh-agentic")
+		switch {
+		case version == "" || !referencesFramework:
+			g.Results = append(g.Results, CheckResult{
+				Name: wf, Status: Pass, Message: wf + " present",
+			})
+		case strings.Contains(string(data), "@"+version):
 			g.Results = append(g.Results, CheckResult{
 				Name: wf, Status: Pass, Message: fmt.Sprintf("%s → @%s", wf, version),
 			})
-		} else if version != "" {
+		default:
 			g.Results = append(g.Results, CheckResult{
 				Name: wf, Status: Fail,
 				Message:     fmt.Sprintf("%s — version tag mismatch (expected @%s)", wf, version),
 				Remediation: "Run 'gh agentic mount'",
-			})
-		} else {
-			g.Results = append(g.Results, CheckResult{
-				Name: wf, Status: Pass, Message: wf + " present",
 			})
 		}
 	}

--- a/internal/doctorv2/checks_test.go
+++ b/internal/doctorv2/checks_test.go
@@ -212,6 +212,40 @@ func TestCheckWorkflows_VersionMatch(t *testing.T) {
 	}
 }
 
+// TestCheckWorkflows_InlinedNoFrameworkRefs documents the regression that
+// previously broke `gh agentic check` for repos whose workflows are inlined
+// (no `eddiecarpenter/gh-agentic/...@v...` reference). Such workflows do not
+// need a framework version tag and must pass.
+func TestCheckWorkflows_InlinedNoFrameworkRefs(t *testing.T) {
+	root := t.TempDir()
+	setupAIGitRepo(t, filepath.Join(root, ".ai"), "v2.1.0")
+	_ = mount.WriteAIVersion(root, "v2.1.0")
+
+	workflowsDir := filepath.Join(root, ".github", "workflows")
+	_ = os.MkdirAll(workflowsDir, 0o755)
+	// Inlined workflow with only third-party action refs — no gh-agentic ref.
+	inlined := `name: Agentic Pipeline
+on: [push]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+`
+	_ = os.WriteFile(filepath.Join(workflowsDir, "agentic-pipeline.yml"), []byte(inlined), 0o644)
+	_ = os.WriteFile(filepath.Join(workflowsDir, "release.yml"), []byte(inlined), 0o644)
+
+	deps := CheckDeps{Root: root}
+	g := checkWorkflows(deps)
+
+	for _, r := range g.Results {
+		if r.Status != Pass {
+			t.Errorf("expected %s to Pass (inlined workflow, no framework ref), got %v: %s",
+				r.Name, r.Status, r.Message)
+		}
+	}
+}
+
 func TestCheckAgentFiles_AllPresent(t *testing.T) {
 	root := setupHealthyRepo(t)
 	deps := CheckDeps{Root: root}

--- a/internal/doctorv2/repair.go
+++ b/internal/doctorv2/repair.go
@@ -2,16 +2,90 @@ package doctorv2
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/eddiecarpenter/gh-agentic/internal/auth"
 	"github.com/eddiecarpenter/gh-agentic/internal/mount"
 	"github.com/eddiecarpenter/gh-agentic/internal/ui"
 )
 
+// pendingKind classifies a failed CheckResult as a variable, secret, or
+// neither, by inspecting its remediation string. Returns ("variable"|"secret",
+// true) on a match, and ("", false) when the result isn't a known
+// var/secret-set hint (so the caller falls back to surfacing it as
+// non-auto-repairable).
+func pendingKind(r CheckResult) (string, bool) {
+	switch {
+	case strings.HasPrefix(r.Remediation, "gh variable set "):
+		return "variable", true
+	case strings.HasPrefix(r.Remediation, "gh secret set "):
+		return "secret", true
+	}
+	return "", false
+}
+
+// ApplyPendingPrompt sets a single GitHub variable or secret using the
+// supplied run function. The CLI layer calls this after collecting values
+// from the user via huh. Empty values are treated as a skip.
+func ApplyPendingPrompt(run auth.RunCommandFunc, repoFullName string, p PendingPrompt, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("skipped (no value supplied)")
+	}
+	switch p.Kind {
+	case "variable":
+		_, err := run("gh", "variable", "set", p.Name, "--repo", repoFullName, "--body", value)
+		return err
+	case "secret":
+		_, err := run("gh", "secret", "set", p.Name, "--repo", repoFullName, "--body", value)
+		return err
+	default:
+		return fmt.Errorf("unknown pending kind %q", p.Kind)
+	}
+}
+
+// FormatPromptApplied renders a single line summarising the outcome of an
+// ApplyPendingPrompt call. Repair callers append this to the output.
+func FormatPromptApplied(p PendingPrompt, err error) string {
+	if err != nil {
+		return fmt.Sprintf("  %s  %s — %v",
+			ui.StatusDanger.Render("✗"), p.Name, err)
+	}
+	return fmt.Sprintf("  %s  %s set",
+		ui.StatusOK.Render("✓"), p.Name)
+}
+
 // RepairResult holds the outcome of a pipeline-side repair run.
 type RepairResult struct {
-	Lines      []string
-	Repaired   int
-	Unrepaired int
+	Lines          []string
+	Repaired       int
+	Unrepaired     int
+	PendingPrompts []PendingPrompt
+}
+
+// PendingPrompt describes a variable or secret that needs a human-supplied
+// value. RepairPipeline collects these so the CLI layer can prompt for values
+// after the spinner phase finishes (the spinner can't share the terminal with
+// an interactive form).
+type PendingPrompt struct {
+	Name        string // GitHub variable or secret name
+	Kind        string // "variable" or "secret"
+	Description string // shown in the form
+	Default     string // suggested default value (may be empty)
+}
+
+// pendingDescriptions maps known variable/secret names to short descriptions
+// and sensible defaults. Names absent from the map are still prompted, with
+// the bare name shown as the title.
+var pendingDescriptions = map[string]struct {
+	Description string
+	Default     string
+}{
+	"AGENT_USER":      {"GitHub username the agent commits as (e.g. goose-bot)", ""},
+	"RUNNER_LABEL":    {"GitHub Actions runner label", ""}, // resolved via select in cli layer
+	"GOOSE_PROVIDER":  {"The LLM provider the agent will use", "claude-code"},
+	"GOOSE_MODEL":     {"Goose model override", "default"},
+	"GOOSE_AGENT_PAT": {"Personal Access Token for the agent (stored as a secret)", ""},
 }
 
 // workflowRepairNames is the set of CheckResult names produced by checkWorkflows
@@ -76,19 +150,46 @@ func RepairPipeline(deps CheckDeps, setLabel func(string)) RepairResult {
 					result.Unrepaired++
 					continue
 				}
-				if err := mount.UpdateWorkflowVersions(deps.Root, version); err != nil {
+				rewrites, err := mount.UpdateWorkflowVersionsCount(deps.Root, version)
+				switch {
+				case err != nil:
 					result.Lines = append(result.Lines,
 						fmt.Sprintf("  %s  Could not update workflow versions: %v",
 							ui.StatusDanger.Render("✗"), err))
 					result.Unrepaired++
-				} else {
+				case rewrites == 0:
+					// The check failed but the rewriter found nothing to change —
+					// the workflows don't reference gh-agentic reusable workflows.
+					// Surface honestly instead of claiming a phantom repair.
 					result.Lines = append(result.Lines,
-						fmt.Sprintf("  %s  Workflow version tags updated to %s",
-							ui.StatusOK.Render("✓"), version))
+						fmt.Sprintf("  %s  %s",
+							ui.StatusDanger.Render("✗"), r.Message))
+					if r.Remediation != "" {
+						result.Lines = append(result.Lines,
+							"     "+ui.Muted.Render("→ "+r.Remediation))
+					}
+					result.Unrepaired++
+				default:
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Workflow version tags updated to %s (%d file(s))",
+							ui.StatusOK.Render("✓"), version, rewrites))
 					result.Repaired++
 				}
 
 			default:
+				// Variable / secret failures: defer to interactive prompts so
+				// the CLI layer can collect values after the spinner phase.
+				if kind, ok := pendingKind(r); ok {
+					meta := pendingDescriptions[r.Name]
+					result.PendingPrompts = append(result.PendingPrompts, PendingPrompt{
+						Name:        r.Name,
+						Kind:        kind,
+						Description: meta.Description,
+						Default:     meta.Default,
+					})
+					continue
+				}
+
 				// Not auto-repairable — surface so the user sees what is left.
 				line := fmt.Sprintf("  %s  %s",
 					ui.StatusDanger.Render("✗"), r.Message)

--- a/internal/mount/mount.go
+++ b/internal/mount/mount.go
@@ -131,16 +131,26 @@ var versionTagPattern = regexp.MustCompile(`(eddiecarpenter/gh-agentic/\.github/
 // UpdateWorkflowVersions scans all .yml files in .github/workflows/ and
 // replaces gh-agentic version tags with the new version.
 func UpdateWorkflowVersions(root, newVersion string) error {
+	_, err := UpdateWorkflowVersionsCount(root, newVersion)
+	return err
+}
+
+// UpdateWorkflowVersionsCount is like UpdateWorkflowVersions but reports the
+// number of files actually rewritten. Returns 0 when the workflows in
+// .github/workflows/ don't reference gh-agentic reusable workflows at all
+// (the current framework template uses inlined steps, not @vX.Y.Z refs).
+func UpdateWorkflowVersionsCount(root, newVersion string) (int, error) {
 	workflowsDir := filepath.Join(root, ".github", "workflows")
 
 	entries, err := os.ReadDir(workflowsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return 0, nil
 		}
-		return fmt.Errorf("reading workflows directory: %w", err)
+		return 0, fmt.Errorf("reading workflows directory: %w", err)
 	}
 
+	rewrites := 0
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -153,16 +163,17 @@ func UpdateWorkflowVersions(root, newVersion string) error {
 		path := filepath.Join(workflowsDir, name)
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("reading %s: %w", name, err)
+			return rewrites, fmt.Errorf("reading %s: %w", name, err)
 		}
 
 		updated := versionTagPattern.ReplaceAllString(string(data), "${1}@"+newVersion)
 		if updated != string(data) {
 			if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
-				return fmt.Errorf("writing %s: %w", name, err)
+				return rewrites, fmt.Errorf("writing %s: %w", name, err)
 			}
+			rewrites++
 		}
 	}
 
-	return nil
+	return rewrites, nil
 }


### PR DESCRIPTION
## Summary

- `checkWorkflows` no longer reports a spurious version-tag mismatch for inlined workflows (the current framework template). The check now only enforces `@vX.Y.Z` when the workflow actually references `eddiecarpenter/gh-agentic`.
- Repair no longer claims a phantom \"Workflow version tags updated\" when the rewriter changes nothing — `UpdateWorkflowVersionsCount` returns the rewrite count, and repair surfaces the failure with the real remediation when zero files were rewritten.
- Pipeline repair is now interactive for variables/secrets. After the spinner phase, repair prompts for each missing value (one form per item, secrets masked) and applies them via `gh variable set` / `gh secret set`. Empty input + non-empty default uses the default; empty input with no default skips.
- `RUNNER_LABEL` reuses `initv2.BuildRunnerOptions` so the picker matches `gh agentic init` exactly (ubuntu-latest / repo / owner / self-hosted / other → custom). `GOOSE_PROVIDER` and `GOOSE_MODEL` defaults are aligned with init (`claude-code` / `default`).

## Test plan

- [x] `go test ./...` — all packages pass
- [x] New `TestCheckWorkflows_InlinedNoFrameworkRefs` covers the regression
- [x] Manual run against `~/Development/goplay/openbss`: workflow check passes, repair prompts for all 5 missing var/secret values and sets them via gh

🤖 Generated with [Claude Code](https://claude.com/claude-code)