### PR TITLE
fix: route Project v2 mutations through PROJECT_PAT (non-blocking)

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -2,6 +2,13 @@ name: Add Issue to Project
 
 # Automatically adds newly opened issues to the GitHub Project board
 # and sets their initial status based on pipeline labels.
+#
+# Authentication: uses PROJECT_PAT (not the agentic GitHub App). GitHub
+# Apps cannot mutate user-owned Projects v2 (platform limitation —
+# see docs/github-app-setup.md "PROJECT_PAT"). When PROJECT_PAT is
+# unset the workflow exits cleanly with a warning; when set but
+# invalid/expired, the mutating steps fail non-blockingly so the
+# stale PAT is visible without halting other automation.
 
 on:
   issues:
@@ -17,38 +24,42 @@ jobs:
 
     steps:
       # -----------------------------------------------------------------------
-      # Step 0 — Mint a GitHub App installation token
+      # Step 1 — Check that prerequisites are present
+      # Requires both AGENTIC_PROJECT_ID (variable) and PROJECT_PAT (secret).
+      # Either missing → skip cleanly with a warning so the workflow stays
+      # green; the rest of the pipeline does not depend on this sync.
       # -----------------------------------------------------------------------
-      - name: Mint GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
-        with:
-          app-id: ${{ vars.AGENTIC_APP_ID }}
-          private-key: ${{ secrets.AGENTIC_APP_PRIVATE_KEY }}
-
-      # -----------------------------------------------------------------------
-      # Step 1 — Check if project sync is configured
-      # Exit silently if AGENTIC_PROJECT_ID is not set (graceful no-op)
-      # -----------------------------------------------------------------------
-      - name: Check project configuration
+      - name: Check project sync prerequisites
         id: config
+        env:
+          PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
         run: |
           if [ -z "${{ vars.AGENTIC_PROJECT_ID }}" ]; then
-            echo "AGENTIC_PROJECT_ID not set — skipping project sync"
+            echo "::warning::AGENTIC_PROJECT_ID not set — skipping project sync"
             echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
+          if [ -z "${PROJECT_PAT}" ]; then
+            echo "::warning::PROJECT_PAT secret is not set — skipping project sync."
+            echo "::warning::To enable: create a PAT with user-level project read/write access, set it as PROJECT_PAT in repo secrets."
+            echo "::warning::Background: GitHub Apps cannot mutate user-owned Projects v2 (platform limit, see docs/github-app-setup.md)."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "skip=false" >> $GITHUB_OUTPUT
 
       # -----------------------------------------------------------------------
       # Step 2 — Add issue to project
-      # Uses addProjectV2ItemById mutation to add the issue to the board
+      # Uses addProjectV2ItemById mutation to add the issue to the board.
+      # continue-on-error so a stale/expired PAT shows red on this step
+      # but does not block the rest of GitHub Actions on the repo.
       # -----------------------------------------------------------------------
       - name: Add issue to project
         if: steps.config.outputs.skip != 'true'
         id: add
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
           ISSUE_NODE_ID="${{ github.event.issue.node_id }}"
           PROJECT_ID="${{ vars.AGENTIC_PROJECT_ID }}"
@@ -71,7 +82,7 @@ jobs:
           ITEM_ID=$(echo "${RESULT}" | jq -r '.data.addProjectV2ItemById.item.id')
 
           if [ -z "${ITEM_ID}" ] || [ "${ITEM_ID}" = "null" ]; then
-            echo "::error::Failed to add issue to project"
+            echo "::error::Failed to add issue to project (PROJECT_PAT may be invalid or expired)"
             exit 1
           fi
 
@@ -118,8 +129,9 @@ jobs:
       - name: Get status field and option
         if: steps.config.outputs.skip != 'true' && steps.add.outputs.item_id && steps.map.outputs.skip != 'true'
         id: field
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
           PROJECT_ID="${{ vars.AGENTIC_PROJECT_ID }}"
           TARGET_STATUS="${{ steps.map.outputs.status }}"
@@ -173,8 +185,9 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Update project status
         if: steps.config.outputs.skip != 'true' && steps.add.outputs.item_id && steps.map.outputs.skip != 'true' && steps.field.outputs.field_id
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
           PROJECT_ID="${{ vars.AGENTIC_PROJECT_ID }}"
           ITEM_ID="${{ steps.add.outputs.item_id }}"

--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -67,6 +67,16 @@ on:
         required: true
       CLAUDE_CREDENTIALS_JSON:
         required: true
