### PR TITLE
fix(release): use GITHUB_TOKEN for AGENTIC_FRAMEWORK_VERSION bump

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -57,9 +57,16 @@ jobs:
       # step closes that loop. It is local to this repo (documented in
       # LOCALRULES.md "Release Version Sync") and does not belong in any
       # framework-shared workflow.
+      # Uses the workflow's GITHUB_TOKEN (not the App token): the
+      # `actions: write` permission declared on this job covers
+      # `gh variable set` against this repo, while the App installation
+      # currently lacks the "Variables" permission. This step does not
+      # need to trigger any downstream workflow, so the GITHUB_TOKEN
+      # event-cascading restriction (which applies to the GoReleaser
+      # step above) does not matter here.
       - name: Bump AGENTIC_FRAMEWORK_VERSION to released tag
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           gh variable set AGENTIC_FRAMEWORK_VERSION \


### PR DESCRIPTION
## Summary

- The v2.5.4 [Publish Release run](https://github.com/eddiecarpenter/gh-agentic/actions/runs/25035722436) failed at the `Bump AGENTIC_FRAMEWORK_VERSION` step with `HTTP 403: Resource not accessible by integration` — the agentic GitHub App installation lacks the `Variables` permission, so its installation token cannot write repo Actions variables.
- Switched the bump step to the workflow's `GITHUB_TOKEN`. The job already declares `permissions: actions: write`, which covers `gh variable set` against this repo. The App token remains in use for the GoReleaser step (which must publish the release event so [release.yml](.github/workflows/release.yml) can pick it up — `GITHUB_TOKEN` cannot trigger downstream workflows; App tokens can). The bump step triggers nothing, so that constraint does not apply to it.
- Variable was bumped manually to `v2.5.4` post-failure; this PR ensures the next release auto-bumps cleanly.

## Test plan

- [ ] CI green on this branch
- [ ] Next tag push (e.g. v2.5.5) auto-bumps `AGENTIC_FRAMEWORK_VERSION` without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)