### PR TITLE
chore: cleanup loose threads — app-id deprecation, doc table sync, Closes-part-of reminder

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -101,7 +101,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ vars.AGENTIC_APP_ID }}
+          client-id: ${{ vars.AGENTIC_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENTIC_APP_PRIVATE_KEY }}
 
       - name: Checkout domain repo
@@ -307,7 +307,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ vars.AGENTIC_APP_ID }}
+          client-id: ${{ vars.AGENTIC_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENTIC_APP_PRIVATE_KEY }}
 
       - name: Resolve feature branch
@@ -514,7 +514,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ vars.AGENTIC_APP_ID }}
+          client-id: ${{ vars.AGENTIC_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENTIC_APP_PRIVATE_KEY }}
 
       - name: Checkout domain repo
@@ -617,7 +617,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ vars.AGENTIC_APP_ID }}
+          client-id: ${{ vars.AGENTIC_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENTIC_APP_PRIVATE_KEY }}
 
       - name: Checkout domain repo
@@ -727,7 +727,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ vars.AGENTIC_APP_ID }}
+          client-id: ${{ vars.AGENTIC_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENTIC_APP_PRIVATE_KEY }}
 
       - name: Extract feature issue number

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,7 +26,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ vars.AGENTIC_APP_ID }}
+          client-id: ${{ vars.AGENTIC_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENTIC_APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ vars.AGENTIC_APP_ID }}
+          client-id: ${{ vars.AGENTIC_APP_CLIENT_ID }}
           private-key: ${{ secrets.AGENTIC_APP_PRIVATE_KEY }}
 
       - name: Checkout domain repo

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -31,7 +31,9 @@ The App is initially owned by `eddiecarpenter` (personal account). It can be tra
 | `contents` | write | Push commits, branches, files |
 | `issues` | write | Manage Requirements, Features, Tasks |
 | `pull_requests` | write | Open PRs, comment on reviews |
-| `projects` | write | Move cards on the GitHub Project |
+| `projects` (org) | write | Mutate Project v2 boards. **Ineffective for user-owned Projects v2** (platform limitation — see `PROJECT_PAT` below). |
+| `repository_projects` | admin | Mutate legacy "Projects classic" boards attached to a repository. |
+| `workflows` | write | Required for agent commits that touch `.github/workflows/*.yml`. Without it, dev-session pushes are rejected for any Task editing workflows. |
 | `secrets` | write | In-band rotation of `CLAUDE_CREDENTIALS_JSON` (transitional — see rationale) |
 | `metadata` | read | Always required by GitHub |
 
@@ -88,17 +90,19 @@ The App is now installed and can mint installation tokens for `gh-agentic` via `
 
 ## Configuration storage
 
-The App's identity splits into one **variable** (not sensitive) and one **secret** (sensitive). Treating them according to their actual sensitivity is intentional — see "App ID is a variable, not a secret" in the Rationale section below.
+The App's identity splits into one **variable** (not sensitive) and one **secret** (sensitive). Treating them according to their actual sensitivity is intentional — see "Client ID is a variable, not a secret" below.
 
 ### Repo variable
 
 | Variable | Value |
 |---|---|
-| `AGENTIC_APP_ID` | The App ID integer (e.g. `1234567`). Public per GitHub's API; not sensitive. |
+| `AGENTIC_APP_CLIENT_ID` | The App's **Client ID** (alphanumeric string like `Iv23li8K3O...`). Found on the App settings page under "About → Client ID". Not sensitive — the App's Client ID is public information surfaced wherever the App is installed. |
 
 ```bash