+      PROJECT_PAT:
+        required: false
+        description: |
+          Personal Access Token for user-owned Project v2 mutations only.
+          GitHub Apps cannot mutate user-owned Projects v2 (platform
+          limitation — see docs/github-app-setup.md). When unset, project
+          status updates are skipped with a warning; the rest of the
+          pipeline proceeds. When set but invalid/expired, the project
+          step fails non-blockingly (continue-on-error) so the PAT
+          refresh is visible in CI without halting work.
 
 jobs:
 
@@ -203,18 +213,29 @@ jobs:
 
       # Inline project status update — mirror the dev-session pattern so
       # Stage 3 also keeps the project board in lockstep with the label.
+      # Uses PROJECT_PAT (not the App token) because GitHub Apps cannot
+      # mutate user-owned Projects v2 (platform limitation). Skipped
+      # gracefully if PROJECT_PAT is unset; non-blocking on failure.
       - name: Set project status to 'In Development'
         if: success() && steps.push.outputs.name != ''
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
           AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
           ISSUE: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
+          if [ -z "${PROJECT_PAT}" ]; then
+            echo "::warning::PROJECT_PAT secret is not set — project status update skipped."
+            echo "::warning::To enable: create a PAT with user-level project read/write access, set it as PROJECT_PAT in repo secrets."
+            echo "::warning::Background: GitHub Apps cannot mutate user-owned Projects v2 (platform limit, see docs/github-app-setup.md)."
+            exit 0
+          fi
           if [ -z "${AGENTIC_PROJECT_ID}" ]; then
             echo "::error::AGENTIC_PROJECT_ID is not configured. Set the repo variable to the ProjectV2 node ID."
             exit 1
           fi
+          export GH_TOKEN="${PROJECT_PAT}"
           ISSUE_NODE_ID=$(gh api "repos/${REPO}/issues/${ISSUE}" --jq '.node_id')
           RESULT=$(gh api graphql -f query='
             query($issueId: ID!) {
@@ -416,25 +437,45 @@ jobs:
             --base main \
             --head ${BRANCH}
 
-      - name: Apply in-review label and set project status
+      # Label transition uses the App token (works fine, must succeed —
+      # downstream workflows trigger on the in-review label).
+      - name: Apply in-review label
+        id: relabel
         if: success()
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
         run: |
           COMMITS=$(git rev-list --count origin/main..HEAD)
           if [ "${COMMITS}" -eq 0 ]; then
             echo "No commits — leaving issue in-development."
+            echo "skipped=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           gh issue edit ${{ github.event.issue.number }} \
             --remove-label "in-development" \
             --add-label "in-review"
+          echo "skipped=false" >> $GITHUB_OUTPUT
 
+      # Project status update uses PROJECT_PAT — Apps cannot mutate
+      # user-owned Projects v2 (platform limit). Skipped gracefully if
+      # the PAT is unset; non-blocking on failure.
+      - name: Set project status to 'In Review'
+        if: success() && steps.relabel.outputs.skipped != 'true'
+        continue-on-error: true
+        env:
+          PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
+        run: |
+          if [ -z "${PROJECT_PAT}" ]; then
+            echo "::warning::PROJECT_PAT secret is not set — project status update skipped."
+            echo "::warning::To enable: create a PAT with user-level project read/write access, set it as PROJECT_PAT in repo secrets."
+            exit 0
+          fi
           if [ -z "${AGENTIC_PROJECT_ID}" ]; then
-            echo "ERROR: AGENTIC_PROJECT_ID is not configured."
+            echo "::error::AGENTIC_PROJECT_ID is not configured."
             exit 1
           fi
+          export GH_TOKEN="${PROJECT_PAT}"
           ISSUE_NODE_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }} --jq '.node_id')
           RESULT=$(gh api graphql -f query='query($issueId: ID!) { node(id: $issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }' -f issueId="${ISSUE_NODE_ID}")
           ITEM_ID=$(echo "${RESULT}" | jq -r --arg pid "${AGENTIC_PROJECT_ID}" '.data.node.projectItems.nodes[] | select(.project.id == $pid) | .id')
@@ -698,19 +739,23 @@ jobs:
           ISSUE_NUMBER=$(echo "${BRANCH}" | sed 's|feature/\([0-9]*\)-.*|\1|')
           echo "issue_number=${ISSUE_NUMBER}" >> $GITHUB_OUTPUT
 
