### PR TITLE
chore(workflows): drop .agentic-tools bridge, route composite actions via .ai/

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -16,9 +16,12 @@ name: Agentic Pipeline
 # any repo this workflow runs against (and on `eddiecarpenter/gh-agentic`,
 # whose submodule is fetched during checkout). See `docs/github-app-setup.md`.
 #
-# Framework mount: `.ai/` and `.agentic-tools/` are tracked as git
-# submodules (since PR #620). Checkout steps use `submodules: recursive`
-# to populate them — no separate clone or `Mount AI framework` step.
+# Framework mount: `.ai/` is tracked as a git submodule (since PR #620)
+# pointing at eddiecarpenter/gh-agentic. Checkout steps use
+# `submodules: recursive` to populate it — no separate clone or
+# `Mount AI framework` step. Composite actions are reached via
+# `./.ai/.github/actions/...`, which resolves into the submodule on
+# domain repos and via the `.ai -> .` symlink in gh-agentic itself.
 #
 # `workflow_dispatch` inputs (pr_number, branch_name) reach this workflow
 # two ways: directly from a dispatch event on gh-agentic (via
@@ -130,13 +133,13 @@ jobs:
           node-version: 'lts/*'
 
       - name: Install tools
-        uses: ./.agentic-tools/.github/actions/install-ai-tools
+        uses: ./.ai/.github/actions/install-ai-tools
         with:
           agentic-version: ${{ steps.version.outputs.version }}
           gh-token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Claude Code auth
-        uses: ./.agentic-tools/.github/actions/setup-claude-auth
+        uses: ./.ai/.github/actions/setup-claude-auth
         with:
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -396,13 +399,13 @@ jobs:
           node-version: 'lts/*'
 
       - name: Install tools
-        uses: ./.agentic-tools/.github/actions/install-ai-tools
+        uses: ./.ai/.github/actions/install-ai-tools
         with:
           agentic-version: ${{ steps.version.outputs.version }}
           gh-token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Claude Code auth
-        uses: ./.agentic-tools/.github/actions/setup-claude-auth
+        uses: ./.ai/.github/actions/setup-claude-auth
         with:
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -582,13 +585,13 @@ jobs:
           node-version: 'lts/*'
 
       - name: Install tools
-        uses: ./.agentic-tools/.github/actions/install-ai-tools
+        uses: ./.ai/.github/actions/install-ai-tools
         with:
           agentic-version: ${{ steps.version.outputs.version }}
           gh-token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Claude Code auth
-        uses: ./.agentic-tools/.github/actions/setup-claude-auth
+        uses: ./.ai/.github/actions/setup-claude-auth
         with:
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -683,13 +686,13 @@ jobs:
           node-version: 'lts/*'
 
       - name: Install tools
-        uses: ./.agentic-tools/.github/actions/install-ai-tools
+        uses: ./.ai/.github/actions/install-ai-tools
         with:
           agentic-version: ${{ steps.version.outputs.version }}
           gh-token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Claude Code auth
-        uses: ./.agentic-tools/.github/actions/setup-claude-auth
+        uses: ./.ai/.github/actions/setup-claude-auth
         with:
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           gh-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ name: Release Notes
 #
 # Authentication mirrors agentic-pipeline.yml: a GitHub App installation
 # token is minted at the start of the job. The framework is mounted via
-# git submodules (`.ai/` and `.agentic-tools/` in the parent repo) — no
-# bespoke `Mount AI framework` step.
+# the `.ai/` git submodule in the parent repo — no bespoke
+# `Mount AI framework` step.
 
 on:
   release:
@@ -71,12 +71,12 @@ jobs:
           node-version: 'lts/*'
 
       - name: Install tools
-        uses: ./.agentic-tools/.github/actions/install-ai-tools
+        uses: ./.ai/.github/actions/install-ai-tools
         with:
           gh-token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Claude Code auth
-        uses: ./.agentic-tools/.github/actions/setup-claude-auth
+        uses: ./.ai/.github/actions/setup-claude-auth
         with:
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           gh-token: ${{ steps.app-token.outputs.token }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".agentic-tools"]
-	path = .agentic-tools
-	url = https://github.com/eddiecarpenter/gh-agentic.git

