### PR TITLE
fix: add .gitmodules so submodules can be initialized

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule ".agentic-tools"]
+	path = .agentic-tools
+	url = https://github.com/eddiecarpenter/gh-agentic.git
+[submodule ".ai"]
+	path = .ai
+	url = https://github.com/eddiecarpenter/gh-agentic.git


### PR DESCRIPTION
Third PR #620 leftover surfaced when triggering #624's design phase. The submodule gitlinks for \`.agentic-tools\` and \`.ai\` (mode 160000) were committed by PR #620 but the corresponding \`.gitmodules\` file was never created. Result: every workflow that calls \`actions/checkout\` with \`submodules: recursive\` (added in PR #633) fails at submodule init:

\`\`\`
fatal: No url found for submodule path '.agentic-tools' in .gitmodules
\`\`\`

This unblocks #624 (and every future Feature) at the design-phase Checkout step.

## Summary

- Adds \`.gitmodules\` declaring both submodules with URL \`https://github.com/eddiecarpenter/gh-agentic.git\`.
- Both submodules point to the same repo because that's how PR #620 designed them — \`.agentic-tools/\` for composite actions, \`.ai/\` for skills/recipes. Wasteful but functionally correct; consolidating them is out of scope.

## Test plan

- [x] File parses as valid \`.gitmodules\` (single \`git submodule status\` would resolve URLs).
- [ ] **Post-merge**: re-trigger #624 design phase and confirm Checkout step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)