### PR TITLE
fix: port recipe-dispatch jobs into reusable workflow

### DIFF
--- a/.github/workflows/agentic-pipeline-reusable.yml
+++ b/.github/workflows/agentic-pipeline-reusable.yml
@@ -1,9 +1,15 @@
 name: Agentic Pipeline (Reusable)
 
-# This is the v2 reusable workflow. Domain repos call this from their
-# wrapper workflows. It reads AGENTIC_FRAMEWORK_VERSION from the domain
-# repo's Actions variables, mounts the framework at that version, and
-# runs the pipeline.
+# v2 reusable workflow. Domain repos call this from their wrapper workflows.
+# Reads AGENTIC_FRAMEWORK_VERSION from the domain repo's Actions variables,
+# mounts the framework at that version, selects the right recipe based on the
+# triggering event, and runs it via Goose.
+#
+# Mirrors the job structure of agentic-pipeline.yml (used by gh-agentic itself)
+# adapted for the "called from a domain repo" context: gh-agentic is
+# nested-checked-out into .agentic-tools/ so composite actions resolve, and
+# the framework is mounted via direct git clone (no dependency on the
+# gh-agentic extension being installed at mount time).
 
 on:
   workflow_call:
@@ -14,18 +20,28 @@ on:
         required: true
 
 jobs:
-  mount-and-run:
-    name: Mount Framework & Run Pipeline
+
+  # ---------------------------------------------------------------------------
+  # Stage 3 — Feature Design
+  # Trigger: feature issue labelled 'in-design'
+  # ---------------------------------------------------------------------------
+  feature-design:
+    name: Feature Design (Stage 3)
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'labeled' &&
+      contains(github.event.issue.labels.*.name, 'feature') &&
+      github.event.label.name == 'in-design'
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
     permissions:
       contents: write
       issues: write
-      pull-requests: write
 
     steps:
       - name: Checkout domain repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GOOSE_AGENT_PAT }}
 
@@ -35,19 +51,13 @@ jobs:
           AGENTIC_FRAMEWORK_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
         run: |
           if [ -z "${AGENTIC_FRAMEWORK_VERSION}" ]; then
-            echo "::error::AGENTIC_FRAMEWORK_VERSION is not set. Run 'gh agentic mount <version>' on the control plane to pin the framework version."
+            echo "::error::AGENTIC_FRAMEWORK_VERSION is not set. Set the repo variable to pin the framework version."
             exit 1
           fi
           VERSION=$(echo "${AGENTIC_FRAMEWORK_VERSION}" | tr -d '[:space:]')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Framework version: ${VERSION}"
 
       - name: Checkout gh-agentic tools
-        # Composite actions live in eddiecarpenter/gh-agentic. When this
-        # reusable workflow runs in a domain repo, `./.github/actions/*`
-        # paths resolve against the domain repo's workspace (not this repo),
-        # so the actions must be fetched alongside. Pinned to the same
-        # version as the framework to keep tooling and skills in lockstep.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: eddiecarpenter/gh-agentic
@@ -67,12 +77,6 @@ jobs:
           gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
 
       - name: Mount AI framework
-        # Mount via direct git clone rather than `gh agentic mount`. The CLI
-        # does exactly this (`git clone --depth 1 --branch <tag>`) plus a
-        # .gitignore touch-up — inlining removes a dependency on the
-        # extension being installed and usable at this point in the job, and
-        # keeps the mount step purely declarative. The extension is still
-        # installed by the preceding step for any recipes that need it.
         env:
           FRAMEWORK_VERSION: ${{ steps.version.outputs.version }}
           FRAMEWORK_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
@@ -82,13 +86,11 @@ jobs:
           git clone --depth 1 --branch "${FRAMEWORK_VERSION}" \
             "https://x-access-token:${FRAMEWORK_TOKEN}@github.com/eddiecarpenter/gh-agentic.git" \
             .ai
-          # Keep .ai/ out of the domain repo's tracked tree. Idempotent —
-          # most domain repos already have the entry.
           if ! grep -qxF '.ai/' .gitignore 2>/dev/null; then
             echo '.ai/' >> .gitignore
           fi
