### PR TITLE
feat: Use gh agentic mount in CI workflows

### DIFF
--- a/.github/actions/install-ai-tools/action.yml
+++ b/.github/actions/install-ai-tools/action.yml
@@ -1,6 +1,7 @@
 name: Install AI Tools
 description: >
-  Install system dependencies, Goose and Claude Code CLI with caching support.
+  Install system dependencies, Goose, Claude Code CLI, and the gh-agentic
+  extension with caching support.
 
 inputs:
   goose-version:
@@ -11,6 +12,12 @@ inputs:
     description: 'Claude Code CLI version to install (default: latest)'
     required: false
     default: 'latest'
+  agentic-version:
+    description: 'gh-agentic extension version to install (e.g. v1.2.3). Must match AGENTIC_FRAMEWORK_VERSION.'
+    required: true
+  gh-token:
+    description: 'GitHub token used to install the gh-agentic extension from a private/release context.'
+    required: true
 
 runs:
   using: composite
@@ -93,3 +100,17 @@ runs:
         mkdir -p ~/.local/bin
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         echo "${{ runner.tool_cache }}/claude-cli/bin" >> $GITHUB_PATH
+
+    - name: Install gh-agentic extension
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        AGENTIC_VERSION: ${{ inputs.agentic-version }}
+      run: |
+        if [ -z "${AGENTIC_VERSION}" ]; then
+          echo "::error::agentic-version input is empty. Pass the resolved AGENTIC_FRAMEWORK_VERSION."
+          exit 1
+        fi
+        echo "Installing gh-agentic extension pinned to ${AGENTIC_VERSION}..."
+        gh extension install eddiecarpenter/gh-agentic --pin "${AGENTIC_VERSION}" --force
+        gh agentic --version || true

--- a/.github/workflows/agentic-pipeline-reusable.yml
+++ b/.github/workflows/agentic-pipeline-reusable.yml
@@ -42,50 +42,6 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Framework version: ${VERSION}"
 
-      - name: Mount AI Framework
-        env:
-          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          echo "Mounting AI Framework at version ${VERSION}..."
-
-          # Download and extract the framework from gh-agentic release
-          mkdir -p .ai
-          gh release download "${VERSION}" \
-            --repo eddiecarpenter/gh-agentic \
-            --archive tar.gz \
-            --output framework.tar.gz
-
-          # Extract only framework files (RULEBOOK.md, skills/, recipes/, standards/, concepts/)
-          tar xzf framework.tar.gz --strip-components=1 \
-            --directory=.ai \
-            --include='*/RULEBOOK.md' \
-            --include='*/skills/*' \
-            --include='*/recipes/*' \
-            --include='*/standards/*' \
-            --include='*/concepts/*' \
-            2>/dev/null || true
-
-          rm -f framework.tar.gz
-
-          # Also extract .goose/recipes/ for Goose
-          mkdir -p .goose
-          gh release download "${VERSION}" \
-            --repo eddiecarpenter/gh-agentic \
-            --archive tar.gz \
-            --output framework.tar.gz
-
-          tar xzf framework.tar.gz --strip-components=1 \
-            --directory=. \
-            --include='*/.goose/*' \
-            --include='*/.github/actions/*' \
-            2>/dev/null || true
-
-          rm -f framework.tar.gz
-
-          echo "✓ Framework mounted at .ai/"
-          ls -la .ai/
-
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
@@ -93,6 +49,18 @@ jobs:
 
       - name: Install tools
         uses: ./.github/actions/install-ai-tools
