### PR TITLE
test: introduce deliberate duplicate heading in RULEBOOK as fixture for #666

### DIFF
--- a/RULEBOOK.md
+++ b/RULEBOOK.md
@@ -323,3 +323,23 @@ the GraphQL API. External clients depend on these names and shapes.
 **When all tasks are complete:**
 1. Exit cleanly — do not push, do not open a PR
 2. The workflow pushes and opens the PR automatically
+
+---
+
+<!--
+  TEST FIXTURE — DELIBERATE DUPLICATE for #666
+
+  The "## Communication" heading below intentionally duplicates the heading
+  at line ~307. It exists so that #666 (Detect and remove duplicate headings)
+  has a real duplicate to find and remove during its dev session, AND so
+  the new CI guard test can be exercised end-to-end on a known-bad starting
+  state.
+
+  Once #666 lands, both this duplicate section AND this comment block must
+  be removed. The CI guard added by #666 will then prevent any future
+  duplicates from being introduced silently.
+-->
+
+## Communication
+
+(Duplicate test fixture — see HTML comment above. To be removed by #666.)


### PR DESCRIPTION
Setup-only change for the duplicate-detection Feature (#666 under #665). Adds a clearly-labelled duplicate \`## Communication\` heading at the bottom of \`RULEBOOK.md\` so #666 has something real to find and remove during its dev session, and so the new CI guard test it ships can be exercised end-to-end on a known-bad starting state.

## Summary

- One deliberate duplicate \`## Communication\` heading appended to RULEBOOK.md
- Wrapped in an HTML comment block naming #666 as the Feature that will remove it
- Pure test fixturing — no behavioural impact, no consumer visibility

## Sequence

1. Merge this PR (introduces the broken state).
2. Trigger #666 — its dev session will find and remove this duplicate, AND add a CI guard so the issue can't recur silently.
3. Once #666 lands, both this fixture and the CI guard test pass on a clean RULEBOOK.

## Test plan

- [x] Heading is genuinely duplicated (line ~307 + line ~327)
- [x] HTML comment block clearly identifies it as a fixture and names #666
- [ ] **Post-merge:** trigger #666 and verify it removes both the duplicate AND the comment block, and adds the CI guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)