### PR TITLE
fix: short-circuit check/repair when framework mount is out of sync

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -32,6 +32,23 @@ type checkDeps struct {
 	fetchLinkedRepos project.FetchLinkedReposFunc
 }
 
+// projectFrameworkOutOfSync returns true when the project-side
+// framework-version-sync check reports a Fail status. Pipeline-scope
+// checks (skill frontmatter, catalogue, workflow versions) operate on
+// `.ai/` and produce noise against a stale mount, so both `check` and
+// `repair` short-circuit on this signal.
+func projectFrameworkOutOfSync(report *project.CheckReport) bool {
+	if report == nil {
+		return false
+	}
+	for _, r := range report.Results {
+		if r.Name == "framework-version-sync" && r.Status == project.CheckFail {
+			return true
+		}
+	}
+	return false
+}
+
 // defaultResolveRepo resolves the repo from git remote config.
 func defaultResolveRepo() (repoInfo, error) {
 	currentRepo, err := repository.Current()
@@ -97,10 +114,21 @@ Run 'gh agentic repair' to auto-fix any issues that can be fixed automatically.`
 
 			var projectReport *project.CheckReport
 			var pipelineReport *doctor.Report
+			var pipelineSkipped bool
 
 			_ = ui.RunWithDynamicSpinner(w, "Running project checks...", func(setLabel func(string)) error {
 				// Project-scope checks first — they already handle topology internally.
 				projectReport = project.RunChecksWithProgress(projectDeps, setLabel)
+
+				// Short-circuit: if the mounted framework is out of sync
+				// with the authoritative version, pipeline-side checks
+				// (skill frontmatter, catalogue, workflow versions) will
+				// generate noise against a stale `.ai/`. Stop here and
+				// direct the user to `gh agentic mount` first.
+				if projectFrameworkOutOfSync(projectReport) {
+					pipelineSkipped = true
+					return nil
+				}
 
 				// Pipeline-scope checks need repo identity + resolved topology mode.
 				setLabel("Detecting repository for pipeline checks...")
@@ -157,13 +185,23 @@ Run 'gh agentic repair' to auto-fix any issues that can be fixed automatically.`
 			// Pipeline section.
 			fmt.Fprintln(w, "  "+ui.SectionHeading.Render("Pipeline"))
 			fmt.Fprintln(w, "  "+ui.Divider(48))
-			for _, g := range pipelineReport.Groups {
-				doctor.RenderGroup(w, g)
+			if pipelineSkipped {
+				fmt.Fprintf(w, "  %s  Skipped — framework mount is out of sync; run 'gh agentic mount' first\n", ui.StatusWarning.Render("⚠"))
+			} else {
+				for _, g := range pipelineReport.Groups {
+					doctor.RenderGroup(w, g)
+				}
 			}
 
 			// Combined summary.
-			fails := projectReport.FailCount() + pipelineReport.FailCount()
-			warns := projectReport.WarnCount() + pipelineReport.WarningCount()
+			pipelineFails := 0
+			pipelineWarns := 0
+			if pipelineReport != nil {
+				pipelineFails = pipelineReport.FailCount()
+				pipelineWarns = pipelineReport.WarningCount()
+			}
+			fails := projectReport.FailCount() + pipelineFails
+			warns := projectReport.WarnCount() + pipelineWarns
 			fmt.Fprintln(w, "")
 			switch {
 			case fails > 0:

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -57,9 +57,13 @@ Those failures are surfaced with the exact 'gh' command to run.`,
 			})
 
 			// Phase 2: pipeline-side checks and auto-repairs.
+			// Skip when the framework mount is out of sync — the pipeline
+			// checks run against `.ai/` and only produce noise until the
+			// user runs `gh agentic mount`.
 			pipelineDeps, pdepsErr := buildPipelineCheckDeps(deps)
 			var pipelineResult doctor.RepairResult
-			if pdepsErr == nil {
+			pipelineSkipped := projectResult.FrameworkOutOfSync
+			if pdepsErr == nil && !pipelineSkipped {
 				_ = ui.RunWithDynamicSpinner(w, "Running pipeline checks...", func(setLabel func(string)) error {
 					pipelineResult = doctor.RepairPipeline(pipelineDeps, setLabel)
 					return nil
@@ -80,18 +84,21 @@ Those failures are surfaced with the exact 'gh' command to run.`,
 			fmt.Fprintln(w, "")
 			fmt.Fprintln(w, "  "+ui.SectionHeading.Render("Pipeline"))
 			fmt.Fprintln(w, "  "+ui.Divider(48))
-			if pdepsErr != nil {
+			switch {
+			case pipelineSkipped:
+				fmt.Fprintf(w, "  %s  Skipped — framework mount is out of sync; run 'gh agentic mount' first\n", ui.StatusWarning.Render("⚠"))
+			case pdepsErr != nil:
 				fmt.Fprintf(w, "  %s  Skipped: %v\n", ui.StatusWarning.Render("⚠"), pdepsErr)
-			} else if len(pipelineResult.Lines) == 0 && len(pipelineResult.PendingPrompts) == 0 {
+			case len(pipelineResult.Lines) == 0 && len(pipelineResult.PendingPrompts) == 0:
 				fmt.Fprintf(w, "  %s  No pipeline issues found\n", ui.StatusOK.Render("✓"))
-			} else {
+			default:
 				for _, line := range pipelineResult.Lines {
 					fmt.Fprintln(w, line)
 				}
 			}
 
 			// Phase 3: prompt for missing variables/secrets and apply them.
-			if pdepsErr == nil && len(pipelineResult.PendingPrompts) > 0 {
+			if !pipelineSkipped && pdepsErr == nil && len(pipelineResult.PendingPrompts) > 0 {
 				applied, err := promptAndApplyPending(w, pipelineDeps, pipelineResult.PendingPrompts)
 				if err != nil {
 					fmt.Fprintf(w, "\n  %s  Prompt cancelled: %v\n", ui.StatusWarning.Render("⚠"), err)
@@ -108,7 +115,7 @@ Those failures are surfaced with the exact 'gh' command to run.`,
 			// Phase 4: shadow-vars batch confirm + delete. The prompt must
 			// live outside the spinner phase so huh.NewConfirm can own the
 			// terminal. One confirmation covers the whole batch.
-			if pdepsErr == nil && pipelineResult.ShadowBatch != nil {
+			if !pipelineSkipped && pdepsErr == nil && pipelineResult.ShadowBatch != nil {
 				shadowRes := doctor.RepairShadowValues(
 					pipelineResult.ShadowBatch.Items,
 					pipelineDeps.Run,

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -12,9 +12,10 @@ import (
 
 // RepairResult holds the outcome of a repair run.
 type RepairResult struct {
-	Lines      []string // output lines to display
-	Repaired   int
-	Unrepaired int
+	Lines               []string // output lines to display
+	Repaired            int
+	Unrepaired          int
+	FrameworkOutOfSync  bool // true when framework-version-sync check failed
 }
 
 // RepairWithProgress runs all checks and repairs failures, calling setLabel
@@ -26,6 +27,16 @@ func RepairWithProgress(deps Deps, setLabel func(string)) RepairResult {
 		setLabel("Running agentic project checks...")
 	}
 	report := RunChecksWithProgress(deps, setLabel)
+
+	// Surface framework-out-of-sync so the CLI can short-circuit the
+	// pipeline phase — running skill / workflow checks against a stale
+	// `.ai/` produces noise and blocks the real remediation.
+	for _, r := range report.Results {
+		if r.Name == "framework-version-sync" && r.Status == CheckFail {
+			result.FrameworkOutOfSync = true
+			break
+		}
+	}
 
 	// Nothing to do if there are no failures and no repairable warnings.
 	hasRepairable := false


### PR DESCRIPTION
## Summary

When the local `.ai/` mount is stale relative to the control plane's `AGENTIC_FRAMEWORK_VERSION`, the pipeline-side checks (skill frontmatter, catalogue, workflow versions) validate against stale content and flood the output with noise that blocks the real remediation.

Now: if `framework-version-sync` reports `CheckFail`, `check` and `repair` surface that one failure with the `gh agentic mount` remediation and skip the pipeline phase entirely.

## Test plan

- [x] `go test ./...` — green
- [x] Manual: `/tmp/gh-agentic-test check` against `NewOpenBSS/charging-domain` (mounted at v2.1.0, CP broadcasting v2.2.0) — output is one `✗ framework out of sync` line plus `⚠ Skipped — framework mount is out of sync` in the Pipeline section; no skill-frontmatter noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)