--- a/internal/mount/reusable_workflow_test.go
+++ b/internal/mount/reusable_workflow_test.go
@@ -14,23 +14,18 @@ import (
 // against the domain repo's workspace — which does not contain the
 // actions — and every domain pipeline failed at the "Install tools" step.
 //
-// The fix is to populate `.agentic-tools/` with eddiecarpenter/gh-agentic
-// and reference the actions via that path. Two mechanisms populate it:
-//
-//  1. Legacy (pre-#622): an explicit `actions/checkout` step with
-//     `repository: eddiecarpenter/gh-agentic` + `path: .agentic-tools`.
-//  2. Current (post-#622): `.agentic-tools/` is tracked as a git
-//     submodule pointing at gh-agentic, and the primary checkout step
-//     uses `submodules: recursive` to populate it.
-//
-// This test accepts either mechanism — it only fails if `./.agentic-tools/...`
-// is referenced AND neither population mechanism is present.
+// The fix is to reference the actions via `./.ai/.github/actions/...`. The
+// `.ai/` mount is the single bridge to the framework: it is a git submodule
+// pointing at eddiecarpenter/gh-agentic in domain repos, and a `.ai -> .`
+// symlink in gh-agentic itself. `submodules: recursive` on the primary
+// checkout step populates it.
 //
 // If this test fails, the reusable workflow either:
 //   - re-introduced a `./.github/actions/...` path (must use
-//     `./.agentic-tools/.github/actions/...` instead), or
-//   - dropped both the nested checkout of eddiecarpenter/gh-agentic
-//     and the `submodules: recursive` option on the primary checkout.
+//     `./.ai/.github/actions/...` instead),
+//   - re-introduced a reference to the legacy `.agentic-tools/` bridge, or
+//   - dropped `submodules: recursive` on the primary checkout, leaving
+//     `.ai/` unpopulated when consumed from a domain repo.
 func TestReusableWorkflowHasNoCallerRelativeActionPaths(t *testing.T) {
 	path := reusableWorkflowPath(t)
 	data, err := os.ReadFile(path)
@@ -50,42 +45,34 @@ func TestReusableWorkflowHasNoCallerRelativeActionPaths(t *testing.T) {
 			t.Errorf(
 				"%s line %d references ./.github/actions/... in a uses: step — these paths resolve "+
 					"in the caller's workspace and will fail in every domain repo. Use "+
-					"./.agentic-tools/.github/actions/... and nested-checkout eddiecarpenter/gh-agentic "+
-					"at the resolved framework version.\n  line: %s",
+					"./.ai/.github/actions/... instead — the .ai/ submodule (or symlink in "+
+					"gh-agentic itself) is the bridge to the framework's composite actions.\n  line: %s",
 				filepath.Base(path), i+1, trimmed,
 			)
 		}
 	}
 
-	// `.agentic-tools/` must be populated by one of two mechanisms before
-	// any `./.agentic-tools/...` consumer runs:
-	//   1. Legacy: an explicit nested checkout step with
-	//      `repository: eddiecarpenter/gh-agentic` + `path: .agentic-tools`.
-	//   2. Current: a primary checkout with `submodules: recursive`, which
-	//      populates the `.agentic-tools/` submodule (added in PR #620,
-	//      consolidated by Feature #622).
-	// Either is sufficient. Guard the consumer side so a future edit
-	// cannot drop both mechanisms and leave a dangling relative path.
-	hasNestedCheckout := strings.Contains(content, "repository: eddiecarpenter/gh-agentic") &&
-		strings.Contains(content, "path: .agentic-tools")
-	hasSubmoduleCheckout := strings.Contains(content, "submodules: recursive")
-	hasNestedConsumer := strings.Contains(content, "./.agentic-tools/.github/actions/")
-
-	if hasNestedConsumer && !(hasNestedCheckout || hasSubmoduleCheckout) {
+	// The legacy `.agentic-tools/` bridge has been removed in favour of
+	// `.ai/`. Any reference to it — in `uses:` paths, comments, or
+	// elsewhere — is a regression.
+	if strings.Contains(content, ".agentic-tools") {
 		t.Errorf(
-			"%s references ./.agentic-tools/... actions but neither (a) nested-checkouts "+
-				"eddiecarpenter/gh-agentic into path: .agentic-tools nor (b) uses "+
-				"submodules: recursive on the primary checkout. Add one mechanism "+
-				"before the first consumer.",
+			"%s references the legacy .agentic-tools/ bridge — this was replaced by .ai/. "+
+				"Use ./.ai/.github/actions/... for composite actions.",
 			filepath.Base(path),
 		)
 	}
 
-	if hasNestedCheckout && !hasNestedConsumer {
+	// `.ai/` must be populated by `submodules: recursive` on the primary
+	// checkout before any `./.ai/.github/actions/...` consumer runs.
+	hasSubmoduleCheckout := strings.Contains(content, "submodules: recursive")
+	hasNestedConsumer := strings.Contains(content, "./.ai/.github/actions/")
+
+	if hasNestedConsumer && !hasSubmoduleCheckout {
 		t.Errorf(
-			"%s nested-checkouts eddiecarpenter/gh-agentic into .agentic-tools/ but no step "+
-				"consumes it. The checkout is dead weight — either wire up the actions via "+
-				"./.agentic-tools/.github/actions/... or remove the checkout step.",
+			"%s references ./.ai/.github/actions/... actions but the primary checkout does not "+
+				"use `submodules: recursive`. Without it, the .ai/ submodule is empty in domain "+
+				"repos and every consuming step fails at startup.",
 			filepath.Base(path),
 		)
 	}


### PR DESCRIPTION
## Summary

- Workflows ([agentic-pipeline.yml](.github/workflows/agentic-pipeline.yml), [release.yml](.github/workflows/release.yml)) now reach composite actions via `./.ai/.github/actions/...` instead of the legacy `./.agentic-tools/.github/actions/...`. The `.ai/` mount is the single bridge to the framework: submodule in domain repos, `.ai -> .` symlink in gh-agentic itself.
- `.agentic-tools/` submodule and `.gitmodules` removed — the bridge is gone.
- `internal/mount/reusable_workflow_test.go` rewritten to enforce the new policy: forbid `./.github/actions/...` in `uses:` (the v2.2.2 trap), forbid any reference to the legacy `.agentic-tools/`, and require `submodules: recursive` on the primary checkout whenever `./.ai/.github/actions/...` is consumed.

## Test plan

- [ ] `go build ./...` and `go test ./...` pass locally — done
- [ ] CI green on this branch (verifies the workflow paths resolve at runtime)
- [ ] Spot-check that a domain repo's pipeline (which calls `agentic-pipeline.yml` via `workflow_call`) still resolves the composite actions through its `.ai/` submodule

🤖 Generated with [Claude Code](https://claude.com/claude-code)