### PR TITLE
fix: make install-ai-tools agentic inputs optional

### DIFF
--- a/.github/actions/install-ai-tools/action.yml
+++ b/.github/actions/install-ai-tools/action.yml
@@ -13,11 +13,13 @@ inputs:
     required: false
     default: 'latest'
   agentic-version:
-    description: 'gh-agentic extension version to install (e.g. v1.2.3). Must match AGENTIC_FRAMEWORK_VERSION.'
-    required: true
+    description: 'gh-agentic extension version to install (e.g. v1.2.3). Must match AGENTIC_FRAMEWORK_VERSION. When empty, the extension install is skipped — use this for workflows (e.g. release notes) that do not need the framework mounted.'
+    required: false
+    default: ''
   gh-token:
-    description: 'GitHub token used to install the gh-agentic extension from a private/release context.'
-    required: true
+    description: 'GitHub token used to install the gh-agentic extension. Required when agentic-version is set.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -102,13 +104,14 @@ runs:
         echo "${{ runner.tool_cache }}/claude-cli/bin" >> $GITHUB_PATH
 
     - name: Install gh-agentic extension
+      if: inputs.agentic-version != ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.gh-token }}
         AGENTIC_VERSION: ${{ inputs.agentic-version }}
       run: |
-        if [ -z "${AGENTIC_VERSION}" ]; then
-          echo "::error::agentic-version input is empty. Pass the resolved AGENTIC_FRAMEWORK_VERSION."
+        if [ -z "${GH_TOKEN}" ]; then
+          echo "::error::gh-token input is required when agentic-version is set."
           exit 1
         fi
         echo "Installing gh-agentic extension pinned to ${AGENTIC_VERSION}..."


### PR DESCRIPTION
## Summary

Hotfix for the v2.2.2 release-notes workflow failure. PR #609 made `agentic-version` and `gh-token` required inputs on `install-ai-tools`, which broke `release.yml` — it calls the composite action without those inputs because the release-notes recipe does not need `.ai/` mounted.

## Change

- `agentic-version` and `gh-token` are now optional (default `''`).
- The "Install gh-agentic extension" step runs only when `agentic-version` is set.
- `gh-token` is validated when `agentic-version` is set, so the failure mode is clear.

## Risk

- Pipeline workflows that do pass both inputs behave identically.
- Release workflow now passes through the install step without installing the extension.

## Test plan

- [ ] Release-notes workflow re-runs cleanly on v2.2.2 after merge.
- [ ] Agentic pipeline still installs the extension when triggered.