-      - name: Apply done label, set project status, and close feature issue
+      # Label transition + issue close use the App token. Must succeed —
+      # downstream auto-close-parent and branch-delete steps depend on it.
+      - name: Apply done label and close feature issue
+        id: doneclose
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
         run: |
           ISSUE="${{ steps.feature.outputs.issue_number }}"
           if [ -z "${ISSUE}" ]; then
             echo "Could not extract issue number from branch — skipping"
+            echo "skipped=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           ISSUE_TYPE=$(gh api repos/${{ github.repository }}/issues/${ISSUE} --jq '.pull_request // "issue"' 2>/dev/null || echo "")
           if [ -z "${ISSUE_TYPE}" ] || [ "${ISSUE_TYPE}" != "issue" ]; then
             echo "Issue #${ISSUE} is not an open feature issue — skipping"
+            echo "skipped=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           gh issue edit ${ISSUE} \
@@ -720,11 +765,32 @@ jobs:
             --remove-label "in-development" \
             --remove-label "in-review" \
             --add-label "done"
+          gh issue close ${ISSUE} \
+            --repo ${{ github.repository }} \
+            --comment "Feature implemented and merged via PR #${{ github.event.pull_request.number }}."
+          echo "skipped=false" >> $GITHUB_OUTPUT
 
+      # Project status update uses PROJECT_PAT — Apps cannot mutate
+      # user-owned Projects v2 (platform limit). Skipped gracefully if
+      # the PAT is unset; non-blocking on failure.
+      - name: Set project status to 'Done'
+        if: success() && steps.doneclose.outputs.skipped != 'true'
+        continue-on-error: true
+        env:
+          PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
+        run: |
+          ISSUE="${{ steps.feature.outputs.issue_number }}"
+          if [ -z "${PROJECT_PAT}" ]; then
+            echo "::warning::PROJECT_PAT secret is not set — project status update skipped."
+            echo "::warning::To enable: create a PAT with user-level project read/write access, set it as PROJECT_PAT in repo secrets."
+            exit 0
+          fi
           if [ -z "${AGENTIC_PROJECT_ID}" ]; then
-            echo "ERROR: AGENTIC_PROJECT_ID is not configured."
+            echo "::error::AGENTIC_PROJECT_ID is not configured."
             exit 1
           fi
+          export GH_TOKEN="${PROJECT_PAT}"
           ISSUE_NODE_ID=$(gh api repos/${{ github.repository }}/issues/${ISSUE} --jq '.node_id')
           RESULT=$(gh api graphql -f query='query($issueId: ID!) { node(id: $issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }' -f issueId="${ISSUE_NODE_ID}")
           ITEM_ID=$(echo "${RESULT}" | jq -r --arg pid "${AGENTIC_PROJECT_ID}" '.data.node.projectItems.nodes[] | select(.project.id == $pid) | .id')
