### PR TITLE
fix: feature-design workflow must push branch and swap label post-recipe

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -110,6 +110,123 @@ jobs:
           GOOSE_DISABLE_SESSION_NAMING: "true"
           GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
 
+      # Recipe never pushes — per RULEBOOK, "the workflow pushes after the
+      # recipe exits cleanly". The recipe creates `feature/<N>-*` locally
+      # and may have added commits (refactor tasks, scaffolding, etc.).
+      # Commit any leftover working-tree changes, then push the branch so
+      # Stage 4 can find it.
+      - name: Commit and push feature branch
+        id: push
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          BRANCH=$(git branch --list "feature/${ISSUE}-*" --format='%(refname:short)' | head -1)
+          if [ -z "${BRANCH}" ]; then
+            echo "::error::Feature Design recipe exited without creating a feature/${ISSUE}-* branch."
+            echo "Dev Session cannot proceed without the branch. Inspect the recipe log above."
+            exit 1
+          fi
+          echo "name=${BRANCH}" >> $GITHUB_OUTPUT
+          git checkout "${BRANCH}"
+          # Stage+commit any uncommitted work the recipe left behind (e.g. a
+          # refactor task that produced scaffolding). Empty working tree is
+          # fine — the commit is guarded by git diff-index.
+          git add -A
+          if ! git diff-index --quiet HEAD --; then
+            git commit -m "chore: feature-design scaffolding — feature #${ISSUE}"
+          else
+            echo "No working-tree changes to commit — branch is at main HEAD."
+          fi
+          git push --set-upstream origin "${BRANCH}"
+          echo "✓ Pushed ${BRANCH} to origin."
+
+      # The recipe attempts the in-design → in-development swap itself, but
+      # the agent's token can be denied that transition (seen in the wild as
+      # FORBIDDEN on AddLabelsToLabelable for fine-grained PATs). The workflow
+      # retries the swap here with the same PAT — if the recipe already swapped,
+      # this is a no-op; if it didn't, this is what triggers Stage 4.
+      - name: Swap in-design → in-development
+        if: success() && steps.push.outputs.name != ''
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          LABELS=$(gh issue view "${ISSUE}" --json labels --jq '[.labels[].name] | join(",")')
+          if echo ",${LABELS}," | grep -q ",in-development,"; then
+            echo "Issue #${ISSUE} already labelled in-development — swap already performed by recipe."
+            exit 0
+          fi
+          gh issue edit "${ISSUE}" \
+            --remove-label in-design \
+            --add-label in-development
+          echo "✓ Swapped in-design → in-development on #${ISSUE} (will trigger Dev Session)."
+
+      # Inline project status update — mirror the dev-session pattern so
+      # Stage 3 also keeps the project board in lockstep with the label.
+      # Hard-fails on missing AGENTIC_PROJECT_ID to surface misconfiguration.
+      - name: Set project status to 'In Development'
+        if: success() && steps.push.outputs.name != ''
+        env:
+          GH_TOKEN: ${{ secrets.GOOSE_AGENT_PAT }}
+          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "${AGENTIC_PROJECT_ID}" ]; then
+            echo "::error::AGENTIC_PROJECT_ID is not configured. Set the repo variable to the ProjectV2 node ID."
+            exit 1
+          fi
+          ISSUE_NODE_ID=$(gh api "repos/${REPO}/issues/${ISSUE}" --jq '.node_id')
+          RESULT=$(gh api graphql -f query='
+            query($issueId: ID!) {
+              node(id: $issueId) {
+                ... on Issue {
+                  projectItems(first: 100) { nodes { id project { id } } }
+                }
+              }
+            }
+          ' -f issueId="${ISSUE_NODE_ID}")
+          ITEM_ID=$(echo "${RESULT}" | jq -r --arg pid "${AGENTIC_PROJECT_ID}" \
+            '.data.node.projectItems.nodes[] | select(.project.id == $pid) | .id')
+          if [ -z "${ITEM_ID}" ]; then
+            ADD_RESULT=$(gh api graphql -f query='
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item { id }
+                }
+              }
+            ' -f projectId="${AGENTIC_PROJECT_ID}" -f contentId="${ISSUE_NODE_ID}")
+            ITEM_ID=$(echo "${ADD_RESULT}" | jq -r '.data.addProjectV2ItemById.item.id')
+          fi
+          FIELDS=$(gh api graphql -f query='
+            query($projectId: ID!) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  fields(first: 50) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id name options { id name }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ' -f projectId="${AGENTIC_PROJECT_ID}")
+          FIELD_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+          OPTION_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "In Development") | .id')
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+                value: { singleSelectOptionId: $optionId }
+              }) { projectV2Item { id } }
+            }
+          ' -f projectId="${AGENTIC_PROJECT_ID}" -f itemId="${ITEM_ID}" -f fieldId="${FIELD_ID}" -f optionId="${OPTION_ID}"
+          echo "✓ Project status set to 'In Development'."
+
   # ---------------------------------------------------------------------------
   # Stage 4 — Dev Session
   # Trigger: feature issue labelled 'in-development'