+          # Recipes are consumed from .ai/.goose/recipes/ — no separate copy.
           echo "✓ Framework mounted at .ai/ (ref: $(git -C .ai describe --tags --exact-match 2>/dev/null || echo 'unknown'))"
-          ls -la .ai/
 
       - name: Setup Claude Code auth
         uses: ./.agentic-tools/.github/actions/setup-claude-auth
@@ -109,6 +111,619 @@ jobs:
           GOOSE_MODEL: ${{ vars.GOOSE_MODEL || 'default' }}
           GOOSEEOF
 
-      # The actual pipeline job dispatch happens in the domain repo's wrapper
-      # workflow which calls this reusable workflow. The domain repo's wrapper
-      # passes the event context through.
+      - name: Run feature-design recipe
+        run: |
+          goose run \
+            --recipe .ai/.goose/recipes/feature-design.yaml \
+            --params feature_issue=${{ github.event.issue.number }} \
+            --params repo=${{ github.repository }}
+        env:
+          GOOSE_PATH_ROOT: ${{ github.workspace }}/.ai/.goose
+          GOOSE_PROVIDER: ${{ vars.GOOSE_PROVIDER || 'claude-code' }}
+          GOOSE_MODEL: ${{ vars.GOOSE_MODEL || 'default' }}
+          GOOSE_MODE: auto
+          GOOSE_DISABLE_SESSION_NAMING: "true"
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+
+  # ---------------------------------------------------------------------------
+  # Stage 4 — Dev Session
+  # Trigger: feature issue labelled 'in-development'
+  # ---------------------------------------------------------------------------
+  dev-session:
+    name: Dev Session (Stage 4)
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'labeled' &&
+      contains(github.event.issue.labels.*.name, 'feature') &&
+      github.event.label.name == 'in-development'
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Resolve feature branch
+        id: branch
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          BRANCH=$(curl --proto '=https' --tlsv1.2 -fsSL \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/branches?per_page=100" \
+            | jq -r ".[].name | select(startswith(\"feature/${ISSUE}-\"))" \
+            | head -1)
+          if [ -z "$BRANCH" ]; then
+            echo "No branch found matching feature/${ISSUE}-*"
+            exit 1
+          fi
+          echo "name=$BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Checkout domain repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ steps.branch.outputs.name }}
+          fetch-depth: 0
+          token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Resolve framework version
+        id: version
+        env:
+          AGENTIC_FRAMEWORK_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+        run: |
+          if [ -z "${AGENTIC_FRAMEWORK_VERSION}" ]; then
+            echo "::error::AGENTIC_FRAMEWORK_VERSION is not set. Set the repo variable to pin the framework version."
+            exit 1
+          fi
+          VERSION=$(echo "${AGENTIC_FRAMEWORK_VERSION}" | tr -d '[:space:]')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Checkout gh-agentic tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: eddiecarpenter/gh-agentic
+          ref: ${{ steps.version.outputs.version }}
+          path: .agentic-tools
+          token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 'lts/*'
+
+      - name: Install tools
+        uses: ./.agentic-tools/.github/actions/install-ai-tools
+        with:
+          agentic-version: ${{ steps.version.outputs.version }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Mount AI framework
+        env:
+          FRAMEWORK_VERSION: ${{ steps.version.outputs.version }}
+          FRAMEWORK_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          echo "Mounting framework ${FRAMEWORK_VERSION} into .ai/ via git clone..."
+          rm -rf .ai
+          git clone --depth 1 --branch "${FRAMEWORK_VERSION}" \
+            "https://x-access-token:${FRAMEWORK_TOKEN}@github.com/eddiecarpenter/gh-agentic.git" \
+            .ai
+          if ! grep -qxF '.ai/' .gitignore 2>/dev/null; then
+            echo '.ai/' >> .gitignore
+          fi
+          echo "✓ Framework mounted at .ai/"
+
+      - name: Setup Claude Code auth
+        uses: ./.agentic-tools/.github/actions/setup-claude-auth
+        with:
+          claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Configure environment
+        run: |
+          git config user.name "${{ vars.AGENT_USER }}"
+          git config user.email "${{ vars.AGENT_USER }}@users.noreply.github.com"
+
+      - name: Rebase feature branch onto main
+        run: |
+          git fetch origin main
+          git rebase origin/main || {
+            echo "::error::Rebase failed — conflicts require manual resolution."
+            git diff --name-only --diff-filter=U
+            git rebase --abort
+            exit 1
+          }
+          git push origin HEAD:${{ steps.branch.outputs.name }} --force-with-lease
+
+      - name: Configure Goose
+        run: |
+          mkdir -p ~/.config/goose
+          cat > ~/.config/goose/config.yaml <<GOOSEEOF
+          GOOSE_PROVIDER: ${{ vars.GOOSE_PROVIDER || 'claude-code' }}
+          GOOSE_MODEL: ${{ vars.GOOSE_MODEL || 'default' }}
+          GOOSEEOF
+
+      - name: Run dev-session recipe
+        id: goose
+        run: |
+          BRANCH="${{ steps.branch.outputs.name }}"
+          for attempt in 1 2 3; do
+            echo "--- Dev session attempt ${attempt} ---"
+            goose run \
+              --recipe .ai/.goose/recipes/dev-session.yaml \
+              --params feature_issue=${{ github.event.issue.number }} \
+              --params branch_name=${BRANCH} \
+              --params repo=${{ github.repository }} && break
+            EXIT_CODE=$?
+            if [ $attempt -lt 3 ]; then
+              echo "Attempt ${attempt} failed (exit ${EXIT_CODE}). Waiting 60s before retry..."
+              sleep 60
+            else
+              exit $EXIT_CODE
+            fi
+          done
+        env:
+          GOOSE_PATH_ROOT: ${{ github.workspace }}/.ai/.goose
+          GOOSE_PROVIDER: ${{ vars.GOOSE_PROVIDER || 'claude-code' }}
+          GOOSE_MODEL: ${{ vars.GOOSE_MODEL || 'default' }}
+          GOOSE_MODE: auto
+          GOOSE_DISABLE_SESSION_NAMING: "true"
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Push branch
+        if: success()
+        run: git push origin ${{ steps.branch.outputs.name }}
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Open PR
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          BRANCH="${{ steps.branch.outputs.name }}"
+          COMMITS=$(git rev-list --count origin/main..HEAD)
+          if [ "${COMMITS}" -eq 0 ]; then
+            echo "No commits on ${BRANCH} beyond main — nothing to PR. Skipping."
+            exit 0
+          fi
+          gh pr create \
+            --title "feat: ${ISSUE_TITLE}" \
+            --body "Closes #${ISSUE_NUMBER}" \
+            --base main \
+            --head ${BRANCH}
+
+      - name: Apply in-review label and set project status
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
+        run: |
+          COMMITS=$(git rev-list --count origin/main..HEAD)
+          if [ "${COMMITS}" -eq 0 ]; then
+            echo "No commits — leaving issue in-development."
+            exit 0
+          fi
+          gh issue edit ${{ github.event.issue.number }} \
+            --remove-label "in-development" \
+            --add-label "in-review"
+
+          if [ -z "${AGENTIC_PROJECT_ID}" ]; then
+            echo "ERROR: AGENTIC_PROJECT_ID is not configured."
+            exit 1
+          fi
+          ISSUE_NODE_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }} --jq '.node_id')
+          RESULT=$(gh api graphql -f query='query($issueId: ID!) { node(id: $issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }' -f issueId="${ISSUE_NODE_ID}")
+          ITEM_ID=$(echo "${RESULT}" | jq -r --arg pid "${AGENTIC_PROJECT_ID}" '.data.node.projectItems.nodes[] | select(.project.id == $pid) | .id')
+          if [ -z "${ITEM_ID}" ]; then
+            ADD_RESULT=$(gh api graphql -f query='mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) { item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f contentId="${ISSUE_NODE_ID}")
+            ITEM_ID=$(echo "${ADD_RESULT}" | jq -r '.data.addProjectV2ItemById.item.id')
+          fi
+          FIELDS=$(gh api graphql -f query='query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }' -f projectId="${AGENTIC_PROJECT_ID}")
+          FIELD_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+          OPTION_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "In Review") | .id')
+          gh api graphql -f query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { projectV2Item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f itemId="${ITEM_ID}" -f fieldId="${FIELD_ID}" -f optionId="${OPTION_ID}"
+
+  # ---------------------------------------------------------------------------
+  # Stage 4b — PR Review Session
+  # Trigger: PR review submitted (comments or changes requested)
+  # ---------------------------------------------------------------------------
+  pr-review-session:
+    name: PR Review Session (Stage 4b)
+    if: |
+      github.event_name == 'workflow_dispatch' || (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.user.login != vars.AGENT_USER &&
+        startsWith(github.event.pull_request.head.ref, 'feature/') &&
+        (github.event.review.state == 'commented' || github.event.review.state == 'changes_requested')
+      )
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: pr-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout domain repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Resolve framework version
+        id: version
+        env:
+          AGENTIC_FRAMEWORK_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+        run: |
+          if [ -z "${AGENTIC_FRAMEWORK_VERSION}" ]; then
+            echo "::error::AGENTIC_FRAMEWORK_VERSION is not set."
+            exit 1
+          fi
+          VERSION=$(echo "${AGENTIC_FRAMEWORK_VERSION}" | tr -d '[:space:]')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Checkout gh-agentic tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: eddiecarpenter/gh-agentic
+          ref: ${{ steps.version.outputs.version }}
+          path: .agentic-tools
+          token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 'lts/*'
+
+      - name: Install tools
+        uses: ./.agentic-tools/.github/actions/install-ai-tools
+        with:
+          agentic-version: ${{ steps.version.outputs.version }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Mount AI framework
+        env:
+          FRAMEWORK_VERSION: ${{ steps.version.outputs.version }}
+          FRAMEWORK_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          echo "Mounting framework ${FRAMEWORK_VERSION} into .ai/ via git clone..."
+          rm -rf .ai
+          git clone --depth 1 --branch "${FRAMEWORK_VERSION}" \
+            "https://x-access-token:${FRAMEWORK_TOKEN}@github.com/eddiecarpenter/gh-agentic.git" \
+            .ai
+          if ! grep -qxF '.ai/' .gitignore 2>/dev/null; then
+            echo '.ai/' >> .gitignore
+          fi
+
+      - name: Setup Claude Code auth
+        uses: ./.agentic-tools/.github/actions/setup-claude-auth
+        with:
+          claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Configure environment
+        run: |
+          git config user.name "${{ vars.AGENT_USER }}"
+          git config user.email "${{ vars.AGENT_USER }}@users.noreply.github.com"
+
+      - name: Configure Goose
+        run: |
+          mkdir -p ~/.config/goose
+          cat > ~/.config/goose/config.yaml <<GOOSEEOF
+          GOOSE_PROVIDER: ${{ vars.GOOSE_PROVIDER || 'claude-code' }}
+          GOOSE_MODEL: ${{ vars.GOOSE_MODEL || 'default' }}
+          GOOSEEOF
+
+      - name: Run PR review recipe
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+          BRANCH: ${{ github.event.inputs.branch_name || github.event.pull_request.head.ref }}
+          GOOSE_PATH_ROOT: ${{ github.workspace }}/.ai/.goose
+          GOOSE_PROVIDER: ${{ vars.GOOSE_PROVIDER || 'claude-code' }}
+          GOOSE_MODEL: ${{ vars.GOOSE_MODEL || 'default' }}
+          GOOSE_MODE: auto
+          GOOSE_DISABLE_SESSION_NAMING: "true"
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          goose run \
+            --recipe .ai/.goose/recipes/pr-review-session.yaml \
+            --params pr_number=${PR_NUMBER} \
+            --params branch_name=${BRANCH} \
+            --params repo=${{ github.repository }}
+
+      - name: Push fixes
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          BRANCH: ${{ github.event.inputs.branch_name || github.event.pull_request.head.ref }}
+        run: |
+          LOCAL=$(git rev-parse HEAD)
+          REMOTE=$(git rev-parse origin/${BRANCH})
+          if [ "$LOCAL" != "$REMOTE" ]; then
+            git push origin ${BRANCH}
+          else
+            echo "No code changes — only review replies posted"
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Stage 4c — Issue Session
+  # Trigger: issue assigned to the agent user
+  # ---------------------------------------------------------------------------
+  issue-session:
+    name: Issue Session (Stage 4c)
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'assigned' &&
+      github.event.assignee.login == vars.AGENT_USER
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    concurrency:
+      group: issue-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout domain repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Resolve framework version
+        id: version
+        env:
+          AGENTIC_FRAMEWORK_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+        run: |
+          if [ -z "${AGENTIC_FRAMEWORK_VERSION}" ]; then
+            echo "::error::AGENTIC_FRAMEWORK_VERSION is not set."
+            exit 1
+          fi
+          VERSION=$(echo "${AGENTIC_FRAMEWORK_VERSION}" | tr -d '[:space:]')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Checkout gh-agentic tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: eddiecarpenter/gh-agentic
+          ref: ${{ steps.version.outputs.version }}
+          path: .agentic-tools
+          token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 'lts/*'
+
+      - name: Install tools
+        uses: ./.agentic-tools/.github/actions/install-ai-tools
+        with:
+          agentic-version: ${{ steps.version.outputs.version }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Mount AI framework
+        env:
+          FRAMEWORK_VERSION: ${{ steps.version.outputs.version }}
+          FRAMEWORK_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          echo "Mounting framework ${FRAMEWORK_VERSION} into .ai/ via git clone..."
+          rm -rf .ai
+          git clone --depth 1 --branch "${FRAMEWORK_VERSION}" \
+            "https://x-access-token:${FRAMEWORK_TOKEN}@github.com/eddiecarpenter/gh-agentic.git" \
+            .ai
+          if ! grep -qxF '.ai/' .gitignore 2>/dev/null; then
+            echo '.ai/' >> .gitignore
+          fi
+
+      - name: Setup Claude Code auth
+        uses: ./.agentic-tools/.github/actions/setup-claude-auth
+        with:
+          claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
+          gh-token: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Configure environment
+        run: |
+          git config user.name "${{ vars.AGENT_USER }}"
+          git config user.email "${{ vars.AGENT_USER }}@users.noreply.github.com"
+
+      - name: Configure Goose
+        run: |
+          mkdir -p ~/.config/goose
+          cat > ~/.config/goose/config.yaml <<GOOSEEOF
+          GOOSE_PROVIDER: ${{ vars.GOOSE_PROVIDER || 'claude-code' }}
+          GOOSE_MODEL: ${{ vars.GOOSE_MODEL || 'default' }}
+          GOOSEEOF
+
+      - name: Run issue session recipe
+        run: |
+          goose run \
+            --recipe .ai/.goose/recipes/issue-session.yaml \
+            --params issue_number=${{ github.event.issue.number }} \
+            --params repo=${{ github.repository }}
+        env:
+          GOOSE_PATH_ROOT: ${{ github.workspace }}/.ai/.goose
+          GOOSE_PROVIDER: ${{ vars.GOOSE_PROVIDER || 'claude-code' }}
+          GOOSE_MODEL: ${{ vars.GOOSE_MODEL || 'default' }}
+          GOOSE_MODE: auto
+          GOOSE_DISABLE_SESSION_NAMING: "true"
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+
+      - name: Push fix branch
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          BRANCH=$(git branch --show-current)
+          if [[ "${BRANCH}" == fix/issue-* ]]; then
+            git push origin ${BRANCH}
+          else
+            echo "No fix branch — question answered or issue skipped"
+          fi
+
+      - name: Open PR
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          BRANCH=$(git branch --show-current)
+          if [[ "${BRANCH}" == fix/issue-* ]]; then
+            ISSUE_TITLE=$(gh issue view ${{ github.event.issue.number }} \
+              --repo ${{ github.repository }} --json title --jq '.title')
+            gh pr create \
+              --title "fix: ${ISSUE_TITLE}" \
+              --body "Fixes #${{ github.event.issue.number }}" \
+              --base main \
+              --head ${BRANCH}
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Stage 5 — Feature Complete
+  # Trigger: feature branch PR merged to main
+  # ---------------------------------------------------------------------------
+  feature-complete:
+    name: Feature Complete (Stage 5)
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'feature/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: Extract feature issue number
+        id: feature
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          BRANCH="${PR_HEAD_REF}"
+          ISSUE_NUMBER=$(echo "${BRANCH}" | sed 's|feature/\([0-9]*\)-.*|\1|')
+          echo "issue_number=${ISSUE_NUMBER}" >> $GITHUB_OUTPUT
+
+      - name: Apply done label, set project status, and close feature issue
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
+        run: |
+          ISSUE="${{ steps.feature.outputs.issue_number }}"
+          if [ -z "${ISSUE}" ]; then
+            echo "Could not extract issue number from branch — skipping"
+            exit 0
+          fi
+          ISSUE_TYPE=$(gh api repos/${{ github.repository }}/issues/${ISSUE} --jq '.pull_request // "issue"' 2>/dev/null || echo "")
+          if [ -z "${ISSUE_TYPE}" ] || [ "${ISSUE_TYPE}" != "issue" ]; then
+            echo "Issue #${ISSUE} is not an open feature issue — skipping"
+            exit 0
+          fi
+          gh issue edit ${ISSUE} \
+            --repo ${{ github.repository }} \
+            --remove-label "backlog" \
+            --remove-label "in-design" \
+            --remove-label "in-development" \
+            --remove-label "in-review" \
+            --add-label "done"
+
+          if [ -z "${AGENTIC_PROJECT_ID}" ]; then
+            echo "ERROR: AGENTIC_PROJECT_ID is not configured."
+            exit 1
+          fi
+          ISSUE_NODE_ID=$(gh api repos/${{ github.repository }}/issues/${ISSUE} --jq '.node_id')
+          RESULT=$(gh api graphql -f query='query($issueId: ID!) { node(id: $issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }' -f issueId="${ISSUE_NODE_ID}")
+          ITEM_ID=$(echo "${RESULT}" | jq -r --arg pid "${AGENTIC_PROJECT_ID}" '.data.node.projectItems.nodes[] | select(.project.id == $pid) | .id')
+          if [ -z "${ITEM_ID}" ]; then
+            ADD_RESULT=$(gh api graphql -f query='mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) { item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f contentId="${ISSUE_NODE_ID}")
+            ITEM_ID=$(echo "${ADD_RESULT}" | jq -r '.data.addProjectV2ItemById.item.id')
+          fi
+          FIELDS=$(gh api graphql -f query='query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }' -f projectId="${AGENTIC_PROJECT_ID}")
+          FIELD_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+          OPTION_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id')
+          gh api graphql -f query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { projectV2Item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f itemId="${ITEM_ID}" -f fieldId="${FIELD_ID}" -f optionId="${OPTION_ID}"
+
+          gh issue close ${ISSUE} \
+            --repo ${{ github.repository }} \
+            --comment "Feature implemented and merged via PR #${{ github.event.pull_request.number }}."
+
+      - name: Parse parent requirement
+        id: parent
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+        run: |
+          ISSUE="${{ steps.feature.outputs.issue_number }}"
+          if [ -z "${ISSUE}" ]; then
+            exit 0
+          fi
+          AGENTIC_REPO="${{ vars.AGENTIC_REPO || github.repository }}"
+          BODY=$(gh issue view ${ISSUE} --repo ${{ github.repository }} --json body --jq '.body')
+          PARENT=$(echo "${BODY}" | \
+            grep -oP '(?:Closes(?:\s+part\s+of)?\s+(?:[a-zA-Z0-9_.\-]+/[a-zA-Z0-9_.\-]+#|#))(\d+)' | \
+            grep -oP '\d+$' | head -1)
+          if [ -z "${PARENT}" ]; then
+            exit 0
+          fi
+          HAS_LABEL=$(gh issue view ${PARENT} --repo ${AGENTIC_REPO} --json labels \
+            --jq '.labels[].name' | grep -c '^requirement$' || true)
+          if [ "${HAS_LABEL}" -eq 0 ]; then
+            exit 0
+          fi
+          echo "requirement_number=${PARENT}" >> $GITHUB_OUTPUT
+          echo "agentic_repo=${AGENTIC_REPO}" >> $GITHUB_OUTPUT
+
+      - name: Auto-close parent requirement if all sub-issues complete
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
+        run: |
+          PARENT="${{ steps.parent.outputs.requirement_number }}"
+          AGENTIC_REPO="${{ steps.parent.outputs.agentic_repo }}"
+          if [ -z "${PARENT}" ]; then
+            exit 0
+          fi
+          REQ_NODE_ID=$(gh api repos/${AGENTIC_REPO}/issues/${PARENT} --jq '.node_id')
+          if [ -z "${REQ_NODE_ID}" ]; then
+            exit 0
+          fi
+          OPEN_COUNT=$(gh api graphql -f query='query($issueId: ID!) { node(id: $issueId) { ... on Issue { subIssues(first: 100) { nodes { state } } } } }' -f issueId="${REQ_NODE_ID}" \
+            --jq '[.data.node.subIssues.nodes[] | select(.state == "OPEN")] | length')
+          if [ "${OPEN_COUNT}" -gt 0 ]; then
+            echo "${OPEN_COUNT} sub-issue(s) still open — leaving requirement #${PARENT} open"
+            exit 0
+          fi
+          gh issue edit ${PARENT} \
+            --repo ${AGENTIC_REPO} \
+            --remove-label "backlog" \
+            --remove-label "scoping" \
+            --remove-label "scheduled" \
+            --add-label "done"
+          if [ -n "${AGENTIC_PROJECT_ID}" ]; then
+            RESULT=$(gh api graphql -f query='query($issueId: ID!) { node(id: $issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }' -f issueId="${REQ_NODE_ID}")
+            ITEM_ID=$(echo "${RESULT}" | jq -r --arg pid "${AGENTIC_PROJECT_ID}" '.data.node.projectItems.nodes[] | select(.project.id == $pid) | .id')
+            if [ -z "${ITEM_ID}" ]; then
+              ADD_RESULT=$(gh api graphql -f query='mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) { item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f contentId="${REQ_NODE_ID}")
+              ITEM_ID=$(echo "${ADD_RESULT}" | jq -r '.data.addProjectV2ItemById.item.id')
+            fi
+            FIELDS=$(gh api graphql -f query='query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }' -f projectId="${AGENTIC_PROJECT_ID}")
+            FIELD_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+            OPTION_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id')
+            gh api graphql -f query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { projectV2Item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f itemId="${ITEM_ID}" -f fieldId="${FIELD_ID}" -f optionId="${OPTION_ID}"
+          fi
+          gh issue close ${PARENT} \
+            --repo ${AGENTIC_REPO} \
+            --comment "All child feature issues are now complete. Auto-closing requirement."
+
+      - name: Delete feature branch
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          gh api repos/${{ github.repository }}/git/refs/heads/${HEAD_REF} --method DELETE
+          echo "Deleted branch ${HEAD_REF}"


### PR DESCRIPTION
## Summary

- Reusable workflow `agentic-pipeline-reusable.yml` was missing all recipe dispatch — it mounted the framework, configured Goose, then exited. Pipeline runs in domain repos were green but did nothing.
- Ports the 5 conditional jobs from `agentic-pipeline.yml` (feature-design, dev-session, pr-review-session, issue-session, feature-complete) into the reusable, each ending with the correct `goose run --recipe`.
- Adapts paths for the called-from-domain context: composite actions resolve via the nested `.agentic-tools/` checkout, and recipes run from `.ai/.goose/recipes/` after the framework is mounted via direct git clone.

## Detected by

`eddiecarpenter/ocs-testbench#22` (feature, `in-design`) triggered a pipeline run that completed successfully in 3m14s without decomposing the feature or producing any tasks — because no recipe ran. Same issue would have affected every domain repo calling `agentic-pipeline-reusable.yml@v2.2.4` (and earlier v2.x).

## Test plan

- [ ] Review YAML structure and job `if:` conditions match `agentic-pipeline.yml` intent
- [ ] Confirm `install-ai-tools` composite action works via nested checkout path `./.agentic-tools/.github/actions/install-ai-tools`
- [ ] Confirm `.ai/.goose/recipes/<recipe>.yaml` resolves correctly after git-clone mount
- [ ] After merge, tag `v2.2.5`
- [ ] Bump `AGENTIC_FRAMEWORK_VERSION=v2.2.5` on `eddiecarpenter/ocs-testbench` repo variable
- [ ] Re-trigger pipeline on `ocs-testbench#22` (remove + re-add `in-design` label) and confirm Goose runs the `feature-design` recipe and produces task sub-issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)