@@ -736,10 +802,6 @@ jobs:
           FIELD_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
           OPTION_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id')
           gh api graphql -f query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { projectV2Item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f itemId="${ITEM_ID}" -f fieldId="${FIELD_ID}" -f optionId="${OPTION_ID}"
-
-          gh issue close ${ISSUE} \
-            --repo ${{ github.repository }} \
-            --comment "Feature implemented and merged via PR #${{ github.event.pull_request.number }}."
 
       - name: Parse parent requirement
         id: parent
@@ -766,24 +828,30 @@ jobs:
           echo "requirement_number=${PARENT}" >> $GITHUB_OUTPUT
           echo "agentic_repo=${AGENTIC_REPO}" >> $GITHUB_OUTPUT
 
+      # Label transition + parent close use the App token. Project status
+      # update for the parent requirement is split into the next step
+      # (uses PROJECT_PAT, non-blocking).
       - name: Auto-close parent requirement if all sub-issues complete
+        id: autoclose
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
         run: |
           PARENT="${{ steps.parent.outputs.requirement_number }}"
           AGENTIC_REPO="${{ steps.parent.outputs.agentic_repo }}"
           if [ -z "${PARENT}" ]; then
+            echo "no_parent=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           REQ_NODE_ID=$(gh api repos/${AGENTIC_REPO}/issues/${PARENT} --jq '.node_id')
           if [ -z "${REQ_NODE_ID}" ]; then
+            echo "no_parent=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           OPEN_COUNT=$(gh api graphql -f query='query($issueId: ID!) { node(id: $issueId) { ... on Issue { subIssues(first: 100) { nodes { state } } } } }' -f issueId="${REQ_NODE_ID}" \
             --jq '[.data.node.subIssues.nodes[] | select(.state == "OPEN")] | length')
           if [ "${OPEN_COUNT}" -gt 0 ]; then
             echo "${OPEN_COUNT} sub-issue(s) still open — leaving requirement #${PARENT} open"
+            echo "still_open=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           gh issue edit ${PARENT} \
@@ -792,21 +860,43 @@ jobs:
             --remove-label "scoping" \
             --remove-label "scheduled" \
             --add-label "done"
-          if [ -n "${AGENTIC_PROJECT_ID}" ]; then
-            RESULT=$(gh api graphql -f query='query($issueId: ID!) { node(id: $issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }' -f issueId="${REQ_NODE_ID}")
-            ITEM_ID=$(echo "${RESULT}" | jq -r --arg pid "${AGENTIC_PROJECT_ID}" '.data.node.projectItems.nodes[] | select(.project.id == $pid) | .id')
-            if [ -z "${ITEM_ID}" ]; then
-              ADD_RESULT=$(gh api graphql -f query='mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) { item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f contentId="${REQ_NODE_ID}")
-              ITEM_ID=$(echo "${ADD_RESULT}" | jq -r '.data.addProjectV2ItemById.item.id')
-            fi
-            FIELDS=$(gh api graphql -f query='query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }' -f projectId="${AGENTIC_PROJECT_ID}")
-            FIELD_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
-            OPTION_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id')
-            gh api graphql -f query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { projectV2Item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f itemId="${ITEM_ID}" -f fieldId="${FIELD_ID}" -f optionId="${OPTION_ID}"
-          fi
           gh issue close ${PARENT} \
             --repo ${AGENTIC_REPO} \
             --comment "All child feature issues are now complete. Auto-closing requirement."
+          echo "req_node_id=${REQ_NODE_ID}" >> $GITHUB_OUTPUT
+          echo "no_parent=false" >> $GITHUB_OUTPUT
+          echo "still_open=false" >> $GITHUB_OUTPUT
+
+      # Project status update for the parent requirement uses PROJECT_PAT.
+      # Same pattern as the feature-status step: skip gracefully if the
+      # PAT isn't set; non-blocking on failure.
+      - name: Set parent requirement project status to 'Done'
+        if: success() && steps.autoclose.outputs.no_parent != 'true' && steps.autoclose.outputs.still_open != 'true'
+        continue-on-error: true
+        env:
+          PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+          AGENTIC_PROJECT_ID: ${{ vars.AGENTIC_PROJECT_ID }}
+          REQ_NODE_ID: ${{ steps.autoclose.outputs.req_node_id }}
+        run: |
+          if [ -z "${PROJECT_PAT}" ]; then
+            echo "::warning::PROJECT_PAT secret is not set — parent requirement project status update skipped."
+            exit 0
+          fi
+          if [ -z "${AGENTIC_PROJECT_ID}" ]; then
+            echo "::warning::AGENTIC_PROJECT_ID is not configured — skipping parent project status update."
+            exit 0
+          fi
+          export GH_TOKEN="${PROJECT_PAT}"
+          RESULT=$(gh api graphql -f query='query($issueId: ID!) { node(id: $issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }' -f issueId="${REQ_NODE_ID}")
+          ITEM_ID=$(echo "${RESULT}" | jq -r --arg pid "${AGENTIC_PROJECT_ID}" '.data.node.projectItems.nodes[] | select(.project.id == $pid) | .id')
+          if [ -z "${ITEM_ID}" ]; then
+            ADD_RESULT=$(gh api graphql -f query='mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) { item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f contentId="${REQ_NODE_ID}")
+            ITEM_ID=$(echo "${ADD_RESULT}" | jq -r '.data.addProjectV2ItemById.item.id')
+          fi
+          FIELDS=$(gh api graphql -f query='query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }' -f projectId="${AGENTIC_PROJECT_ID}")
+          FIELD_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
+          OPTION_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id')
+          gh api graphql -f query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { projectV2Item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f itemId="${ITEM_ID}" -f fieldId="${FIELD_ID}" -f optionId="${OPTION_ID}"
 
       - name: Delete feature branch
         env:

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -112,6 +112,24 @@ gh secret set AGENTIC_APP_PRIVATE_KEY --repo eddiecarpenter/gh-agentic < /path/t
 
 The private key is stored as **raw PEM** — no base64 wrapping. `actions/create-github-app-token` accepts this format natively. After the secret is set, securely delete the local `.pem` file (`shred -u` or equivalent).
 
+### `PROJECT_PAT` (optional but strongly recommended)
+
+GitHub Apps installed on a personal account **cannot mutate user-owned Projects v2** — confirmed limitation by GitHub Support ([community discussion #46681](https://github.com/orgs/community/discussions/46681)). The App can do everything else; project board sync alone needs a separate credential.
+
+To keep the project board in lockstep with pipeline labels, set a **Personal Access Token** as the `PROJECT_PAT` secret:
+
+```bash
+gh secret set PROJECT_PAT --repo eddiecarpenter/gh-agentic --body "<your-pat>"
+```
+
+**Required scope:** the PAT needs read/write access to the user-owned Projects v2. For a fine-grained PAT: enable **Account permissions → Projects: Read and write**. For a classic PAT: the `project` scope.
+
+**When unset:** every pipeline workflow that would update project status emits a `::warning::` and skips the project step cleanly (✓ outcome — no red noise). The pipeline itself works fully — labels carry pipeline state; only the visual project board stops auto-syncing. This is a documented, supported degradation mode.
+
+**When set but invalid/expired:** the project step exits non-zero (visible red ✗ in the run summary), but `continue-on-error: true` keeps the overall workflow green. Refresh the PAT and project sync resumes on the next run.
+
+**Rotation:** PATs do not auto-rotate. Plan for periodic refresh (annually if the PAT has an expiration, or on any suspected leak). When migrating to an organization topology (where the App's `Projects: Write` permission becomes effective), the `PROJECT_PAT` secret can be deleted entirely.
+
 ### Existing Claude credential secret
 
 `CLAUDE_CREDENTIALS_JSON` remains as before. The App holds `secrets: write` (see Permissions section), which preserves the in-band credential refresh flow performed by `setup-claude-auth/action.yml`.


### PR DESCRIPTION
Hotfix for the regression discovered on PR #633's merge — the GitHub App's installation token cannot mutate user-owned Projects v2, so the `feature-complete` job consistently failed at the project-status step.

Root cause confirmed by GitHub Support and our own reproduction: GitHub Apps installed on a personal account categorically cannot access user-owned Projects v2, regardless of `organization_projects: admin` permission or per-project collaborator grants. See [community discussion #46681](https://github.com/orgs/community/discussions/46681). Same App installed on an org would work — but moving to an org is a larger migration we don't want to bundle here.

## Summary

- Routes every Project v2 mutation through `secrets.PROJECT_PAT` (a narrowly-scoped Personal Access Token) while keeping every other operation on the App token.
- Non-blocking by design: PAT unset → step skipped with warning; PAT invalid → step fails visibly but `continue-on-error: true` keeps the workflow green.
- The PAT is **already set** on `eddiecarpenter/gh-agentic` (you added it during diagnostics), so this should work end-to-end on first merge.

## Operational pre-flight (already done)

- [x] `secrets.PROJECT_PAT` set on the repo with user-level Projects v2 access

## Behaviour matrix

| PROJECT_PAT state | Project step result | Workflow result |
|---|---|---|
| Not set | ✓ (skipped with warning) | ✓ green |
| Set, valid | ✓ (mutation succeeds) | ✓ green |
| Set, expired/wrong | ✗ (visible signal) | ✓ green (continue-on-error) |

## Why this isn't permanent

When the framework moves to an org topology, the agentic App's `Projects: Write` permission becomes effective and the PAT can be deleted. The hotfix is intentionally a degradation primitive, not a long-term dependency on PAT-based auth — that's why the docs (`docs/github-app-setup.md`) explicitly call out the org-migration off-ramp.

## Test plan

- [x] `actionlint -ignore "shellcheck reported issue" .github/workflows/*.yml` → exit 0
- [x] `go test ./internal/cli/ -run TestNoLegacyAuthRefsInWorkflows` → PASS (PROJECT_PAT name doesn't trip the legacy guard)
- [x] No `GOOSE_AGENT_PAT` / `AGENT_USER` regressions
- [ ] **Post-merge:** verify the failed `feature-complete` run from PR #633 succeeds when re-run with PROJECT_PAT in place
- [ ] **Post-merge:** trigger a no-op pipeline cycle on a small Requirement to confirm project sync survives the full design → dev → review → merge loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)