+        with:
+          agentic-version: ${{ steps.version.outputs.version }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Mount AI framework
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          echo "Mounting AI framework via gh agentic mount..."
+          gh agentic mount -y
+          echo "✓ Framework mounted at .ai/"
+          ls -la .ai/
 
       - name: Setup Claude Code auth
         uses: ./.github/actions/setup-claude-auth

--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -51,8 +51,31 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      - name: Resolve framework version
+        id: version
+        env:
+          AGENTIC_FRAMEWORK_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+        run: |
+          if [ -z "${AGENTIC_FRAMEWORK_VERSION}" ]; then
+            echo "::error::AGENTIC_FRAMEWORK_VERSION is not set. Set the repo variable to pin the framework version."
+            exit 1
+          fi
+          VERSION=$(echo "${AGENTIC_FRAMEWORK_VERSION}" | tr -d '[:space:]')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Install tools
         uses: ./.github/actions/install-ai-tools
+        with:
+          agentic-version: ${{ steps.version.outputs.version }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Mount AI framework
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          echo "Mounting AI framework via gh agentic mount..."
+          gh agentic mount -y
+          echo "✓ Framework mounted at .ai/"
 
       - name: Setup Claude Code auth
         uses: ./.github/actions/setup-claude-auth
@@ -136,8 +159,31 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      - name: Resolve framework version
+        id: version
+        env:
+          AGENTIC_FRAMEWORK_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+        run: |
+          if [ -z "${AGENTIC_FRAMEWORK_VERSION}" ]; then
+            echo "::error::AGENTIC_FRAMEWORK_VERSION is not set. Set the repo variable to pin the framework version."
+            exit 1
+          fi
+          VERSION=$(echo "${AGENTIC_FRAMEWORK_VERSION}" | tr -d '[:space:]')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Install Goose and Claude Code CLI
         uses: ./.github/actions/install-ai-tools
+        with:
+          agentic-version: ${{ steps.version.outputs.version }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Mount AI framework
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          echo "Mounting AI framework via gh agentic mount..."
+          gh agentic mount -y
+          echo "✓ Framework mounted at .ai/"
 
       - name: Setup Claude Code auth
         uses: ./.github/actions/setup-claude-auth
@@ -330,8 +376,31 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      - name: Resolve framework version
+        id: version
+        env:
+          AGENTIC_FRAMEWORK_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+        run: |
+          if [ -z "${AGENTIC_FRAMEWORK_VERSION}" ]; then
+            echo "::error::AGENTIC_FRAMEWORK_VERSION is not set. Set the repo variable to pin the framework version."
+            exit 1
+          fi
+          VERSION=$(echo "${AGENTIC_FRAMEWORK_VERSION}" | tr -d '[:space:]')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Install tools
         uses: ./.github/actions/install-ai-tools
+        with:
+          agentic-version: ${{ steps.version.outputs.version }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Mount AI framework
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          echo "Mounting AI framework via gh agentic mount..."
+          gh agentic mount -y
+          echo "✓ Framework mounted at .ai/"
 
       - name: Setup Claude Code auth
         uses: ./.github/actions/setup-claude-auth
@@ -415,8 +484,31 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      - name: Resolve framework version
+        id: version
+        env:
+          AGENTIC_FRAMEWORK_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+        run: |
+          if [ -z "${AGENTIC_FRAMEWORK_VERSION}" ]; then
+            echo "::error::AGENTIC_FRAMEWORK_VERSION is not set. Set the repo variable to pin the framework version."
+            exit 1
+          fi
+          VERSION=$(echo "${AGENTIC_FRAMEWORK_VERSION}" | tr -d '[:space:]')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Install tools
         uses: ./.github/actions/install-ai-tools
+        with:
+          agentic-version: ${{ steps.version.outputs.version }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Mount AI framework
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          echo "Mounting AI framework via gh agentic mount..."
+          gh agentic mount -y
+          echo "✓ Framework mounted at .ai/"
 
       - name: Setup Claude Code auth
         uses: ./.github/actions/setup-claude-auth


### PR DESCRIPTION
Closes #607

## Summary

- Install the `gh-agentic` extension in the `install-ai-tools` composite action, pinned to `AGENTIC_FRAMEWORK_VERSION`.
- Replace hand-rolled `gh release download` + `tar xzf` in `agentic-pipeline-reusable.yml` with `gh agentic mount -y`.
- Add `Resolve framework version` + `Mount AI framework` steps to all four jobs in `agentic-pipeline.yml` (`feature-design`, `dev-session`, `pr-review-session`, `issue-session`) — previously none of them mounted `.ai/` at all, so any recipe that read `.ai/*` would have failed.

CI now exercises the same mount path as developer machines. Mount-side improvements (version validation, include rules, topology detection) flow into CI automatically.

## Pipeline context

- Requirement: #606
- Feature: #607
- Task: #608 (closed)

## Prerequisites

Requires the repo variable `AGENTIC_FRAMEWORK_VERSION` to be set. Now set to `v2.2.1`.

## Test plan

- [ ] CI on this PR runs `gh agentic mount` successfully in the agentic-pipeline workflow jobs (observable once a pipeline trigger label is applied post-merge — this PR alone does not exercise those jobs).
- [ ] `go build ./...` and `go test ./...` pass locally (verified).
- [ ] No residual `tar xzf` / `gh release download` for framework mounting in workflow YAML (verified).

## Risk

- Workflows now hard-fail if `AGENTIC_FRAMEWORK_VERSION` is unset. This enforcement already existed in the reusable workflow; this PR extends it to the main pipeline.