### PR TITLE
feat: shared definitions for cross-cutting skill boilerplate (#674)

### DIFF
--- a/skills/apply-label/SKILL.md
+++ b/skills/apply-label/SKILL.md
@@ -128,7 +128,8 @@ other skill.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/apply-label/SKILL.md
@@ -136,26 +137,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/apply-
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `apply-label`.
-
 ## Error Handling
 
 - `LABEL_LIST_EMPTY` from step 1 → severity `ERROR`; propagate.

--- a/skills/definitions/branch-safety.md
+++ b/skills/definitions/branch-safety.md
@@ -1,0 +1,87 @@
+# Branch Safety
+
+The "refuse-on-main" guard. Skills that mutate the local working
+tree (write files, run `git add`, delete branches, etc.) MUST refuse
+to operate when the active branch is `main` (or `master`) so an
+accidental commit cannot land directly on the integration branch.
+
+This rule is unconditional and matches RULEBOOK.md's "Never commit
+or make changes on `main`" rule. It is enforced at the skill's
+entry, before any state mutation.
+
+## The check
+
+Run as the first action after the skill's entry banner, before any
+file write, git operation, or GitHub mutation:
+
+```bash
+git branch --show-current
+```
+
+Branch on the result:
+
+- **Empty / detached HEAD** — surface a `WARN` and exit cleanly.
+  The skill cannot determine the branch; refusing is the safe
+  default.
+- **`main` or `master`** — raise the skill's branch-safety error
+  code (typically `ON_MAIN_BRANCH`) with severity `ERROR` and exit
+  cleanly. Render the remediation template below to the human.
+- **Anything else** — capture the branch name as `<branch>` and
+  continue.
+
+## Remediation template
+
+When the check fails, render to the human:
+
+```
+This skill refuses to run on main. Switch to a branch first
+(e.g. `git checkout -b <suggested-prefix>-<short-context>`), then
+re-invoke this skill.
+```
+
+`<suggested-prefix>` is skill-specific — examples in the live
+framework:
+
+- `solution-architecture` → `chore/architecture-update`
+- `foreground-recovery` → `chore/recovery-<timestamp>`
+
+The skill MAY also recommend a different branching base (e.g.,
+the human's current feature branch) when context makes it
+appropriate — the prefix above is the default fallback.
+
+## Where this guard applies
+
+Any skill that:
+
+- Writes files in the working tree (e.g., creating or editing
+  `docs/ARCHITECTURE.md`, scaffolding source files).
+- Runs `git add`, `git commit`, or any other history-mutating
+  command in the working tree.
+- Deletes local branches, removes worktree files, or otherwise
+  modifies the local repo state.
+- Performs interactive recovery operations whose remediation
+  could touch local state.
+
+It does NOT apply to:
+
+- Pure-read skills (`gh agentic status` queries, repo inspection).
+- Skills that operate entirely against GitHub via `gh` (creating
+  issues, posting comments) without touching the local working
+  tree.
+- Skills that *create* a feature branch as their first action
+  (e.g., `dev-session` checks out `feature/<N>-<slug>` before any
+  local edits — it never edits files while on `main`).
+
+Consumer skills today: `solution-architecture`, `foreground-recovery`.
+Future consumers: any new skill that opens an interactive session
+involving local file edits.
+
+## Why this is a separate guard
+
+The check is mechanically trivial (one git command, one branch),
+but the failure mode it prevents is severe: a stray commit on
+`main` that bypasses the framework's branch/PR/review pipeline.
+Centralising the rule and its remediation template in one
+definition means a future change (e.g., adding `develop` to the
+refuse list, or extending the error message) lands once rather
+than per skill.

--- a/skills/definitions/concurrency-beacon.md
+++ b/skills/definitions/concurrency-beacon.md
@@ -1,0 +1,138 @@
+# Concurrency Beacon
+
+A label on a GitHub issue that marks "a session is currently
+working on this entity". Skills that perform multi-step work on a
+single entity use a beacon to prevent two sessions from racing —
+e.g., a workflow re-firing while a prior run is still active, or
+a human invoking interactively while automation is running.
+
+The pattern is: **claim** the beacon on entry, **release** it on
+exit, **best-effort release** on every error path.
+
+A skill that loads this definition supplies its own concrete
+beacon label name (`design-in-progress`, `development-in-progress`,
+`issue-in-progress`, etc.) and the specific steps where claim and
+release fire.
+
+## Claim semantics
+
+The first step that mutates state for the entity (typically very
+early in the skill) MUST claim the beacon:
+
+```
+apply-label(repo=<active-repo>, issue=<N>,
+            add=["<beacon-name>"], remove=[])
+```
+
+Before the apply, probe whether the beacon is already set:
+
+```bash
+gh issue view <N> --repo <active-repo> --json labels \
+  --jq '[.labels[].name] | index("<beacon-name>")'
+```
+
+Branch on the result:
+
+- **Beacon already set** in headless mode → another session is in
+  flight (or recently was). Exit cleanly with a one-line note:
+  "Another session is active; this run is a no-op." Do NOT remove
+  the beacon — it belongs to the other session. Do NOT proceed.
+- **Beacon already set** in interactive mode → another session
+  *may* be in flight (the prior session may also have crashed
+  leaving the beacon stuck). Surface a warning to the human and
+  prompt:
+  ```
+  ⚠ <beacon-name> is set on this entity. Another session may be
+     actively working on it. Continuing will likely cause conflicts.
+  ```
+  Then offer "Continue anyway" / "Cancel". If the human picks
+  Continue, fall through to the apply step (the apply is a no-op
+  if the beacon is already set; the slot is now claimed by *this*
+  session for release purposes).
+- **Beacon not set** → apply it. On apply failure, raise the
+  skill's invalid-state error and exit before any further work.
+  The beacon is the lock; without it, single-writer semantics are
+  not guaranteed.
+
+From the moment the beacon is claimed, every exit path (success,
+parked, error, cancel) MUST attempt to release it.
+
+## Release semantics
+
+The skill's normal exit path removes the beacon as the first
+action of its closeout step:
+
+```
+apply-label(repo=<active-repo>, issue=<N>,
+            add=[], remove=["<beacon-name>"])
+```
+
+A failure here is surfaced as a `WARN` and does not block exit —
+the substantive work is complete; a stuck beacon is a presentation
+issue the human can clear by hand or via `foreground-recovery`.
+
+## Slot-release rule (universal — applies to every error path)
+
+Every error path AND every cancel path that fires AFTER the beacon
+was claimed MUST attempt to remove the beacon before exit, on a
+best-effort basis. If the removal itself fails, surface it as a
+`WARN` and exit anyway — the original error is what matters; a
+stuck beacon is a secondary concern.
+
+In the consuming skill's `## Error Handling` section, surface the
+rule explicitly so future maintainers see the obligation:
+
+```markdown
+**Slot-release rule (universal).** Every error path AND every
+graceful exit AFTER step <N> (the slot was claimed) MUST attempt
+to remove `<beacon-name>` before exit, on a best-effort basis.
+If the removal itself fails, surface it as a `WARN` and exit
+anyway — the original error is what matters.
+```
+
+## Why a beacon and not just relying on workflow concurrency
+
+GitHub Actions has its own `concurrency:` group mechanism, but it
+does not cover:
+
+- A workflow run + an interactive human session against the same
+  entity.
+- Two runs against the same entity from different triggers (label
+  apply vs comment vs PR review).
+- Recovery: a beacon that *should* be set isn't (so a re-fire is
+  the wrong choice), or a beacon is *stuck* set after a crash (so
+  a re-fire is the right choice but the workflow won't fire it).
+
+The label-based beacon is observable and inspectable from any
+session, lives on the same entity as the rest of the state, and
+can be cleared manually. It is the defensive complement to
+workflow-level concurrency, not a replacement.
+
+## Where this pattern applies
+
+Any skill that:
+
+- Performs multi-step work tied to a single GitHub entity
+  (typically a Feature or Requirement).
+- Has at least one mutation that, if duplicated by a concurrent
+  run, would produce conflicting or duplicated artefacts.
+- Can be invoked from more than one trigger (workflow + human,
+  multiple workflow events).
+
+Consumer skills today: `dev-session` (`development-in-progress`),
+`feature-design` (`design-in-progress`), `issue-session`
+(`issue-in-progress`), `foreground-recovery` (operates on stuck
+beacons rather than claiming one — special case).
+
+## Naming convention
+
+Beacon labels use the pattern `<phase>-in-progress`:
+
+- `design-in-progress` — `feature-design` is active.
+- `development-in-progress` — `dev-session` is active.
+- `issue-in-progress` — `issue-session` is active.
+
+Future skills introducing a new phase MUST use this pattern. The
+canonical list of beacon labels lives in
+`internal/project/assets/project-template.json` so `gh agentic
+init` provisions them on new projects.

--- a/skills/definitions/state-model-pattern.md
+++ b/skills/definitions/state-model-pattern.md
@@ -1,0 +1,124 @@
+# State Model Pattern
+
+Skills that perform a sequence of GitHub-side mutations whose
+recoverability differs use this pattern to make the cancellation
+and failure semantics explicit. The agent must always know which
+state it is in so it can choose the correct cancel or failure
+behaviour.
+
+A skill that loads this definition supplies its own concrete
+**transition table** (the per-skill list of T0/T1/T2/T3/...
+mutations and their recoverability) and refers to the universal
+**cancel rules** and **failure-during-transition rules** described
+below.
+
+## The transition table
+
+Each consuming skill provides a table of this shape, near the top
+of its `## Steps` section:
+
+```markdown
+| Transition | Where | Effect | Skill-recoverable? |
+|---|---|---|---|
+| **T0 → T1** | step <N> | <one-line description of what mutates>     | <Yes / Partial / No — with rationale> |
+| **T1 → T2** | step <N> | <one-line description>                      | <Yes / Partial / No — with rationale> |
+| ...        | ...      | ...                                          | ...                                     |
+```
+
+Conventions:
+
+- **T0** is the pre-entry state (no mutations yet); the skill is at
+  T0 before any work runs.
+- Number the transitions in the order they fire during a normal
+  run. Skip numbers if a transition is conditional.
+- The **Where** column points at the specific step that fires the
+  transition.
+- The **Skill-recoverable?** column has three permitted values:
+  - **Yes** — the skill can cleanly revert this transition on
+    cancel/failure.
+  - **Partial** — the skill can revert some artefacts but not
+    others; the partial state must be surfaced.
+  - **No — point of no return** — once this fires, the skill
+    cannot revert. The human picks up.
+
+## Cancel rules by state (universal)
+
+Every consuming skill applies these rules unless it explicitly
+overrides one in a "Skill-specific cancel override" subsection.
+
+- **Before T1** (no mutations yet) → clean exit. No revert is
+  needed because no GitHub state has changed.
+- **At T_k** where T_k is **Yes**-recoverable → revert the
+  T_k mutation (and any later mutations, in reverse order) and
+  exit. Surface to the human which mutations were reverted.
+- **At T_k** where T_k is **Partial**-recoverable → revert what
+  the skill can; surface the residual partial state explicitly
+  (which artefacts remain, what state they are in) so the human
+  can decide whether to complete manually or run a repair flow.
+- **At T_k** where T_k is **No — point of no return** → the
+  skill MUST NOT attempt to revert. Surface the partial state
+  in the exit block; recommend manual cleanup or completion.
+  Do NOT attempt a "best-effort" rollback that would leave
+  orphans pointing at reverted parents.
+
+The "No — point of no return" tier MUST be surfaced as a warning
+to the human at the confirmation gate immediately before it fires:
+
+> ⚠ Once you confirm, <effect of T_k>. Cancellation after this
+> point cannot <revert action> automatically; the session would
+> exit with <residual state> in place.
+
+## Failure-during-transition rules (universal)
+
+When a transition fails partway through (e.g., the label apply
+succeeds but the status set fails), the resulting state is a
+mismatch — the skill MUST raise the appropriate error code (per
+its Error Handling section), exit, and rely on the next session's
+pre-entry check to detect and surface the inconsistency.
+
+- **T0 → T1 fails partway** → raise the skill's transition error.
+  Surface which side of the mutation succeeded and which failed.
+  Recommend `gh agentic repair`.
+- **T_k → T_{k+1} partial** where multiple artefacts are created
+  (e.g., creating N Feature issues) → raise the issue-creation
+  error. Do NOT continue past the partial set; partial work on a
+  partial set tends to make recovery harder, not easier. Surface
+  which artefacts succeeded and which failed; recommend keeping
+  the successful ones (they are valid pipeline state) and either
+  re-running the skill (which the orphan-re-entry check will
+  detect) or closing the orphans manually.
+- **A late transition fails** (the final label/status flip in a
+  closeout) → raise the transition error. The earlier artefacts
+  are in their intended states; the skill is stuck on the final
+  flip. Recommend `gh agentic repair` and a manual re-run of the
+  final transition only.
+
+## Orphan re-entry detection
+
+When a skill is re-invoked on an entity that is mid-transition (a
+prior session was interrupted between T_k and T_{k+1}), the skill's
+pre-entry check (typically the first step that reads the entity's
+state) MUST detect the partial state and branch:
+
+- **Pre-T2 leftover** (only T1 fired, no irreversible artefacts
+  yet) → offer the human "continue from current state" or "revert
+  to T0".
+- **T2-or-later leftover** (irreversible artefacts already exist)
+  → the skill cannot cleanly resume (would duplicate work) and
+  cannot cleanly revert (would orphan the artefacts). Surface
+  the existing artefacts and recommend manual completion or
+  cleanup. Exit cleanly without changes.
+
+## Where this pattern applies
+
+Any skill whose `## Steps` section performs more than one
+GitHub-side mutation in sequence and where any of those mutations
+is non-trivially recoverable. Pure-read skills do not need this
+pattern; single-mutation skills (e.g., `apply-label`,
+`set-issue-status`) do not need it either — there is nothing to
+revert mid-flow.
+
+Consumer skills today: `requirement-scoping`, `feature-design`.
+Future consumers: any skill that creates issues, posts comments,
+and transitions labels in sequence (PR-merge cascade workflow,
+multi-Feature parallel scoping, etc.).

--- a/skills/definitions/verification-procedure.md
+++ b/skills/definitions/verification-procedure.md
@@ -129,3 +129,93 @@ It does not apply to:
   are setup verification, not change verification.
 - Logging/telemetry assertions — these are observability, not
   fidelity.
+
+## Section format — the canonical `## Verification` stanza
+
+Every skill that loads this definition replaces its `## Verification`
+section with the canonical stanza below. The framework's two scripts
+(`verify-skill-mechanical.py`, `check-description-triggers.py`) and
+the universal check list are described here so each consumer skill
+need not restate them.
+
+### Canonical stanza
+
+```markdown
+## Verification
+
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
+
+\`\`\`bash
+python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/<name>/SKILL.md
+python3 skills/skill-creator/scripts/check-description-triggers.py skills/<name>/SKILL.md
+\`\`\`
+
+Pass criteria: both commands exit 0.
+```
+
+Replace `<name>` with the skill's directory name. The two script
+invocations are skill-specific because the path argument names the
+skill's own SKILL.md — they cannot be hoisted into the definition.
+
+### What the two scripts check (universal — do not restate per skill)
+
+`verify-skill-mechanical.py` runs the following mechanical checks
+on every skill:
+
+- `all_sections_present` — every mandatory section heading exists
+  (Goal, Output Artefacts, Definitions, Dependencies, Steps,
+  Verification, Error Handling).
+- `frontmatter_required_fields(name, description, triggers, loads)`.
+- `frontmatter_name_valid` — kebab-case, matches the file's
+  parent-directory name.
+- `description_within_length_limit` — ≤ 1024 chars.
+- `description_assertive` — contains "Use when" plus an assertive
+  clause directing when the skill should fire.
+- `description_third_person` — written about the skill, not in
+  first-person voice.
+- `references_resolve` — every `loads:` path resolves to an
+  existing file.
+
+`check-description-triggers.py` runs the following ground-truth
+check:
+
+- `description_triggers_appropriately` — the skill's `description:`
+  classifies the canonical phrasings (per the `GROUND_TRUTH` entry
+  for the skill) into trigger / no-trigger correctly.
+
+Consumer skills do not list these bullets in their own Verification
+sections. The canonical stanza above is the entire body for any
+skill whose verification is exactly the framework checks.
+
+### Skill-specific extensions
+
+A skill MAY append a "Skill-specific extension" subsection after
+the canonical stanza when it has additional verification beyond the
+framework checks (e.g., a CI-enforced sync test, a domain-specific
+fixture, a benchmark threshold). Format:
+
+```markdown
+### Skill-specific extension
+
+<one paragraph naming the extra check, what it covers, and how to
+run it. Followed by the command in a fenced code block.>
+
+\`\`\`bash
+<command>
+\`\`\`
+
+Pass criteria: <when this check passes>.
+```
+
+Examples in the live framework:
+
+- `gh-agentic/SKILL.md` adds the `TestGhAgenticToolSkillCoversCLI`
+  Go test as a CI-enforced sync check.
+- `skill-creator/SKILL.md` adds skill-creator-specific mechanical
+  bullets that don't apply to other skills.
+
+The extension is *additive* — never copy the universal-check bullets
+into the skill-specific extension. If a check applies to every
+skill, it lives in this definition; if it applies only to one
+skill, it goes in that skill's extension.

--- a/skills/dev-session/SKILL.md
+++ b/skills/dev-session/SKILL.md
@@ -586,7 +586,8 @@ discipline at task granularity:
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/dev-session/SKILL.md
@@ -594,26 +595,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/dev-se
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `dev-session`.
-
 ## Error Handling
 
 **Slot-release rule (universal).** Every error path AND every

--- a/skills/dev-session/SKILL.md
+++ b/skills/dev-session/SKILL.md
@@ -5,6 +5,7 @@ triggers: automated
 user-invocable: false
 loads:
   - skills/definitions/error-handling.md
+  - skills/definitions/concurrency-beacon.md
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
   - skills/definitions/commit-discipline.md
@@ -597,11 +598,9 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/dev-se
 Pass criteria: both commands exit 0.
 ## Error Handling
 
-**Slot-release rule (universal).** Every error path AND every
-graceful exit AFTER step 5 (the slot was claimed) MUST attempt to
-remove `development-in-progress` before exit, on a best-effort
-basis. If the removal itself fails, surface it as a `WARN` and exit
-anyway — the original error is what matters.
+**Slot-release rule.** Per `skills/definitions/concurrency-beacon.md`
+— every error path AND every graceful exit AFTER step 5 (beacon
+claimed) MUST best-effort remove `development-in-progress`.
 
 - `INVALID_DEV_STATE` from steps 2–5 (Feature missing, wrong
   labels, no rationale, no tasks, slot-claim failed) → severity

--- a/skills/feature-design/SKILL.md
+++ b/skills/feature-design/SKILL.md
@@ -7,6 +7,7 @@ loads:
   - skills/definitions/error-handling.md
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
+  - skills/definitions/state-model-pattern.md
   - skills/prompt-user/SKILL.md
   - skills/gh-agentic/SKILL.md
   - skills/apply-label/SKILL.md
@@ -167,8 +168,19 @@ The step-skip rule does not require justification when the step is
 not applicable to the running mode. Steps without a mode tag run in
 both modes.
 
-**State model & cancel semantics.** This skill performs four
-sequential GitHub-side mutations whose recoverability differs:
+**State model & cancel semantics.** This skill follows the pattern
+in `skills/definitions/state-model-pattern.md`. The concrete tier
+table below is this skill's specifics; the universal cancel rules
+and failure-during-transition rules come from the definition.
+
+Headless mode has no cancel — only interactive mode applies the
+cancel rules.
+
+Skill-specific cancel override (T1): the rationale comment cannot
+be unposted; on cancel-at-T1 the skill MUST edit the comment to
+prepend `**[CANCELLED — design did not complete]**` rather than
+leaving it as a misleading active rationale. Cancel-at-T2 also
+applies this comment-marking step before deleting the branch.
 
 | Transition | Where | Effect | Skill-recoverable? |
 |---|---|---|---|
@@ -176,24 +188,6 @@ sequential GitHub-side mutations whose recoverability differs:
 | **T2** | step 13 | Feature branch created in active repo | Yes — branch can be deleted |
 | **T3** | step 16 | Task issues created with sub-issue links | **No — point of no return.** Created issues cannot be auto-removed |
 | **T4** | step 18 | Feature label/status transitioned (via `trigger-implementation` or to `designed`) | Partial — depends on the primitive's outcome |
-
-**Cancel rules by state (interactive mode only — headless has no cancel):**
-
-- **Before T1** (during rationale draft) → Output E. No mutations.
-  Exit cleanly; Feature unchanged.
-- **At T1** (rationale posted, no branch yet) → Output F variant.
-  Comment cannot be unposted; the rationale lives on the issue. Mark
-  the comment as cancelled by editing it to prepend
-  `**[CANCELLED — design did not complete]**` and exit.
-- **At T2** (branch created, no tasks yet) → Output F variant.
-  Delete the local branch (`git branch -D feature/<N>-<slug>`); the
-  remote was never pushed by this skill. Mark the rationale comment
-  as cancelled per T1. Exit.
-- **At T3 or later** (tasks created) → Output F. Surface the partial
-  state — rationale comment, branch, K of M tasks created, label
-  unchanged. Recommend either manual cleanup (close orphan tasks,
-  delete branch, edit comment) or manual completion. Do NOT
-  auto-revert.
 
 **Re-run safety (fail softly).** Step 4 detects whether design has
 already been run for this Feature. The skill exits cleanly in any

--- a/skills/feature-design/SKILL.md
+++ b/skills/feature-design/SKILL.md
@@ -251,42 +251,23 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
 
 4. **Entry guards.** Two checks fire in order before any work:
 
-   **4a. Concurrency check.** Look for the `design-in-progress`
-   label. The label is a beacon: while set, another session is —
-   or recently was — actively designing this Feature.
+   **4a. Concurrency check.** Apply the beacon-claim probe per
+   `skills/definitions/concurrency-beacon.md` for beacon
+   `design-in-progress`:
 
    ```bash
    gh issue view <N> --repo <active-repo> --json labels \
      --jq '[.labels[].name] | index("design-in-progress")'
    ```
 
-   - **Headless** + label set → another session is running. Exit
-     cleanly with Output B variant: "Another design session is in
-     flight; this run is a no-op." Do NOT remove the label (it
-     belongs to the other session).
-   - **Interactive** + label set → render the warning:
-     ```
-     ⚠ design-in-progress is set on this Feature. Another session
-        (workflow run or a separate human session) may be actively
-        designing it. Continuing will likely cause conflicts.
-     ```
-     Then `prompt-user`:
-     ```
-     prompt-user(
-       question: "Another design session may be in progress. Continue anyway?",
-       header: "Concurrent design detected",
-       options: [
-         {label: "Continue anyway",
-          description: "I know the other session is dead or stuck. Proceed."},
-         {label: "Cancel",
-          description: "Exit; the other session keeps its claim."}
-       ]
-     )
-     ```
-     - Continue → fall through to 4b. Step 4c will re-claim the slot.
-     - Cancel → exit cleanly (Output E variant); do NOT remove the
-       label.
-   - Label not set → continue to 4b.
+   Mode-specific exit shapes (per definition's claim-semantics):
+   - **Headless** + beacon set → exit with **Output B variant**:
+     "Another design session is in flight; this run is a no-op."
+   - **Interactive** + beacon set → use the definition's warning
+     and Continue/Cancel prompt (header "Concurrent design
+     detected"). Continue → fall through to 4b (step 4c re-claims).
+     Cancel → Output E variant; do NOT remove the beacon.
+   - **Beacon not set** → continue to 4b.
 
    **4b. Re-run safety check (fail softly).** Detect prior-run artefacts:
 
@@ -327,8 +308,8 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
      ```
      Exit cleanly (Output B variant).
 
-   **4c. Claim the slot.** Apply the `design-in-progress` label to
-   mark this session as the active designer:
+   **4c. Claim the slot.** Apply `design-in-progress` per the
+   concurrency-beacon definition:
 
    ```
    apply-label(repo=<active-repo>, issue=<N>,
@@ -336,13 +317,9 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
    ```
 
    On failure → raise `INVALID_DESIGN_STATE` (`ERROR`); exit before
-   any further work. The label is the lock; without it we cannot
-   guarantee single-writer semantics.
-
-   From this point on, every exit path (success, parked, error,
-   cancel) MUST remove the label as part of its cleanup. See step
-   18 for the happy-path removal and the Error Handling section
-   for the failure-path rule.
+   any further work. From this point on, every exit path MUST
+   release the beacon (see step 18 happy-path and the slot-release
+   rule in Error Handling).
 
 5. **Architecture context.** Read `docs/ARCHITECTURE.md` if it
    exists; hold its contents as Slice SA context for the rationale.
@@ -845,12 +822,9 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/featur
 Pass criteria: both commands exit 0.
 ## Error Handling
 
-**Slot-release rule (universal).** Every error path AND every
-cancel path that fires AFTER step 4c (the label was claimed) MUST
-attempt to remove `design-in-progress` before exit, on a best-effort
-basis. If the removal itself fails, surface it as a `WARN` and exit
-anyway — the original error is what matters; a stuck beacon is a
-secondary concern the human can clear by hand.
+**Slot-release rule.** Per `skills/definitions/concurrency-beacon.md`
+— every error path AND every cancel path that fires AFTER step 4c
+(beacon claimed) MUST best-effort remove `design-in-progress`.
 
 - `INVALID_DESIGN_STATE` from steps 2–3 (Feature missing, not a
   Feature, wrong/multiple/missing trigger labels) → severity

--- a/skills/feature-design/SKILL.md
+++ b/skills/feature-design/SKILL.md
@@ -840,7 +840,8 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/feature-design/SKILL.md
@@ -848,26 +849,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/featur
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `feature-design`.
-
 ## Error Handling
 
 **Slot-release rule (universal).** Every error path AND every

--- a/skills/foreground-recovery/SKILL.md
+++ b/skills/foreground-recovery/SKILL.md
@@ -5,6 +5,7 @@ triggers: human-interactive
 user-invocable: true
 loads:
   - skills/definitions/error-handling.md
+  - skills/definitions/concurrency-beacon.md
   - skills/definitions/step-skip-rule.md
   - skills/prompt-user/SKILL.md
   - skills/gh-agentic/SKILL.md

--- a/skills/foreground-recovery/SKILL.md
+++ b/skills/foreground-recovery/SKILL.md
@@ -415,7 +415,8 @@ exact mutation. Human-in-the-loop is the entire point — bulk
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/foreground-recovery/SKILL.md
@@ -423,26 +424,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/foregr
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `foreground-recovery`.
-
 ## Error Handling
 
 - `INVALID_TARGET` from step 3 (target issue number unparseable

--- a/skills/foreground-recovery/SKILL.md
+++ b/skills/foreground-recovery/SKILL.md
@@ -126,25 +126,20 @@ exact mutation. Human-in-the-loop is the entire point — bulk
    Resolve the active repo per the rule above and hold as
    `<active-repo>`.
 
-   **Branch-safety check.** Some remediations in this skill touch
-   the local working tree (deleting branches, possibly closing
-   issues that auto-update branches via gh hooks). The agent MUST
-   refuse to operate from `main` to prevent any chance of
-   accidental main-branch mutations.
+   **Branch-safety check.** Apply the refuse-on-main guard per
+   `skills/definitions/branch-safety.md`. Some remediations in this
+   skill touch the local working tree (deleting branches, closing
+   issues that auto-update branches via gh hooks).
 
    ```bash
    git branch --show-current
    ```
 
-   - Result `main` (or `master`) → exit cleanly with a clear
-     remediation message:
-     ```
-     This skill refuses to run on main. Switch to a branch first
-     (e.g. `git checkout -b chore/recovery-<timestamp>`), then
-     re-invoke /foreground-recovery.
-     ```
-     No prompt, no scan, no mutations.
-   - Anything else → continue. Hold the branch name as `<branch>`.
+   On `main` / `master` → exit cleanly using the remediation
+   template from the definition with `<suggested-prefix>` =
+   `chore/recovery-<timestamp>`. No prompt, no scan, no mutations.
+
+   Otherwise → hold the branch name as `<branch>` and continue.
 
 2. **Pick mode.** Ask the human:
 

--- a/skills/gh-agentic/SKILL.md
+++ b/skills/gh-agentic/SKILL.md
@@ -415,48 +415,31 @@ Bypass via `--skip-app-install`.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/gh-agentic/SKILL.md
 python3 skills/skill-creator/scripts/check-description-triggers.py skills/gh-agentic/SKILL.md
 ```
 
-Plus the live CI sync check:
+Pass criteria: both commands exit 0.
+
+### Skill-specific extension
+
+This skill is the only one with a CI-enforced sync check between
+its body and the live CLI surface. Run alongside the framework
+checks:
 
 ```bash
 go test ./internal/... -run TestGhAgenticToolSkillCoversCLI
 ```
 
-Pass criteria: all three commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present`, `frontmatter_required_fields`,
-  `frontmatter_name_valid`, `description_within_length_limit`,
-  `description_assertive`, `description_third_person`,
-  `references_resolve`.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `gh-agentic`.
-
-### CI-enforced sync check
-
-Run by `TestGhAgenticToolSkillCoversCLI` in the Go test suite:
-
-- Every cobra command path is mentioned by name in this skill's
-  Command Reference.
-- Every declared flag is mentioned for its command.
-- Removed commands/flags are not mentioned (false positives caught).
-
-If the test fails, the CLI surface drifted. Update this skill in
-the same PR as the CLI change.
+Pass criteria: exit 0. The test asserts every cobra command path
+and flag is mentioned in this skill's Command Reference, and that
+removed commands/flags are not mentioned. If it fails, the CLI
+surface drifted; update this skill in the same PR as the CLI
+change.
 
 ## Error Handling
 

--- a/skills/issue-session/SKILL.md
+++ b/skills/issue-session/SKILL.md
@@ -455,7 +455,8 @@ Hold as `<self>`.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/issue-session/SKILL.md
@@ -463,26 +464,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/issue-
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `issue-session`.
-
 ## Error Handling
 
 **Slot-release rule (universal).** Every error path AND every

--- a/skills/issue-session/SKILL.md
+++ b/skills/issue-session/SKILL.md
@@ -5,6 +5,7 @@ triggers: automated
 user-invocable: false
 loads:
   - skills/definitions/error-handling.md
+  - skills/definitions/concurrency-beacon.md
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
   - skills/definitions/commit-discipline.md
@@ -466,10 +467,9 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/issue-
 Pass criteria: both commands exit 0.
 ## Error Handling
 
-**Slot-release rule (universal).** Every error path AND every
-graceful exit AFTER step 4 (the slot was claimed) MUST attempt to
-remove `issue-in-progress` before exit, on a best-effort basis.
-If the removal itself fails, surface as a `WARN` and exit anyway.
+**Slot-release rule.** Per `skills/definitions/concurrency-beacon.md`
+— every error path AND every graceful exit AFTER step 4 (beacon
+claimed) MUST best-effort remove `issue-in-progress`.
 
 - `INVALID_ISSUE_STATE` from steps 2–4 (issue closed, label
   missing, issue is a pipeline artefact, slot-claim failed) →

--- a/skills/post-issue-comment/SKILL.md
+++ b/skills/post-issue-comment/SKILL.md
@@ -99,7 +99,8 @@ invoke any other skill.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/post-issue-comment/SKILL.md
@@ -107,26 +108,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/post-i
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `post-issue-comment`.
-
 ## Error Handling
 
 - `COMMENT_BODY_EMPTY` from step 1 → severity `ERROR`; propagate.

--- a/skills/pr-review-session/SKILL.md
+++ b/skills/pr-review-session/SKILL.md
@@ -438,7 +438,8 @@ authors use this login.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/pr-review-session/SKILL.md
@@ -446,26 +447,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/pr-rev
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `pr-review-session`.
-
 ## Error Handling
 
 - `INVALID_REVIEW_STATE` from steps 2–3 (PR not open, head branch

--- a/skills/prompt-user/SKILL.md
+++ b/skills/prompt-user/SKILL.md
@@ -156,7 +156,8 @@ not a framework skill and therefore not declared in `loads:`.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/prompt-user/SKILL.md
@@ -164,26 +165,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/prompt
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `prompt-user`.
-
 ## Error Handling
 
 - `MULTI_QUESTION_REJECTED` from step 1 → severity `ERROR`;

--- a/skills/recipe-creation/SKILL.md
+++ b/skills/recipe-creation/SKILL.md
@@ -447,7 +447,8 @@ up the change automatically since it loads the file.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/recipe-creation/SKILL.md
@@ -455,30 +456,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/recipe
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present`, `frontmatter_required_fields`,
-  `frontmatter_name_valid`, `description_within_length_limit`,
-  `description_assertive`, `description_third_person`,
-  `references_resolve`.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `recipe-creation`.
-
-### Self-application
-
-A future enhancement: a Go-side or Python-side lint that re-applies
-the Section B rules to every `recipes/*.yaml` and fails CI on
-non-compliance. Out of scope for this skill itself; tracked as a
-candidate Requirement.
-
 ## Error Handling
 
 - `INVALID_RECIPE_NAME` from step 3 (chosen name is not

--- a/skills/release-notes/SKILL.md
+++ b/skills/release-notes/SKILL.md
@@ -309,7 +309,8 @@ Hold as `<tag>` and `<repo>`.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/release-notes/SKILL.md
@@ -317,26 +318,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/releas
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `release-notes`.
-
 ## Error Handling
 
 - `INVALID_TAG` from step 1 (the tag does not exist locally) →

--- a/skills/requirement-scoping/SKILL.md
+++ b/skills/requirement-scoping/SKILL.md
@@ -1261,7 +1261,8 @@ prompt-user(
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/requirement-scoping/SKILL.md
@@ -1269,33 +1270,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/requir
 ```
 
 Pass criteria: both commands exit 0.
-
-**Behavioural-ceiling note.** Passing the framework checks verifies
-structure (frontmatter, sections, trigger phrasings) and reference
-integrity — not that the agent honours the anti-fabrication clause,
-the per-revision diff, or the impact-delta rule at runtime. Those
-disciplines are self-policed. "Passes verification" means the skill
-is well-formed, not that scoping output will be high quality.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `requirement-scoping`.
-
 ## Error Handling
 
 - `USER_CANCELLED` (raised at any cancel point — Requirement pick,

--- a/skills/requirement-scoping/SKILL.md
+++ b/skills/requirement-scoping/SKILL.md
@@ -6,6 +6,7 @@ loads:
   - skills/definitions/error-handling.md
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
+  - skills/definitions/state-model-pattern.md
   - skills/prompt-user/SKILL.md
   - skills/gh-agentic/SKILL.md
   - skills/apply-label/SKILL.md
@@ -181,10 +182,13 @@ artefact walk (steps in section C):
       now: <new value>
     <unchanged fields are omitted>
   ```
-**State model & cancel semantics.** This skill performs four
-sequential GitHub-side transitions whose recoverability differs.
-The agent must know which state it is in to handle cancellation and
-failure correctly.
+**State model & cancel semantics.** This skill follows the pattern
+in `skills/definitions/state-model-pattern.md`. The concrete tier
+table below is this skill's specifics; the universal cancel rules
+and failure-during-transition rules come from the definition.
+
+Transition errors raised by this skill: `STATUS_TRANSITION_FAILED`
+(label/status flips), `ISSUE_CREATION_FAILED` (Feature creation).
 
 | Transition | Where | Effect | Skill-recoverable? |
 |---|---|---|---|
@@ -193,55 +197,9 @@ failure correctly.
 | **T2 → T3** | step 21 | Triggered Features Backlog → In Design (label + status) | Partial — failed triggers leave Features at Backlog |
 | **T3 → T4** | step 23 | Requirement Scoping → Ready to Implement (label + status) | Partial — failed transition leaves Requirement at Scoping with Features in their final states |
 
-**Cancel rules by state:**
-
-- **Before T1** (during Requirement pick or exploration) → clean
-  exit; no mutations to revert.
-- **At T1** (Requirement at Scoping, no Features yet) → revert
-  the Requirement to Backlog (label + status) and exit (Output D).
-- **At T2 or later** (Features have been created) → the skill
-  CANNOT cleanly undo. Surface the partial state to the human:
-  which Features were created, their current labels and statuses,
-  the Requirement's current state. Recommend manual cleanup
-  (close orphan Features) or completing the work manually (apply
-  `in-design` to selected Features and transition the Requirement
-  to Ready to Implement). Do NOT auto-revert the Requirement to Backlog
-  when Features exist — they would be left as orphans pointing
-  to a backlog-stage parent.
-
-The issue-creation confirmation gate (step 17) MUST warn the human
-about this boundary before T2 fires:
-> "Once you confirm, Feature issues will be created in GitHub.
-> Cancellation after this point cannot remove the created issues
-> automatically; the session would exit with the Features in place
-> and the Requirement still at Scoping."
-
-**Failure-during-transition rules:**
-
-- **T0 → T1 fails partway** (e.g., label applied but status not
-  set) → raise `STATUS_TRANSITION_FAILED`. Exit. The Requirement
-  is in a label/status mismatch state; the next session's pre-entry
-  check (step 3) detects and surfaces it. Recommend
-  `gh agentic repair`.
-- **T1 → T2 partial** (Feature 1 created, Feature 2 fails) → raise
-  `ISSUE_CREATION_FAILED`. DO NOT continue with trigger
-  confirmation — the Feature set is incomplete and partial trigger
-  on a partial set leaves the framework in a worse state. Surface
-  which Features succeeded and which didn't; recommend keeping the
-  successful Features (already valid pipeline artefacts), closing
-  any partial-creation orphans manually, and re-running scoping
-  for the failed ones (which will create them as additional
-  Features under the same parent).
-- **T2 → T3 partial** (some Features triggered, others failed) →
-  raise `STATUS_TRANSITION_FAILED`. DO NOT proceed to T3 → T4 —
-  the Requirement transition is conditional on all triggers
-  succeeding. Surface which Features are at `in-design` vs still
-  at `backlog`; recommend manual re-trigger. The Requirement
-  remains at Scoping.
-- **T3 → T4 fails** → raise `STATUS_TRANSITION_FAILED`. Features
-  are in their intended states; the Requirement is stuck at
-  Scoping. Recommend `gh agentic repair` and manual re-run of
-  the final transition only.
+The issue-creation confirmation gate (step 17) is where the
+"point-of-no-return" warning required by the definition fires;
+see step 17 for the exact phrasing.
 
 **Orphan re-entry refinement.** When step 3 detects the picked
 Requirement at `scoping`, the same `gh agentic status requirement

--- a/skills/requirements-session/SKILL.md
+++ b/skills/requirements-session/SKILL.md
@@ -569,7 +569,8 @@ conditional. Every other step is mandatory.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/requirements-session/SKILL.md
@@ -577,37 +578,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/requir
 ```
 
 Pass criteria: both commands exit 0.
-
-**Behavioural-ceiling note.** Passing the framework checks is a
-necessary but not sufficient signal of quality. The checks verify
-structure (frontmatter, sections, trigger phrasings) and reference
-integrity — they do NOT verify that the agent honours the
-anti-fabrication clause, quoted-evidence gate, or per-revision
-diff at runtime. Those disciplines are self-policed by the agent.
-Treat "passes verification" as "the skill is well-formed", not "the
-skill produces correct requirements".
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `requirements-session` (e.g.
-  *"capture a new requirement"* triggers; *"check the build"*
-  doesn't).
-
 ## Error Handling
 
 - `USER_CANCELLED` (raised from any user-cancel choice — step 2

--- a/skills/session-init/SKILL.md
+++ b/skills/session-init/SKILL.md
@@ -232,7 +232,8 @@ Step 5's dispatch targets:
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/session-init/SKILL.md
@@ -240,26 +241,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/sessio
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `session-init`.
-
 ## Error Handling
 
 - `INDEX_INCOMPLETE` from step 2 (the skill index is missing core

--- a/skills/set-issue-status/SKILL.md
+++ b/skills/set-issue-status/SKILL.md
@@ -220,7 +220,8 @@ get`; it does not invoke any other skill.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/set-issue-status/SKILL.md
@@ -228,26 +229,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/set-is
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `set-issue-status`.
-
 ## Error Handling
 
 - `PROJECT_ID_MISSING` from step 2 → severity `ERROR`; propagate.

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -314,7 +314,8 @@ user. No display primitive needed.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/skill-creator/SKILL.md
@@ -322,31 +323,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/skill-
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists
-  (Goal, Output Artefacts, Definitions, Dependencies, Steps,
-  Verification, Error Handling).
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" and at least one
-  "even if not explicitly asked"-style assertive clause.
-- `description_third_person`.
-- `references_resolve` — every path in Definitions and Dependencies
-  resolves to an existing file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — the description correctly
-  classifies the 5 phrasings pinned in the script's `GROUND_TRUTH`
-  dict for `skill-creator`.
-
 ## Error Handling
 
 - `INTENT_AMBIGUOUS` detected during step 1 → propagate. The user

--- a/skills/skill-creator/scripts/test_no_duplicated_definition_content.py
+++ b/skills/skill-creator/scripts/test_no_duplicated_definition_content.py
@@ -1,0 +1,125 @@
+"""Tests for the no_duplicated_definition_content check.
+
+Run with: python3 -m unittest skills/skill-creator/scripts/test_no_duplicated_definition_content.py
+"""
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+import textwrap
+import unittest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from importlib import import_module
+verify_mod = import_module("verify-skill-mechanical")
+
+
+SKILL_TEMPLATE = textwrap.dedent("""\
+    ---
+    name: {name}
+    description: Test skill. Use when testing the duplication check on a small fixture skill body.
+    triggers: human
+    loads:
+      - skills/definitions/test-definition.md
+    ---
+
+    # Test Skill
+
+    ## Goal
+    Test goal.
+
+    ## Output Artefacts
+    Test artefacts.
+
+    ## Definitions
+    None.
+
+    ## Dependencies
+    None.
+
+    ## Steps
+    {steps_body}
+
+    ## Verification
+    Per skills/definitions/verification-procedure.md.
+
+    ## Error Handling
+    None.
+    """)
+
+
+DEFINITION_BODY = textwrap.dedent("""\
+    # Test Definition
+
+    The skill must apply the canonical safety guard before mutating state.
+    Every consumer skill is required to follow the safe-default protocol.
+    Failures must surface a warning to the operator and halt the work.
+    On retry the skill should re-check whether the precondition still holds.
+    Documentation should record the outcome with a stable identifier.
+    """)
+
+
+class TestNoDuplicatedDefinitionContent(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        # Build a minimal repo layout — .git marker is required for
+        # _find_repo_root to terminate at our temp root.
+        (self.tmp / ".git").mkdir()
+        (self.tmp / "skills" / "definitions").mkdir(parents=True)
+        (self.tmp / "skills" / "test-skill").mkdir(parents=True)
+        # Write definition
+        (self.tmp / "skills" / "definitions" / "test-definition.md").write_text(
+            DEFINITION_BODY
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def _run(self, steps_body: str) -> verify_mod.CheckResult:
+        skill_path = self.tmp / "skills" / "test-skill" / "SKILL.md"
+        skill_path.write_text(SKILL_TEMPLATE.format(
+            name="test-skill", steps_body=steps_body))
+        skill = verify_mod.Skill.load(skill_path)
+        return verify_mod.check_no_duplicated_definition_content(skill)
+
+    def test_clean_skill_passes(self):
+        """Skill loads the definition without restating content."""
+        steps = "Follow the test-definition for the canonical procedure."
+        result = self._run(steps)
+        self.assertTrue(result.passed,
+            f"clean skill should pass; got: {result.detail}")
+
+    def test_full_block_duplication_fails(self):
+        """Skill restates 4+ consecutive lines from the definition verbatim."""
+        # Copy 4 meaningful lines from DEFINITION_BODY into the skill body
+        steps = textwrap.dedent("""\
+            Inline copy of the definition's content (this should fail):
+
+            The skill must apply the canonical safety guard before mutating state.
+            Every consumer skill is required to follow the safe-default protocol.
+            Failures must surface a warning to the operator and halt the work.
+            On retry the skill should re-check whether the precondition still holds.
+            """)
+        result = self._run(steps)
+        self.assertFalse(result.passed,
+            "verbatim 4-line block should fail the check")
+        self.assertIn("test-definition.md", result.detail)
+
+    def test_short_phrase_echo_passes(self):
+        """A 1-2 line phrase echo from the definition does NOT fail the check."""
+        steps = textwrap.dedent("""\
+            Some skill-specific prose here that talks about verification.
+
+            The skill must apply the canonical safety guard before mutating state.
+            But the rest of this section is genuinely skill-specific and
+            does not echo any further lines from the test-definition body.
+            We pivot to a different topic and stay on it for the duration.
+            """)
+        result = self._run(steps)
+        self.assertTrue(result.passed,
+            f"single-line echo should pass; got: {result.detail}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/skill-creator/scripts/verify-skill-mechanical.py
+++ b/skills/skill-creator/scripts/verify-skill-mechanical.py
@@ -333,6 +333,102 @@ def _extract_referenced_paths(body: str) -> set[str]:
     return paths
 
 
+# A skill loading a skills/definitions/*.md file MUST NOT also restate
+# the definition's content inline — the load directive is the canonical
+# reference. The check below catches drift where a maintainer adds a
+# load directive but forgets to remove the now-duplicate inline prose.
+DUPLICATION_RUN_LENGTH = 4
+_TRIVIAL_LINE_RE = re.compile(r"^(?:\s*|\s*```.*|\s*#+\s*.*|\s*[-*]\s*|\s*\|.*)$")
+
+
+def _meaningful_lines(text: str) -> list[tuple[int, str]]:
+    """Return (1-based line number, stripped content) for non-trivial lines.
+
+    Trivial lines (blank, fence markers, headings, list-bullet skeletons,
+    table separators) are excluded so a run of N consecutive meaningful
+    lines is a strong duplication signal rather than coincidental
+    structural overlap.
+    """
+    out: list[tuple[int, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or _TRIVIAL_LINE_RE.match(line):
+            continue
+        # Drop very short lines (under 20 chars) — phrase-level overlap
+        # is not duplication of substance.
+        if len(stripped) < 20:
+            continue
+        out.append((i, stripped))
+    return out
+
+
+def check_no_duplicated_definition_content(skill: Skill) -> CheckResult:
+    """A skill loading a definition MUST NOT restate its content inline.
+
+    For each `skills/definitions/*.md` entry in the skill's `loads:`
+    frontmatter, look for a run of `DUPLICATION_RUN_LENGTH` consecutive
+    meaningful lines from the definition appearing verbatim in the skill
+    body. Failure surfaces the skill, the definition, and the line
+    range of the first offending run.
+    """
+    loads = skill.frontmatter.get("loads", [])
+    if not isinstance(loads, list):
+        return CheckResult("no_duplicated_definition_content", passed=True,
+                           detail="no loads list to check")
+
+    repo_root = _find_repo_root(skill.path)
+    skill_body_set = set(line for _, line in _meaningful_lines(skill.body))
+    skill_body_lines = [line for _, line in _meaningful_lines(skill.body)]
+
+    duplications: list[dict] = []
+    for ref in loads:
+        if not ref.startswith("skills/definitions/"):
+            continue
+        def_path = repo_root / ref
+        if not def_path.exists():
+            continue  # references_resolve catches this separately
+        def_lines = _meaningful_lines(def_path.read_text())
+        # Slide a window of DUPLICATION_RUN_LENGTH over the definition's
+        # meaningful lines; flag if every line in the window also appears
+        # in the skill body.
+        for i in range(len(def_lines) - DUPLICATION_RUN_LENGTH + 1):
+            window = def_lines[i:i + DUPLICATION_RUN_LENGTH]
+            if all(line in skill_body_set for _, line in window):
+                # Now require the matching skill-body lines to be
+                # contiguous as well — otherwise it's coincidental
+                # phrase reuse, not block duplication.
+                first_def_line = window[0][1]
+                if first_def_line not in skill_body_lines:
+                    continue
+                start_idx = skill_body_lines.index(first_def_line)
+                contiguous = all(
+                    start_idx + k < len(skill_body_lines)
+                    and skill_body_lines[start_idx + k] == window[k][1]
+                    for k in range(DUPLICATION_RUN_LENGTH)
+                )
+                if contiguous:
+                    duplications.append({
+                        "definition": ref,
+                        "definition_lines": f"{window[0][0]}-{window[-1][0]}",
+                        "first_match": first_def_line[:80],
+                    })
+                    break  # one report per definition is enough
+
+    if duplications:
+        first = duplications[0]
+        detail = (
+            f"skill body restates {len(duplications)} loaded definition(s); "
+            f"first: {first['definition']} lines {first['definition_lines']}"
+        )
+        return CheckResult(
+            "no_duplicated_definition_content",
+            passed=False,
+            detail=detail,
+            extra={"duplications": duplications},
+        )
+    return CheckResult("no_duplicated_definition_content", passed=True)
+
+
 # ---------------------------------------------------------------------------
 # Check registry
 # ---------------------------------------------------------------------------
@@ -345,6 +441,7 @@ CHECKS: dict[str, Callable[[Skill], CheckResult]] = {
     "description_assertive": check_description_assertive,
     "description_third_person": check_description_third_person,
     "references_resolve": check_references_resolve,
+    "no_duplicated_definition_content": check_no_duplicated_definition_content,
 }
 
 

--- a/skills/solution-architecture/SKILL.md
+++ b/skills/solution-architecture/SKILL.md
@@ -166,21 +166,18 @@ prompt-user(
    Resolve the active repo (informational) and hold as
    `<active-repo>`.
 
-2. **Branch check.** Confirm we are NOT on `main`:
+2. **Branch check.** Apply the refuse-on-main guard per
+   `skills/definitions/branch-safety.md`:
 
    ```bash
    git branch --show-current
    ```
 
-   - Result `main` (or `master`) → raise `ON_MAIN_BRANCH` (`ERROR`)
-     with a clear remediation:
-     ```
-     This skill refuses to run on main. Switch to a branch first
-     (e.g. `git checkout -b chore/architecture-update`), then
-     re-invoke /solution-architecture.
-     ```
-     Exit cleanly. No mutations.
-   - Anything else → continue. Hold the branch name as `<branch>`.
+   On `main` / `master` → raise `ON_MAIN_BRANCH` (`ERROR`) using the
+   remediation template from the definition with `<suggested-prefix>`
+   = `chore/architecture-update`. Exit cleanly. No mutations.
+
+   Otherwise → hold the branch name as `<branch>` and continue.
 
 3. **Detect mode.** Check whether `docs/ARCHITECTURE.md` exists:
 

--- a/skills/solution-architecture/SKILL.md
+++ b/skills/solution-architecture/SKILL.md
@@ -480,7 +480,8 @@ right; the human will extend over time.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/solution-architecture/SKILL.md
@@ -488,26 +489,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/soluti
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `solution-architecture`.
-
 ## Error Handling
 
 - `ON_MAIN_BRANCH` from step 2 (current branch is `main` /

--- a/skills/trigger-design/SKILL.md
+++ b/skills/trigger-design/SKILL.md
@@ -155,7 +155,8 @@ No file artefacts. No state outside the named Feature changes.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/trigger-design/SKILL.md
@@ -163,26 +164,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/trigge
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `trigger-design`.
-
 ## Error Handling
 
 - `INVALID_TRIGGER_STATE` from steps 2–3 (issue not found, not a

--- a/skills/trigger-implementation/SKILL.md
+++ b/skills/trigger-implementation/SKILL.md
@@ -160,7 +160,8 @@ No file artefacts. No state outside the named Feature changes.
 
 ## Verification
 
-Run the framework checks against this skill:
+Per `skills/definitions/verification-procedure.md` "Section format".
+Skill-specific commands:
 
 ```bash
 python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/trigger-implementation/SKILL.md
@@ -168,26 +169,6 @@ python3 skills/skill-creator/scripts/check-description-triggers.py skills/trigge
 ```
 
 Pass criteria: both commands exit 0.
-
-### Mechanical checks
-
-Run by `verify-skill-mechanical.py`:
-
-- `all_sections_present` — every mandatory section heading exists.
-- `frontmatter_required_fields(name, description, triggers, loads)`.
-- `frontmatter_name_valid` — kebab-case, matches filename.
-- `description_within_length_limit` — ≤ 1024 chars.
-- `description_assertive` — contains "Use when" + assertive clause.
-- `description_third_person`.
-- `references_resolve` — every `loads:` path resolves to a file.
-
-### Ground-truth checks
-
-Run by `check-description-triggers.py`:
-
-- `description_triggers_appropriately` — phrasings classified per
-  the `GROUND_TRUTH` entry for `trigger-implementation`.
-
 ## Error Handling
 
 - `INVALID_TRIGGER_STATE` from steps 2–3 (issue not found, not a


### PR DESCRIPTION
## Summary

- Extracts four cross-cutting boilerplate patterns into `skills/definitions/`: Verification stanza, state-model & cancel semantics, branch-safety guard, concurrency-beacon claim/release.
- Migrates 19 consumer skills to load these definitions; consumer-skill body shrinks by 468 lines net.
- Adds a new mechanical check `no_duplicated_definition_content` in `verify-skill-mechanical.py` to catch future skills that load a definition AND restate its content inline (with unit tests).

Closes #674.
Implements Tasks #675, #676, #677, #678, #679, #680.

## Changes

| Commit | What |
|---|---|
| Task 1 | Expand `verification-procedure.md` with the canonical Verification section format; migrate 19 skills. |
| Task 2 | Add `state-model-pattern.md`; migrate `requirement-scoping`, `feature-design`. |
| Task 3 | Add `branch-safety.md`; migrate `solution-architecture`, `foreground-recovery`. |
| Task 4 | Add `concurrency-beacon.md`; migrate `dev-session`, `feature-design`, `foreground-recovery`, `issue-session`. |
| Task 5 | Add `no_duplicated_definition_content` check + unit tests. |
| Task 6 | Final verification report (posted on #674 as a comment). |

## Verification

- `python3 skills/skill-creator/scripts/verify-skill-mechanical.py skills/<each>/SKILL.md` — exits 0 for every SKILL.md (8 checks each).
- `python3 skills/skill-creator/scripts/test_no_duplicated_definition_content.py` — 3/3 unit tests pass.
- `go test ./...` — all packages pass.

## AC summary

- AC-1, AC-2, AC-4 (consumer-skill measure: -468 lines, target ~600 within ±200): satisfied.
- AC-3: satisfied in spirit. Literal reading is unsatisfiable because every skill has a Verification section, so every skill received the load directive change. The intended invariant — skills outside the four extraction sets see only the Verification change, no other migration churn — holds.

See the full report at https://github.com/eddiecarpenter/gh-agentic/issues/674#issuecomment-4325569234.

## Test plan

- [x] `verify-skill-mechanical.py` passes for every skill
- [x] `no_duplicated_definition_content` unit tests pass
- [x] `go test ./...` passes
- [ ] Reviewer reads the four new/expanded definitions and confirms the prose captures the universal pattern
- [ ] Reviewer spot-checks 2-3 consumer migrations for content fidelity

🤖 Generated with [Claude Code](https://claude.com/claude-code)