### PR TITLE
fix(doctor): soften AGENT_PROVIDER/AGENT_MODEL missing to warning

### DIFF
--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -265,11 +265,37 @@ func promptValue(p doctor.PendingPrompt, deps doctor.CheckDeps) (string, error) 
 		return promptRunnerLabel(deps)
 	}
 
-	var value string
 	title := p.Name
 	if p.Description != "" {
 		title = p.Name + " — " + p.Description
 	}
+
+	// When the variable has a sensible default, ask whether to accept it or
+	// supply a custom value, rather than presenting an open-ended input.
+	if p.Default != "" && p.Kind != "secret" {
+		const (
+			useDefault = "default"
+			useCustom  = "custom"
+		)
+		choice := useDefault
+		selectForm := huh.NewForm(huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(title).
+				Options(
+					huh.NewOption(fmt.Sprintf("Use default (%q)", p.Default), useDefault),
+					huh.NewOption("Set a custom value", useCustom),
+				).
+				Value(&choice),
+		))
+		if err := selectForm.Run(); err != nil {
+			return "", err
+		}
+		if choice == useDefault {
+			return p.Default, nil
+		}
+	}
+
+	var value string
 	input := huh.NewInput().Title(title).Value(&value)
 	if p.Default != "" {
 		input = input.Placeholder(p.Default)

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -587,6 +587,18 @@ func checkVariable(deps CheckDeps, name string) CheckResult {
 		return CheckResult{Name: name, Status: Pass, Message: name + " configured"}
 	}
 
+	// Variables with a known sensible default are not hard failures — the
+	// workflows fall back to the same default, so the pipeline is still
+	// runnable. Surface as a Warning so the human sees the suggestion but
+	// `check` exits 0. Repair still offers an interactive prompt.
+	if meta, ok := pendingDescriptions[name]; ok && meta.Default != "" {
+		return CheckResult{
+			Name: name, Status: Warning,
+			Message:     fmt.Sprintf("%s not set — using default %q", name, meta.Default),
+			Remediation: remediationSet("variable", name, deps),
+		}
+	}
+
 	return CheckResult{
 		Name: name, Status: Fail,
 		Message:     name + " not configured",

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -912,6 +912,29 @@ func TestFindShadowValues_DeterministicOrder(t *testing.T) {
 	}
 }
 
+// TestCheckVariable_MissingWithDefault_Warns covers the soft-default behaviour:
+// AGENT_PROVIDER and AGENT_MODEL have safe defaults (workflows fall back to
+// `claude-code`), so a missing value is reported as a Warning with the
+// default surfaced — not a hard failure.
+func TestCheckVariable_MissingWithDefault_Warns(t *testing.T) {
+	deps := CheckDeps{
+		RepoFullName: "acme/domain", Owner: "acme", Topology: "single",
+		Run: func(name string, args ...string) (string, error) {
+			return "", nil // variable absent
+		},
+	}
+	res := checkVariable(deps, "AGENT_PROVIDER")
+	if res.Status != Warning {
+		t.Fatalf("status: got %d (%s), want Warning", res.Status, res.Message)
+	}
+	if !strings.Contains(res.Message, "claude-code") {
+		t.Errorf("message: got %q, want default 'claude-code' surfaced", res.Message)
+	}
+	if !strings.HasPrefix(res.Remediation, "gh variable set AGENT_PROVIDER") {
+		t.Errorf("remediation should still offer set hint, got %q", res.Remediation)
+	}
+}
+
 func TestCheckVariable_Federated_SharedAtNeither_FailWithOrgRemediation(t *testing.T) {
 	r := &ghRun{}
 	deps := CheckDeps{

--- a/internal/doctor/repair.go
+++ b/internal/doctor/repair.go
@@ -261,7 +261,15 @@ func RepairPipeline(deps CheckDeps, setLabel func(string)) RepairResult {
 
 	for _, g := range report.Groups {
 		for _, r := range g.Results {
-			if r.Status != Fail {
+			// Warning results are normally informational and ignored by repair.
+			// Exception: missing variables that have a known default still
+			// expose a remediation hint — let the human accept the default or
+			// supply a custom value via the interactive prompt path.
+			if r.Status == Warning {
+				if _, ok := pendingKind(r); !ok {
+					continue
+				}
+			} else if r.Status != Fail {
 				continue
 			}
 


### PR DESCRIPTION
## Summary
- `checkVariable` returns `Warning` (not `Fail`) when a missing variable has a known default in `pendingDescriptions` — message surfaces the default value, e.g. `AGENT_PROVIDER not set — using default "claude-code"`. Workflows fall back to the same default, so the pipeline is still runnable.
- `repair` loop now also processes Warning results that carry a `gh variable set` / `gh secret set` remediation hint, so the var is still offered interactively.
- `promptValue` in the CLI shows a Select first when the var has a default: `Use default ("claude-code")` vs `Set a custom value`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New unit test `TestCheckVariable_MissingWithDefault_Warns` covers the soft-default path.
- [ ] Manual: `gh agentic check` on a repo without `AGENT_PROVIDER` / `AGENT_MODEL` — verify Warning rendering and exit 0.
- [ ] Manual: `gh agentic repair` on the same repo — verify the new "Use default / Set custom" select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)