### PR DESCRIPTION
## Summary

The Feature Design (Stage 3) job ends immediately after the goose recipe exits. Per RULEBOOK — *"the workflow pushes after the recipe exits cleanly"* — but no push step existed, and the pipeline depended on the recipe to apply `in-development` itself to trigger Stage 4.

On `ocs-testbench` today: the recipe completed and created all 9 task sub-issues correctly, then its `gh issue edit --add-label in-development` call failed with `FORBIDDEN on AddLabelsToLabelable`. The feature branch was never pushed to origin. Dev Session sat idle for an hour until a human manually swapped the labels and dev-session fired on the label event.

## What changes

Three new steps at the end of the `feature-design` job:

1. **Commit and push feature branch.** Detect `feature/<N>-*` locally, commit any leftover working-tree changes, `git push --set-upstream origin`. Hard-fails if the recipe exited without creating a feature branch — that's a recipe bug and Stage 4 cannot proceed without it.
2. **Swap `in-design → in-development`, idempotently.** Skips if the recipe already did it; otherwise performs the swap. This is what triggers Stage 4.
3. **Set project status to 'In Development'.** Mirrors the existing dev-session → in-review project-status sequence in the same workflow, so the board stays in lockstep with labels.

## Why in the workflow, not the recipe

- The RULEBOOK explicitly places push + label-swap in the workflow, not the recipe. Stage 3 was the only stage not following that rule.
- The recipe's token may be denied label-apply on a given repo even when the workflow's token can do it (different env surface, PAT scope variants). The workflow step is the reliable path.
- The recipe's existing attempt is kept as a best-effort — the idempotency check makes the workflow step a no-op when the recipe succeeded.

## Why inline, not a composite action

Per the recent v2.2.3–v2.2.4 hot-fixes, GitHub Actions cannot compose composite actions across repos via relative paths. Inline steps are the robust path today. A future refactor could extract the project-status GraphQL block into a composite action once the composition story is sorted.

## Post-merge steps

1. Cut **v2.2.5** — wait, v2.2.5 already exists (released earlier today). This should be **v2.2.6**.
2. `gh variable set AGENTIC_FRAMEWORK_VERSION --repo eddiecarpenter/gh-agentic --body v2.2.6`
3. Bump on any domain repo that needs the fix.

## Test plan

- [x] `go build ./... && go test ./...` green
- [x] YAML parses and structure intact (12 steps in feature-design, new ones in the right order)
- [ ] Merge, release, bump a domain repo, trigger a Feature Design run, confirm the feature branch appears on origin and Stage 4 fires automatically

## Context

- Observed failure on eddiecarpenter/ocs-testbench feature #22 today — design ran successfully at 07:37Z, dev-session did not trigger until a human manually swapped labels at 08:38Z.
- Does **not** address the underlying PAT-permission issue on ocs-testbench that prevents `goose-agent` from applying labels via the recipe — that's a repo-level collaborator grant for the user to fix. But with this change the workflow step (using the same PAT surface the repo's own workflows already rely on) takes care of the swap regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)