### PR TITLE
chore: remove legacy references from status help text

### DIFF
--- a/internal/cli/pipeline_cmd.go
+++ b/internal/cli/pipeline_cmd.go
@@ -63,7 +63,6 @@ separator, then the features pipeline, then a combined totals line. Use
 --requirements or --features (mutually exclusive) to render only one of
 the two pipelines.
 
-The layout flags mirror the semantics of the earlier list-flag form:
 --horizontal forces horizontal layout, --vertical forces vertical, and
 omitting both auto-picks based on terminal width. --include-done appends
 the 'done' column. --this-repo narrows the federated view to the current

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -155,8 +155,7 @@ append created_at and last_transitioned_at columns.
 Pass --include-done to include completed requirements; by default only open
 items are listed.
 
-For the pipeline view, use 'gh agentic status pipeline --requirements'. The
---kanban flag has been removed from this command.`,
+For a side-by-side pipeline view, use 'gh agentic status pipeline --requirements'.`,
 		Example: `  # Default list view
   gh agentic status requirements
 
@@ -166,7 +165,7 @@ For the pipeline view, use 'gh agentic status pipeline --requirements'. The
   # Include closed requirements
   gh agentic status requirements --include-done
 
-  # Pipeline view — use the pipeline subcommand instead
+  # Side-by-side pipeline view
   gh agentic status pipeline --requirements`,
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
@@ -255,8 +254,7 @@ append created_at and last_transitioned_at columns.
 Pass --include-done to include completed features; by default only open items
 are listed.
 
-For the pipeline view, use 'gh agentic status pipeline --features'. The
---kanban flag has been removed from this command.`,
+For a side-by-side pipeline view, use 'gh agentic status pipeline --features'.`,
 		Example: `  # Default list view
   gh agentic status features
 
@@ -266,7 +264,7 @@ For the pipeline view, use 'gh agentic status pipeline --features'. The
   # Narrow to the current repo
   gh agentic status features --this-repo
 
-  # Pipeline view — use the pipeline subcommand instead
+  # Side-by-side pipeline view
   gh agentic status pipeline --features`,
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,


### PR DESCRIPTION
## Summary

- The \`Long\` descriptions on \`status pipeline\`, \`status requirements\`, and \`status features\` referenced "the earlier list-flag form" and "the \`--kanban\` flag has been removed from this command."
- Help text should describe the tool as it is now — not its history. A new user reading \`--help\` does not benefit from hearing about a flag they never saw.
- Replaced those phrases with direct descriptions of current behaviour and the pipeline sub-command.

Follow-up cleanup noticed after #598 merged.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/cli/\` passes
- [x] \`gh agentic status pipeline --help\` no longer mentions "earlier list-flag form"
- [x] \`gh agentic status requirements --help\` no longer mentions \`--kanban\`
- [x] \`gh agentic status features --help\` no longer mentions \`--kanban\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)