-gh variable set AGENTIC_APP_ID --repo eddiecarpenter/gh-agentic --body "<app-id-integer>"
+gh variable set AGENTIC_APP_CLIENT_ID --repo eddiecarpenter/gh-agentic --body "<client-id-string>"
 ```
+
+**Why Client ID, not App ID.** GitHub's `actions/create-github-app-token` action deprecated `app-id` in favour of `client-id` (the OAuth-conventional identifier). Both still work for now, but the App ID input emits a deprecation warning on every run. Future versions of the action will remove `app-id` entirely; setting `AGENTIC_APP_CLIENT_ID` is forward-compatible.
 
 ### Repo secret
 
@@ -138,9 +142,9 @@ gh secret set PROJECT_PAT --repo eddiecarpenter/gh-agentic --body "<your-pat>"
 
 The App has no backend service. When creating the App, leave both **Webhook URL** and **Webhook secret** blank (or untick "Active"). Nothing on GitHub will deliver a webhook anywhere.
 
-### Why App ID is a variable, not a secret
+### Why Client ID is a variable, not a secret
 
-The App ID is a small public integer that GitHub displays on the App's settings page; anyone who knows the App's slug can resolve it via the public REST API. Marking it as a secret would dilute the meaning of "secret" (which should mean *"leaking this is harmful"*) and add audit overhead. The private key alone is what authorizes API calls — the App ID without the private key is useless.
+The Client ID (and the legacy App ID) is a public identifier — GitHub displays it on the App's settings page, surfaces it wherever the App acts, and exposes it via the public REST API. Marking it as a secret would dilute the meaning of "secret" (which should mean *"leaking this is harmful"*) and add audit overhead with no security benefit. The private key alone is what authorizes API calls — the Client ID without the private key is useless.
 
 ---
 

--- a/skills/requirements-session.md
+++ b/skills/requirements-session.md
@@ -83,7 +83,14 @@ When the scope is clear enough to define the Feature(s) without a separate sessi
    - MVP scope and acceptance criteria
    - Serial vs parallel decomposition
    - UX design (if applicable)
-3. Create Feature issue(s) using the `capture-feature` skill
+3. Create Feature issue(s) using the `capture-feature` skill.
+   **Critical:** the Feature body's parent reference must use the literal
+   `Closes part of #<requirement-number>` (or `Closes #<requirement>` for
+   single-Feature Requirements) — never `Parent: #N` or any other phrasing.
+   The `feature-complete` workflow's parent-parse regex matches only the
+   `Closes` form; any other phrasing silently breaks the auto-close-parent
+   logic, leaving the Requirement open after all its sub-issues complete.
+   See `capture-feature.md` "Parent Requirement" section.
 4. Wire sub-issue: Feature → parent Requirement
 5. Apply `in-design` to features that are ready to proceed (cross-repo dependency rules apply)
 6. Transition requirement: `scoping` → `scheduled`


### PR DESCRIPTION
Three small follow-ups discovered during the App migration's recovery and live-pipeline shakedown.

## Summary

1. **`app-id` → `client-id`** in workflows. Action's v3.1.1 manifest deprecates `app-id` (`Use 'client-id' instead.`). Both still work; `app-id` emits a warning every run and a future major version will remove it. Switching now is forward-compatible.
2. **Doc permission table sync** — `workflows: write` (added during #624), `repository_projects: admin` (visible on installation, undocumented), and a pointer on the `projects: write` row to the PROJECT_PAT section explaining its ineffectiveness for user-owned Projects v2.
3. **Variable rename in doc** — `AGENTIC_APP_ID` → `AGENTIC_APP_CLIENT_ID`. Explains Client ID vs App ID and why the rename matters.
4. **`requirements-session.md` reminder** — inline-scoped Features must use `Closes part of #N` (not `Parent: #N`) so the auto-close-parent workflow's regex matches. Closes the gap that left #621 manually-closeable after all child Features merged.

## ⚠️ User action required BEFORE merge

Set the new variable on the repo:

```bash
gh variable set AGENTIC_APP_CLIENT_ID --repo eddiecarpenter/gh-agentic --body "<client-id-value>"
```

Find the Client ID on the App settings page under **About → Client ID** (alphanumeric string like `Iv23li8K3O...`).

If this variable isn't set when the PR merges, the next pipeline run will fail at the `Mint GitHub App token` step.

After merge, the legacy `vars.AGENTIC_APP_ID` can be deleted.

## Test plan

- [x] `actionlint -ignore "shellcheck reported issue" .github/workflows/*.yml` → exit 0
- [x] `go test ./internal/cli/ -run TestNoLegacyAuthRefsInWorkflows` → PASS
- [x] `grep -rn "AGENTIC_APP_ID\b" .github/ docs/` → no matches
- [ ] **Pre-merge:** `gh variable set AGENTIC_APP_CLIENT_ID ...` (your action)
- [ ] **Post-merge:** trigger #651 (SAPAV concept doc) — first end-to-end run with the new client-id input
- [ ] **Post-merge:** confirm no `app-id` deprecation warnings in the new pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)