### PR TITLE
fix(recipes): add prompt: field — recipes were broken in headless mode

### DIFF
--- a/.goose/recipes/dev-session.yaml
+++ b/.goose/recipes/dev-session.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 200
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `dev-session` skill for Feature {{ feature_number }}. The
   skill is the authoritative playbook; do not improvise.

--- a/.goose/recipes/feature-design.yaml
+++ b/.goose/recipes/feature-design.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 100
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `feature-design` skill for Feature {{ feature_number }}. The
   skill is the authoritative playbook; do not improvise.

--- a/.goose/recipes/issue-session.yaml
+++ b/.goose/recipes/issue-session.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 100
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `issue-session` skill for issue {{ issue_number }}. The skill
   is the authoritative playbook; do not improvise.

--- a/.goose/recipes/pr-review-session.yaml
+++ b/.goose/recipes/pr-review-session.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 100
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `pr-review-session` skill for PR {{ pr_number }}. The skill is
   the authoritative playbook; do not improvise.

--- a/.goose/recipes/release-notes.yaml
+++ b/.goose/recipes/release-notes.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 50
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `release-notes` skill for tag {{ tag }}. The skill is the
   authoritative playbook; do not improvise.

--- a/recipes/dev-session.yaml
+++ b/recipes/dev-session.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 200
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `dev-session` skill for Feature {{ feature_number }}. The
   skill is the authoritative playbook; do not improvise.

--- a/recipes/feature-design.yaml
+++ b/recipes/feature-design.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 100
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `feature-design` skill for Feature {{ feature_number }}. The
   skill is the authoritative playbook; do not improvise.

--- a/recipes/issue-session.yaml
+++ b/recipes/issue-session.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 100
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `issue-session` skill for issue {{ issue_number }}. The skill
   is the authoritative playbook; do not improvise.

--- a/recipes/pr-review-session.yaml
+++ b/recipes/pr-review-session.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 100
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `pr-review-session` skill for PR {{ pr_number }}. The skill is
   the authoritative playbook; do not improvise.

--- a/recipes/release-notes.yaml
+++ b/recipes/release-notes.yaml
@@ -20,6 +20,9 @@ settings:
   max_turns: 50
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `release-notes` skill for tag {{ tag }}. The skill is the
   authoritative playbook; do not improvise.

--- a/skills/definitions/recipe-pattern.md
+++ b/skills/definitions/recipe-pattern.md
@@ -63,10 +63,30 @@ settings:
   max_turns: <integer>
 
 instructions: |
-  <thin-shell instructions block — see below>
+  <one-line orientation — see "The instructions block" below>
+
+prompt: |
+  <thin-shell directive — see "The prompt block" below>
 ```
 
 No other top-level keys are permitted.
+
+### Why both `instructions:` and `prompt:`
+
+Goose requires a `prompt:` in headless mode — it is the user
+message that initiates the session. Without it, `goose run
+--recipe <file>` exits immediately with `Error: no text provided
+for prompt in headless mode`. The `instructions:` block is the
+system prompt (persistent context); the `prompt:` block is the
+kick-off (the first user turn).
+
+For a thin-shell recipe both are short, and they carry different
+content:
+
+- `instructions:` — one line of orientation. Names the agent's
+  role abstractly so the system prompt isn't empty.
+- `prompt:` — the actual directive: load the rulebook and execute
+  the named skill with parameters. This is what the agent acts on.
 
 ### The `description:` field — User Story shape
 
@@ -128,11 +148,23 @@ If you need to invoke an interactive skill non-interactively,
 that's an architectural change to the skill (add a hybrid mode),
 not a recipe trick.
 
-## The instructions block — canonical shape
+## The instructions block — orientation only
 
-The `instructions:` block is the only place where recipe-vs-skill
-discipline is at risk. It MUST follow this floor template and
-nothing else.
+`instructions:` is the system prompt. For a thin-shell recipe it
+is one line stating the agent's role abstractly:
+
+```
+You are an automated agent in this project's agentic delivery pipeline.
+```
+
+That is the entire body. No directive, no parameters, no skill
+name. The directive lives in `prompt:`.
+
+## The prompt block — canonical shape
+
+`prompt:` is the kick-off directive. It is the one place where
+recipe-vs-skill discipline is at risk and MUST follow this floor
+template.
 
 ### Default: single skill
 
@@ -332,15 +364,19 @@ settings:
   max_turns: 100
 
 instructions: |
+  You are an automated agent in this project's agentic delivery pipeline.
+
+prompt: |
   Load `AGENTS.md` (the project rulebook). Then execute the
   `feature-design` skill for Feature {{ feature_number }}. The
   skill is the authoritative playbook; do not improvise.
 ```
 
-That's the entire recipe. Below `instructions: |` are exactly
-three lines of directive: load the rulebook, execute the named
-skill with parameters, do not improvise. No steps, no gh commands,
-no decisions, no sub-headings.
+That's the entire recipe. `instructions:` is one line of
+orientation. Below `prompt: |` are exactly three lines of
+directive: load the rulebook, execute the named skill with
+parameters, do not improvise. No steps, no gh commands, no
+decisions, no sub-headings.
 
 ## What changes go in the recipe vs the skill
 


### PR DESCRIPTION
## Summary

The v2.5.0 release-notes workflow ([run 24988378167](https://github.com/eddiecarpenter/gh-agentic/actions/runs/24988378167)) failed with:

\`\`\`
Error: no text provided for prompt in headless mode
\`\`\`

Root cause: the thin-shell rebuild dropped the \`prompt:\` field from every recipe. Goose's headless mode requires \`prompt:\` (the kick-off user message) to be non-empty. The directive lived only in \`instructions:\` (system prompt), so headless invocations had no user message to act on. **All 5 recipes were broken in headless mode**, but the bug only surfaced when the release-notes workflow fired against v2.5.0.

## Fix

- Move the thin-shell directive (load AGENTS.md; execute the named skill) from \`instructions:\` to \`prompt:\`.
- Replace \`instructions:\` with one line of orientation: *"You are an automated agent in this project's agentic delivery pipeline."*
- Update [skills/definitions/recipe-pattern.md](skills/definitions/recipe-pattern.md) to require both fields, document the split (instructions: orientation; prompt: directive), and refresh the worked example.

All 5 recipes fixed in both \`recipes/\` and \`.goose/recipes/\` (these are kept in sync by hand).

## Test plan

- [x] \`go test ./...\` passes
- [ ] Merge → tag v2.5.1 → publish-release.yml → release.yml runs against v2.5.1 with the fixed recipes
- [ ] Verify release-notes workflow exits 0 and posts notes on the v2.5.1 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)