### PR TITLE
fix(upgrade): handle tag pinning and partial-install recovery

### DIFF
--- a/internal/mount/mount_test.go
+++ b/internal/mount/mount_test.go
@@ -144,8 +144,10 @@ func TestDownloadFramework_InstallError(t *testing.T) {
 
 func TestDownloadFramework_RefusesInconsistentExistingAI(t *testing.T) {
 	// A pre-existing .ai/ that is neither a symlink, a submodule, nor a
-	// gitignored legacy mount is now treated as MountStateInconsistent —
-	// the dispatcher refuses rather than silently overwriting.
+	// gitignored legacy mount, AND that contains user-meaningful content
+	// (i.e. not just an aborted-clone .git/ directory) is treated as
+	// MountStateInconsistent — the dispatcher refuses rather than
+	// silently overwriting.
 	root := t.TempDir()
 	aiDir := filepath.Join(root, ".ai")
 	_ = os.MkdirAll(aiDir, 0o755)

--- a/internal/mount/submodule.go
+++ b/internal/mount/submodule.go
@@ -74,9 +74,36 @@ func DetectMountState(root string) (MountState, error) {
 		if gitignored {
 			return MountStateGitignoredMount, nil
 		}
+
+		// Empty .ai/ (or one containing only a stale .git/) is treated
+		// as MountStateNone so the caller can recover from a previous
+		// failed install. The fresh-install path defensively cleans
+		// `.ai/` and `.git/modules/.ai/` before adding the submodule.
+		if isEmptyOrAbortedClone(aiPath) {
+			return MountStateNone, nil
+		}
 	}
 
 	return MountStateInconsistent, nil
+}
+
+// isEmptyOrAbortedClone reports true when `.ai/` exists but contains no
+// user-meaningful content beyond a `.git` directory left over from a
+// previous failed `git submodule add` (the partial-clone state). Used
+// by DetectMountState to classify aborted installs as MountStateNone
+// so the install path can recover cleanly.
+func isEmptyOrAbortedClone(aiPath string) bool {
+	entries, err := os.ReadDir(aiPath)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.Name() == ".git" {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // gitmodulesHasAI returns true when `.gitmodules` at root contains a
@@ -119,28 +146,51 @@ func gitignoreContains(root, entry string) (bool, error) {
 var InstallSubmodule = installSubmoduleViaGit
 
 // installSubmoduleViaGit performs a fresh `git submodule add` of the
-// framework at version `tag` into `.ai/` of the parent repo at root.
-// The resulting `.gitmodules` and gitlink change are staged for commit;
-// this function does NOT create a commit.
+// framework at version `tag` into `.ai/` of the parent repo at root,
+// then checks out the tag inside the new submodule so the gitlink
+// pins to the tag's resolved commit. The resulting `.gitmodules` and
+// gitlink change are staged for commit; this function does NOT create
+// a commit.
 //
-// Pre-conditions: `.ai/` does not exist; `.gitmodules` has no `.ai`
-// entry. Caller is responsible for these guarantees (DetectMountState
-// returned MountStateNone).
+// Pre-conditions: `.ai/` does not exist as a tracked submodule;
+// `.gitmodules` has no `.ai` entry. Caller is responsible for these
+// guarantees (DetectMountState returned MountStateNone). A leftover
+// `.git/modules/.ai/` directory from a previous failed run is handled
+// defensively below — it is removed before `git submodule add` runs.
 func installSubmoduleViaGit(root, tag string) error {
 	if tag == "" {
 		return fmt.Errorf("tag is empty — cannot install submodule")
 	}
 
-	if err := runGit(root, "submodule", "add", "-b", tag, FrameworkRepoURL, ".ai"); err != nil {
+	// Clean up any orphan submodule git-dir from a previous run that
+	// failed mid-add. `git submodule add` refuses to proceed when
+	// `.git/modules/<path>/` already exists (with a "found locally"
+	// error), even though the parent's `.gitmodules` has no entry.
+	if gitDir, err := resolveGitDir(root); err == nil {
+		_ = os.RemoveAll(filepath.Join(gitDir, "modules", ".ai"))
+	}
+
+	// Clean up any orphan `.ai/` directory from a previous run that
+	// failed after the clone but before the gitmodules registration.
+	// DetectMountState classifies this case as MountStateNone (via
+	// isEmptyOrAbortedClone), but git submodule add still refuses to
+	// add into an existing path.
+	_ = os.RemoveAll(filepath.Join(root, ".ai"))
+
+	// Note on the missing -b flag: `git submodule add -b <ref>` treats
+	// <ref> as a branch name. Pinning to a tag therefore must NOT use
+	// -b; we clone from the default branch and then check out the tag
+	// inside the submodule. The gitlink the parent records is whatever
+	// HEAD points at after the checkout, which is exactly the tag's
+	// commit SHA.
+	if err := runGit(root, "submodule", "add", FrameworkRepoURL, ".ai"); err != nil {
 		return fmt.Errorf("git submodule add: %w", err)
 	}
 
-	// Pin the gitlink to the tag's resolved commit, not just the branch
-	// tip — `submodule add -b <tag>` records the branch ref but leaves
-	// the gitlink at whatever HEAD pointed to at clone time. For tags
-	// (which are detached refs), this usually coincides; explicitly
-	// checking out the tag inside `.ai/` makes the pinning explicit.
 	aiPath := filepath.Join(root, ".ai")
+	if err := runGit(aiPath, "fetch", "--tags", "--quiet"); err != nil {
+		return fmt.Errorf("fetching tags inside .ai: %w", err)
+	}
 	if err := runGit(aiPath, "checkout", "--quiet", tag); err != nil {
 		return fmt.Errorf("pinning .ai to %s: %w", tag, err)
 	}

--- a/internal/mount/submodule_test.go
+++ b/internal/mount/submodule_test.go
@@ -78,14 +78,45 @@ func TestDetectMountState_GitignoredMount(t *testing.T) {
 	}
 }
 
-func TestDetectMountState_Inconsistent(t *testing.T) {
+func TestDetectMountState_EmptyAIClassifiedAsNone(t *testing.T) {
+	// An empty .ai/ directory (left over from a failed install attempt)
+	// is recoverable — DetectMountState classifies it as MountStateNone
+	// so the install path can run with its defensive cleanup.
 	root := t.TempDir()
-
-	// Create .ai/ as a regular directory but DON'T add it to .gitignore
-	// and DON'T add a submodule entry. This is the inconsistent state.
 	if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
 		t.Fatalf("creating .ai: %v", err)
 	}
+
+	state, err := DetectMountState(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != MountStateNone {
+		t.Errorf("expected MountStateNone for empty .ai/, got %d", state)
+	}
+}
+
+func TestDetectMountState_AbortedCloneClassifiedAsNone(t *testing.T) {
+	// .ai/ with only a .git/ directory inside (the partial-clone state
+	// after `git submodule add` failed at checkout) is also recoverable.
+	root := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(root, ".ai", ".git"), 0o755)
+
+	state, err := DetectMountState(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != MountStateNone {
+		t.Errorf("expected MountStateNone for aborted-clone .ai/, got %d", state)
+	}
+}
+
+func TestDetectMountState_PopulatedAIClassifiedAsInconsistent(t *testing.T) {
+	// .ai/ with real content but no submodule entry and no gitignore
+	// entry is genuinely inconsistent — refuse rather than wipe.
+	root := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(root, ".ai"), 0o755)
+	_ = os.WriteFile(filepath.Join(root, ".ai", "user-file.md"), []byte("important"), 0o644)
 
 	state, err := DetectMountState(root)
 	if err != nil {
@@ -134,22 +165,10 @@ func TestDownloadFramework_RefusesSymlink(t *testing.T) {
 	}
 }
 
-func TestDownloadFramework_RefusesInconsistent(t *testing.T) {
-	root := t.TempDir()
-	// .ai/ exists but is neither a symlink, a tracked submodule, nor
-	// gitignored — refuse with a clear error.
-	if err := os.MkdirAll(filepath.Join(root, ".ai"), 0o755); err != nil {
-		t.Fatalf("creating .ai: %v", err)
-	}
-
-	err := DownloadFramework(root, "v2.0.0", nil)
-	if err == nil {
-		t.Fatal("expected refusal on inconsistent state")
-	}
-	if !strings.Contains(err.Error(), "inconsistent") {
-		t.Errorf("error should mention inconsistent state, got: %v", err)
-	}
-}
+// Inconsistent-state refusal is now exercised by
+// TestDownloadFramework_RefusesInconsistentExistingAI in mount_test.go,
+// which seeds .ai/ with user content. An empty .ai/ is recoverable and
+// no longer triggers a refusal — see TestDetectMountState_EmptyAIClassifiedAsNone.
 
 func TestDownloadFramework_DispatchesToInstallOnFreshState(t *testing.T) {
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

End-to-end testing of \`gh agentic upgrade v2.5.5\` against a real domain repo surfaced two bugs in the submodule install path that the unit tests didn't catch:

1. **Tag treated as branch.** \`git submodule add -b <tag>\` fails with \`'origin/v2.5.5' is not a commit and a branch 'v2.5.5' cannot be created from it\`. The \`-b\` flag is for branch tracking; tags need a clone-then-checkout. Fixed by dropping \`-b\` and doing \`git submodule add <url> .ai\` → \`git -C .ai fetch --tags\` → \`git -C .ai checkout <tag>\`. The gitlink ends up at the tag's commit SHA, which is the correct pinning.

2. **Orphan \`.git/modules/.ai/\` blocks re-add.** A previous failed run leaves \`.git/modules/.ai/\` behind, and \`git submodule add\` refuses with \`A git directory for '.ai' is found locally\`. Fixed by \`os.RemoveAll\` of that path before the add.

## Refinement: partial-install recovery

A failed install can also leave a \`.ai/\` directory in the working tree (clone succeeded, checkout failed). Previously this triggered \`MountStateInconsistent\` and the user had to \`rm -rf .ai\` manually. Now:

- \`DetectMountState\` recognises "empty \`.ai/\` or \`.ai/\` containing only a stale \`.git/\`" as recoverable (\`MountStateNone\`).
- \`InstallSubmodule\` defensively wipes any leftover \`.ai/\` and \`.git/modules/.ai/\` before the add.
- A \`.ai/\` with real user content (anything beyond \`.git/\`) still triggers \`MountStateInconsistent\` — never silently overwrite user data.

## Verification

- \`go test ./...\` all packages pass
- New unit tests for the recoverable-state classifications (empty / aborted-clone) and that populated \`.ai/\` still refuses
- **End-to-end smoke against a real domain repo:** \`gh agentic upgrade v2.5.5 --yes\` produces \`.gitmodules\` with the \`.ai\` entry, a tracked \`.ai/\` gitlink, and \`git -C .ai describe --tags --exact-match\` returns \`v2.5.5\` exactly. Verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)