### PR TITLE
fix: upgrade must write AGENTIC_FRAMEWORK_VERSION on every topology

### DIFF
--- a/internal/project/switch.go
+++ b/internal/project/switch.go
@@ -65,38 +65,43 @@ func PreflightSwitchVersion(deps Deps, version string) (SwitchVersionPreflight, 
 
 // SwitchVersion upgrades or downgrades the framework version using pre-resolved
 // preflight data to avoid duplicate API calls.
+//
+// AGENTIC_FRAMEWORK_VERSION is the authoritative version the pipeline
+// and `check`/`info` read. `create` (init) and `repair` both write it
+// unconditionally — `SwitchVersion` does the same so upgrade leaves no
+// drift between the mounted `.ai/` tree, the workflow file versions, and
+// the repo variable. Single topology uses the variable locally; a
+// federated control plane broadcasts it to domain repos. Either way it
+// must be written.
 func SwitchVersion(w io.Writer, deps Deps, version string, pre SwitchVersionPreflight, confirm func(string) (bool, error)) error {
-	if pre.CurrentVersion == version {
-		fmt.Fprintf(w, "  %s  Framework is already at %s\n", ui.StatusOK.Render("✓"), version)
-		// Still ensure AGENTIC_FRAMEWORK_VERSION is set if missing on a federated CP.
-		if pre.IsFederatedCP {
-			existing, _ := deps.GetRepoVariable(deps.Owner, deps.RepoName, FrameworkVersionVarName)
-			if existing != version {
-				if err := deps.SetRepoVariable(deps.Owner, deps.RepoName, FrameworkVersionVarName, version); err != nil {
-					return fmt.Errorf("updating %s: %w", FrameworkVersionVarName, err)
-				}
-				fmt.Fprintf(w, "  %s  %s set to %s — domain repos will sync on next mount\n",
-					ui.StatusOK.Render("✓"), FrameworkVersionVarName, version)
-			}
+	writeVariable := func() error {
+		existing, _ := deps.GetRepoVariable(deps.Owner, deps.RepoName, FrameworkVersionVarName)
+		if existing == version {
+			return nil
 		}
+		if err := deps.SetRepoVariable(deps.Owner, deps.RepoName, FrameworkVersionVarName, version); err != nil {
+			return fmt.Errorf("updating %s: %w", FrameworkVersionVarName, err)
+		}
+		suffix := ""
+		if pre.IsFederatedCP {
+			suffix = " — domain repos will sync on next mount"
+		}
+		fmt.Fprintf(w, "  %s  %s set to %s%s\n",
+			ui.StatusOK.Render("✓"), FrameworkVersionVarName, version, suffix)
 		return nil
 	}
 
-	// Switch framework version.
+	if pre.CurrentVersion == version {
+		fmt.Fprintf(w, "  %s  Framework is already at %s\n", ui.StatusOK.Render("✓"), version)
+		return writeVariable()
+	}
+
+	// Switch framework version (mount the new version).
 	if err := mount.RunSwitch(w, deps.Root, pre.CurrentVersion, version, deps.Clone, confirm); err != nil {
 		return err
 	}
 
-	// For federated control plane: update AGENTIC_FRAMEWORK_VERSION so domain repos pick it up.
-	if pre.IsFederatedCP {
-		if err := deps.SetRepoVariable(deps.Owner, deps.RepoName, FrameworkVersionVarName, version); err != nil {
-			return fmt.Errorf("updating %s: %w", FrameworkVersionVarName, err)
-		}
-		fmt.Fprintf(w, "  %s  %s updated to %s — domain repos will sync on next mount\n",
-			ui.StatusOK.Render("✓"), FrameworkVersionVarName, version)
-	}
-
-	return nil
+	return writeVariable()
 }
 
 // switchProjectListFederated returns only the federated projects available to the owner.

--- a/internal/project/switch_test.go
+++ b/internal/project/switch_test.go
@@ -1,0 +1,174 @@
+package project
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eddiecarpenter/gh-agentic/internal/mount"
+)
+
+// TestSwitchVersion_SetsFrameworkVersionVariable_SingleTopology covers the
+// v2.3.0 regression where `gh agentic upgrade` on a single-topology repo
+// updated the .ai/ mount and the workflow uses: refs but left
+// AGENTIC_FRAMEWORK_VERSION at the old value. Drift between the variable
+// and the mounted tree is immediately visible to `check` and to the
+// pipeline's own resolve-version step, which reads the variable. The
+// fix makes variable-writing unconditional — `create` and `repair`
+// already did this; `SwitchVersion` is now aligned.
+//
+// This test freezes the expected behaviour so the regression cannot
+// silently return.
+func TestSwitchVersion_SetsFrameworkVersionVariable_SingleTopology(t *testing.T) {
+	root := t.TempDir()
+
+	// Seed a fake mounted .ai/ at v2.2.6 so RunSwitch has something to
+	// describe as "current version".
+	aiDir := filepath.Join(root, ".ai")
+	if err := os.MkdirAll(aiDir, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Capture the variables the code writes.
+	writes := make(map[string]string)
+	reads := map[string]string{
+		TopologyVarName: "", // single topology — variable unset
+	}
+
+	deps := Deps{
+		Root:         root,
+		Owner:        "eddiecarpenter",
+		RepoName:     "ocs-testbench",
+		RepoFullName: "eddiecarpenter/ocs-testbench",
+		GetRepoVariable: func(owner, repo, name string) (string, error) {
+			return reads[name], nil
+		},
+		SetRepoVariable: func(owner, repo, name, value string) error {
+			writes[name] = value
+			return nil
+		},
+		// No-op clone — the test doesn't exercise mount.RunSwitch's
+		// clone logic, only the post-clone variable write. The stub
+		// lets RunSwitch believe the clone succeeded.
+		Clone: func(repoURL, tag, destDir string) error {
+			return os.MkdirAll(destDir, 0o755)
+		},
+	}
+
+	// CurrentVersion != version and IsFederatedCP: false — the exact
+	// case that was broken in v2.3.0.
+	pre := SwitchVersionPreflight{
+		CurrentVersion: "v2.2.6",
+		IsFederatedCP:  false,
+	}
+
+	var buf bytes.Buffer
+	if err := SwitchVersion(&buf, deps, "v2.3.0", pre, nil); err != nil {
+		// RunSwitch may fail if the stub clone does not produce the
+		// expected workflow file structure; tolerate that as long as
+		// the variable write happened (the bug was the write being
+		// skipped, not the clone).
+		t.Logf("SwitchVersion returned error (possibly from mount layer): %v", err)
+	}
+
+	if got := writes[FrameworkVersionVarName]; got != "v2.3.0" {
+		t.Errorf("%s variable must be updated on single-topology upgrade, got %q (want v2.3.0)",
+			FrameworkVersionVarName, got)
+	}
+}
+
+// TestSwitchVersion_SetsFrameworkVersionVariable_AlreadyAtTarget covers
+// the "already at version" path — variable must still be written if it
+// disagrees with the mounted version. This is the recovery case for a
+// repo whose .ai/ was mounted at the right version but whose variable
+// was never set (e.g. manual mount).
+func TestSwitchVersion_SetsFrameworkVersionVariable_AlreadyAtTarget(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	writes := make(map[string]string)
+	// Variable is absent — the bug case: user's repo has `.ai/` at
+	// v2.3.0 but AGENTIC_FRAMEWORK_VERSION has never been set.
+	reads := map[string]string{}
+
+	deps := Deps{
+		Root:         root,
+		Owner:        "eddiecarpenter",
+		RepoName:     "ocs-testbench",
+		RepoFullName: "eddiecarpenter/ocs-testbench",
+		GetRepoVariable: func(owner, repo, name string) (string, error) {
+			return reads[name], nil
+		},
+		SetRepoVariable: func(owner, repo, name, value string) error {
+			writes[name] = value
+			return nil
+		},
+	}
+
+	pre := SwitchVersionPreflight{
+		CurrentVersion: "v2.3.0",
+		IsFederatedCP:  false,
+	}
+
+	var buf bytes.Buffer
+	if err := SwitchVersion(&buf, deps, "v2.3.0", pre, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := writes[FrameworkVersionVarName]; got != "v2.3.0" {
+		t.Errorf("%s must be backfilled when mount already matches target, got %q",
+			FrameworkVersionVarName, got)
+	}
+}
+
+// TestSwitchVersion_SkipsVariableWrite_WhenAlreadyCorrect confirms the
+// guard against needless writes: if the variable is already at the
+// target value, no SetRepoVariable call is made. This is purely a
+// spam-reduction check so the output doesn't claim to have changed
+// something it hasn't.
+func TestSwitchVersion_SkipsVariableWrite_WhenAlreadyCorrect(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	writes := make(map[string]string)
+	reads := map[string]string{
+		FrameworkVersionVarName: "v2.3.0",
+	}
+
+	deps := Deps{
+		Root:         root,
+		Owner:        "eddiecarpenter",
+		RepoName:     "ocs-testbench",
+		RepoFullName: "eddiecarpenter/ocs-testbench",
+		GetRepoVariable: func(owner, repo, name string) (string, error) {
+			return reads[name], nil
+		},
+		SetRepoVariable: func(owner, repo, name, value string) error {
+			writes[name] = value
+			return nil
+		},
+	}
+
+	pre := SwitchVersionPreflight{CurrentVersion: "v2.3.0", IsFederatedCP: false}
+
+	var buf bytes.Buffer
+	if err := SwitchVersion(&buf, deps, "v2.3.0", pre, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, wrote := writes[FrameworkVersionVarName]; wrote {
+		t.Errorf("variable must not be rewritten when already at target; got write of %q",
+			writes[FrameworkVersionVarName])
+	}
+}
+
+// Compile-time assertion that the mount package is reachable from the
+// test binary — if this breaks, the import above may have been optimised
+// out by a future refactor and the test would silently stop covering
+// the SwitchVersion → RunSwitch path.
+var _ = mount.FrameworkRepo


### PR DESCRIPTION
## Summary

Hot-fix for a v2.3.0 regression.

**Bug:** On single-topology repos, `gh agentic upgrade`:
- ✅ Updates the local `.ai/` mount
- ✅ Updates workflow `uses:` refs (`agentic-pipeline.yml`, `release.yml`)
- ❌ Does **not** update the `AGENTIC_FRAMEWORK_VERSION` repo variable

**Root cause:** `SwitchVersion` in `internal/project/switch.go` gated the variable write on `pre.IsFederatedCP`, assuming single-topology repos didn't need it. They do — the pipeline's resolve-version step reads that variable to pin `uses:` refs, and `check` / `info` compare `.ai/.git` against it.

`create` (init path) and `repair` both write the variable unconditionally. `SwitchVersion` was the outlier.

**Fix:**

- Write `AGENTIC_FRAMEWORK_VERSION` unconditionally in both code paths (version-change and already-at-target).
- Skip the write (and the log line) when the variable already matches — no-spam guard.
- Preserve the "domain repos will sync on next mount" suffix for `IsFederatedCP`, drop it otherwise.

**Regression tests** (new `internal/project/switch_test.go`):

- Single-topology upgrade writes the variable
- Already-at-target upgrade backfills a missing variable
- Already-at-target-and-variable-already-correct skips the write

## Post-merge

1. Release **v2.3.1**
2. `gh variable set AGENTIC_FRAMEWORK_VERSION --repo eddiecarpenter/gh-agentic --body v2.3.1`
3. For any domain repo that already ran upgrade on v2.3.0 and has drifted: run `gh agentic upgrade <version>` again — the fix will write the variable. Or manually set it to match `.ai/.git`.

## Test plan

- [x] `go build ./...` + `go test ./...` green
- [x] Three new regression tests pass
- [ ] Merge, release v2.3.1, run `gh agentic upgrade` on this repo, confirm `AGENTIC_FRAMEWORK_VERSION` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)