### PR TITLE
docs: concept-first README + new GETTING_STARTED guide

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,0 +1,231 @@
+# Getting started with gh-agentic
+
+This guide walks you through installing `gh-agentic` and running your first agentic delivery cycle — capturing a Requirement, scoping it into a Feature, and watching the pipeline open a pull request with the implemented work.
+
+The examples below use **Claude Code** as the agentic workbench. The framework is workbench-agnostic — anywhere you can run agent skills (Goose, OpenCode, an MCP-aware IDE, or any other model that supports tool use and skill invocation) the same flow works. Skill invocations are the only workbench-specific bit, and the substitution is mechanical.
+
+---
+
+## Prerequisites
+
+| Requirement | Why |
+|---|---|
+| [git](https://git-scm.com) | Submodule-based framework mount and pipeline checkouts |
+| [GitHub CLI](https://cli.github.com), authenticated (`gh auth login`) | All `gh agentic` commands route through `gh` |
+| [Claude Code](https://claude.ai/code) | The agentic workbench used in the examples below; also where credentials live for the headless CI agent |
+| A GitHub repository | The agentic environment is per-repo; you can use a fresh repo or an existing one |
+
+Credentials for the headless agent (the one that runs in GitHub Actions) are sourced from your local Claude Code install:
+
+- **macOS:** the macOS Keychain entry `Claude Code-credentials`
+- **Linux:** `~/.claude/.credentials.json`
+
+### Recommended: self-hosted runners (ARC)
+
+The agentic pipeline runs on every phase transition — design, dev-session, PR review, release. Each headless agent run typically takes 10–60 minutes, and a single Feature can fire several runs end-to-end. On GitHub-hosted runners this **consumes Actions minutes quickly** and is the dominant cost of running the framework at scale.
+
+The recommended setup for any non-trivial agentic project is **[Actions Runner Controller (ARC)](https://github.com/actions/actions-runner-controller)** — a Kubernetes-based self-hosted runner with horizontal autoscaling. Once ARC is deployed, the cost of an agent run becomes the cost of the underlying compute (which you control) rather than the Actions-minutes meter. ARC also gives you control over the runner image (preinstalled tools, language toolchains, network policy).
+
+**Hard requirement for local models.** If you want to run agent sessions against a local LLM (Ollama, vLLM, llama.cpp, an in-cluster model service), you **must** have a self-hosted runner — GitHub-hosted runners cannot reach into your network to talk to a local model server. ARC + an in-cluster model deployment is the standard topology.
+
+**Configuration knob.** During `gh agentic init` the wizard collects a `RUNNER_LABEL` value (e.g. `ubuntu-latest` for GitHub-hosted, or a custom label like `arc-runners` matching your runner-set). The reusable workflows pin every job to that label — so you can switch your repo from GitHub-hosted to ARC by changing one repo variable, no workflow edit required.
+
+---
+
+## 1. Install the CLI extension
+
+```bash
+gh extension install eddiecarpenter/gh-agentic
+gh agentic --version
+```
+
+To upgrade later:
+
+```bash
+gh extension upgrade agentic
+```
+
+---
+
+## 2. Bootstrap the agentic environment
+
+In your repo root:
+
+```bash
+gh agentic init
+```
+
+The interactive wizard:
+
+1. Detects the current repo and your GitHub identity.
+2. Asks for the framework version, stack, agent identity, runner label, agent provider/model.
+3. Either creates a new GitHub Project or joins an existing one (single-topology by default; federated topology is available for multi-repo projects).
+4. Mounts the framework at `.ai/` as a tracked git submodule pinned to the chosen version.
+5. Generates `CLAUDE.md` and `AGENTS.md` (the agent entry files).
+6. Writes the reusable workflow callers under `.github/workflows/`.
+7. Configures GitHub repo secrets and variables: `AGENTIC_PROJECT_ID`, `AGENTIC_FRAMEWORK_VERSION`, `AGENTIC_APP_CLIENT_ID`, `AGENTIC_APP_PRIVATE_KEY`, `PROJECT_PAT`, `CLAUDE_CREDENTIALS_JSON`, etc.
+
+Verify everything is wired up:
+
+```bash
+gh agentic check
+```
+
+A clean health check looks like:
+
+```
+✓ Project reachable
+✓ Framework: .ai/ mounted (vX.Y.Z), version pinned, .ai/ not in .gitignore
+✓ Workflows: agentic-pipeline.yml @vX.Y.Z, release.yml @vX.Y.Z
+✓ Variables & secrets: all configured
+```
+
+If any check fails, run `gh agentic repair` — it auto-fixes what it can and prints remediation commands for the rest.
+
+Commit the staged changes (`.gitmodules`, `.ai` gitlink, `CLAUDE.md`, `AGENTS.md`, workflows) and push.
+
+---
+
+## 3. Establish the architectural baseline
+
+Before you can capture your first Requirement, the framework needs an **architectural baseline** to anchor against. This is a non-negotiable gate: the [`requirements-session`](skills/requirements-session/SKILL.md) skill refuses to run if `docs/ARCHITECTURE.md` is missing — without an architectural baseline, Requirements have nothing to anchor against and tend to be vague or contradictory.
+
+Open Claude Code in the repo:
+
+```bash
+claude
+```
+
+Claude Code reads `CLAUDE.md` at session start (which imports `AGENTS.md`, which imports the framework `RULEBOOK.md` and your `LOCALRULES.md`). The full agentic ruleset and skill catalogue load automatically.
+
+Then invoke:
+
+```
+/solution-architecture
+```
+
+The agent runs the [`solution-architecture`](skills/solution-architecture/SKILL.md) skill, which leads a conversational interview to capture the project's **Foundation Solution Architecture** — vision, capability domains, system context, architectural decisions, NFRs, integration points, data model, evolution notes — and writes the result to `docs/ARCHITECTURE.md` on the current branch. You commit and push; the resulting PR is reviewed and merged like any other change.
+
+Once `docs/ARCHITECTURE.md` exists on `main`, the requirements gate clears and you can move on to step 4.
+
+> **Looking ahead:** issue [#673](https://github.com/eddiecarpenter/gh-agentic/issues/673) extends this skill to lead a Domain-Driven Design (DDD) interview — bounded contexts, ubiquitous language, context map, aggregates, domain events, subdomain classification — so the architecture doc establishes a shared language that carries through to every downstream phase. For now the interview is unstructured but produces a working baseline.
+
+The same skill is used later to **extend** the architecture when a new subsystem or significant decision lands. It is not a one-shot — it is the canonical edit path for `docs/ARCHITECTURE.md`.
+
+---
+
+## 4. Run your first delivery cycle
+
+The pipeline moves work through five phases. The human gates **entry** into the agent pipeline (applying the trigger label to a Feature) and **exit** (reviewing the PR). Within the agent pipeline, design hands off to implementation autonomously — once headless design completes, the dev-session fires immediately without waiting for human input. This is the only autonomous transition in the pipeline; every other handoff is gated.
+
+```
+Requirement → Scoping → Design ─┐
+   (human)     (human)   (agent)│ autonomous handoff
+                                ▼
+                        Implementation → Review → Merged
+                            (agent)     (human)  (human)
+```
+
+For Features flagged `needs-interactive-design`, the agent ends design with a 3-way prompt instead — *trigger now*, *park at `designed`*, or *cancel* — so you can review the Design Plan in foreground before code is written.
+
+### 4a. Capture a Requirement
+
+In the same Claude Code session:
+
+```
+/requirements-session
+```
+
+The agent runs the [`requirements-session`](skills/requirements-session/SKILL.md) skill, which interviews you about the underlying business need (role, capability, outcome) and creates a `requirement`-labelled GitHub issue at `backlog`.
+
+Equivalent in another workbench: invoke the same skill (the SKILL.md is workbench-agnostic) or paste its instructions into a system prompt and let your model walk you through the interview. The artefact is the GitHub issue either way.
+
+### 4b. Scope it into Features
+
+```
+/requirement-scoping
+```
+
+Walks the Requirement through nine artefacts (problem framing, decomposition, MVP, acceptance criteria, deployment strategy, parking lot…) and produces one or more `feature`-labelled GitHub issues, each wired as a sub-issue of the parent Requirement. At the end, you choose which Features to trigger for design.
+
+### 4c. The agent designs and implements
+
+The scoping skill ends by asking which Features to trigger; for any you select, it invokes the [`trigger-design`](skills/trigger-design/SKILL.md) primitive — **don't apply `in-design` or `interactive-design` by hand**. `trigger-design` reads the Feature's labels and picks the right path:
+
+- Feature carries `needs-interactive-design` (UX/UI work, novel architecture, or anything you flagged for foreground review during scoping) → `interactive-design`. You run `/feature-design <N>` in your workbench.
+- Otherwise → `in-design`. The Stage 3 workflow picks it up automatically.
+
+For headless design (`in-design`):
+
+1. The **design phase** runs in CI — the agent reads the Feature, drafts a Design Plan rationale (posted as a comment), creates ordered Task sub-issues, and creates the feature branch.
+2. When design completes, it **auto-applies `in-development`** via the `trigger-implementation` primitive and the **implementation phase** fires immediately — no second human gate. The agent walks each Task in order, writes code, runs tests, commits with the conventional task-format message, pushes, and opens the pull request.
+3. The Feature transitions to `in-review` once the PR is open.
+
+For interactive design (`interactive-design`):
+
+1. You run `/feature-design <N>` in Claude Code (or the equivalent in your workbench). The agent walks the design phase in foreground — exploration, rationale draft + confirm, Task list confirm — and posts/creates the same artefacts as the headless path.
+2. At end-of-design the agent presents a 3-way prompt: **trigger now**, **park at `designed`**, or **cancel**. Pick **trigger now** to fire implementation immediately (same as the headless path); pick **park** if you want the Feature to wait.
+3. To un-park a Feature later, invoke `/trigger-implementation` — same primitive the headless design auto-fires, just human-driven. **Do not apply `in-development` by hand**; let the primitive do the right label/status moves atomically.
+
+You can watch progress at any time with:
+
+```bash
+gh agentic status pipeline
+```
+
+…which renders the Requirements and Features side by side as columns of a Kanban board, showing the stage of each.
+
+### 4d. Review the PR
+
+Open the PR. If you request changes, the agent (`pr-review-session`) automatically picks up reviewer comments, addresses them in fresh commits, and pushes back. When you approve and merge, the Feature transitions to `done`.
+
+That's a full cycle. The same pattern holds for every Requirement.
+
+---
+
+## 5. Daily commands
+
+| What you want | Command |
+|---|---|
+| See where everything is | `gh agentic status pipeline` |
+| Detail on one requirement | `gh agentic status requirement <N>` |
+| Detail on one feature | `gh agentic status feature <N>` |
+| Verify the environment | `gh agentic check` |
+| Auto-fix environment issues | `gh agentic repair` |
+| Bump the framework version | `gh agentic upgrade <new-version>` |
+| Refresh expired Claude credentials | `gh agentic auth refresh` |
+| Show repo's agentic state | `gh agentic info` |
+
+Add `--raw` to any `status` subcommand for an agent-oriented payload (TSV / frontmatter+verbatim) suitable for scripting and downstream skills.
+
+---
+
+## 6. Using a different workbench
+
+Anywhere the agent can:
+
+- read framework files at `.ai/` (skills, recipes, standards, rulebook),
+- shell out to `gh` and `git`,
+- and follow a SKILL.md playbook,
+
+…the same delivery flow runs. Concrete substitutions for the examples above:
+
+| Step in this guide | Claude Code | Goose | Generic agent |
+|---|---|---|---|
+| Bootstrap architecture | `/solution-architecture` | `goose run --recipe .ai/recipes/solution-architecture.yaml` | Load `skills/solution-architecture/SKILL.md` and follow it |
+| Capture a requirement | `/requirements-session` | `goose run --recipe .ai/recipes/requirements-session.yaml` | Load `skills/requirements-session/SKILL.md` and follow it |
+| Scope a requirement (calls `trigger-design` for selected Features) | `/requirement-scoping` | analogous recipe | analogous skill load |
+| Run interactive design | `/feature-design <N>` | analogous recipe | analogous skill load |
+| Un-park a `designed` Feature | `/trigger-implementation` | analogous recipe | analogous skill load |
+
+The headless phases (`in-design` and `in-development` triggered via labels) always run via Goose in CI — that's hard-wired into the reusable workflows. The interactive phases are workbench-of-choice.
+
+---
+
+## 7. Where to next
+
+- [`README.md`](README.md) — what gh-agentic *is* and how the pipeline is structured.
+- [`RULEBOOK.md`](RULEBOOK.md) — the universal rules every session follows.
+- [`skills/`](skills/) — per-phase playbooks (one directory per skill, each with a SKILL.md).
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — package structure and mount model.
+- [`eddiecarpenter/ocs-testbench`](https://github.com/eddiecarpenter/ocs-testbench) — a live downstream repo running this framework end-to-end.

--- a/README.md
+++ b/README.md
@@ -6,110 +6,158 @@
 [![Go Version](https://img.shields.io/github/go-mod/go-version/eddiecarpenter/gh-agentic)](go.mod)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-A GitHub CLI extension that bootstraps and manages agentic software delivery environments.
-It replaces manual shell scripts with deterministic Go commands — creating repos, scaffolding
-projects, configuring GitHub, mounting the AI-Native Delivery Framework, and managing
-credentials — so AI agents can focus on the work that actually requires reasoning.
+> A GitHub CLI extension and delivery framework for **agentic software delivery** — a label-driven pipeline where AI agents move work from a captured Requirement to a reviewed pull request via GitHub Issues and Actions, with humans gating phase transitions.
 
-## Install
+> 📘 **For installation and a hands-on walkthrough → [GETTING_STARTED.md](GETTING_STARTED.md)**
 
-```bash
-gh extension install eddiecarpenter/gh-agentic
+---
+
+## What this is
+
+`gh-agentic` is two things in one repository:
+
+1. **A GitHub CLI extension** (`gh agentic ...`) that bootstraps and manages the environment a repo needs to run agentic software delivery — creating projects, configuring secrets and variables, mounting the framework, verifying the setup, and managing Claude Code credentials.
+2. **The AI-Native Delivery Framework** itself — a library of skills, recipes, standards and reusable workflows that any repo can consume as a tracked git submodule at `.ai/`. The framework defines *how* requirements become features become tasks become commits become a pull request.
+
+You run `gh agentic init` once in your repo, inherit the entire pipeline, and from then on move work through phases by applying GitHub labels to issues. Every artefact (Requirement, Feature, Task, Design Plan, PR) is durable on GitHub. Every phase is observable on the GitHub Project board. Every transition is auditable in label history.
+
+---
+
+## How it works
+
+### The pipeline
+
+```mermaid
+flowchart LR
+    R[Requirement<br/><i>human captures need</i>] --> S[Scoping<br/><i>human decomposes<br/>into Features</i>]
+    S --> D[Design<br/><i>agent drafts plan +<br/>creates Tasks + branch</i>]
+    D --> I[Implementation<br/><i>agent writes code,<br/>commits per task,<br/>opens PR</i>]
+    I --> V[Review<br/><i>human reviews;<br/>agent addresses<br/>review comments</i>]
+    V --> M[Merged<br/><i>human merges</i>]
+
+    classDef human fill:#e8f4fd,stroke:#3b82f6,color:#1e40af
+    classDef agent fill:#fef3c7,stroke:#f59e0b,color:#92400e
+    class R,S,V,M human
+    class D,I agent
 ```
 
-## Prerequisites
+Phase transitions are driven by GitHub labels on the issue, but humans don't apply those labels by hand — the framework provides primitive skills (`trigger-design`, `trigger-implementation`) that know which label to apply based on the Feature's flags. The human gates **entry** into the agent pipeline (invoking `trigger-design` for a scoped Feature) and **exit** (reviewing the PR). Within the agent pipeline, **design hands off to implementation autonomously** — once headless design completes, the framework's `trigger-implementation` primitive transitions the Feature to `in-development` without waiting for human input, and the dev-session fires immediately. This is the only autonomous transition in the pipeline; every other handoff (Requirement → Scoping, Scoping → Design, Implementation → Review, Review → Merged) is gated by a human action.
 
-- [git](https://git-scm.com)
-- [GitHub CLI](https://cli.github.com) — authenticated (`gh auth login`)
-- [Claude Code](https://claude.ai/code) — required for agent sessions and credential management
+`trigger-design` reads the Feature's labels to pick the right path: a Feature flagged `needs-interactive-design` (set during scoping for UX/UI work, novel architecture, or anything where a wrong design is expensive to undo) gets `interactive-design`; everything else gets `in-design` and runs headlessly. For Features that took the interactive path, the human chooses at end-of-design between *trigger now*, *park at `designed`*, or *cancel*. A parked Feature is later un-parked by invoking `trigger-implementation` — same primitive the headless design auto-fires, just human-driven this time.
 
-### Platform requirements for credential management
+### What triggers what
 
-- **macOS** — credentials are stored in the macOS keychain (`"Claude Code-credentials"`)
-- **Linux** — credentials are stored at `~/.claude/.credentials.json`
+| Label transition | Workflow that fires | What the agent does |
+|---|---|---|
+| `backlog` → `scoping` | none — interactive | A human runs `/requirement-scoping` in their workbench; the agent walks nine artefacts and produces Feature issues |
+| `backlog` → `in-design` (via `trigger-design`) | `agentic-pipeline.yml` (Stage 3) | Reads the Feature, drafts a Design Plan rationale, creates ordered Task sub-issues, creates the feature branch — and at end-of-flow auto-applies `in-development` so Stage 4 fires without human input |
+| `backlog` → `interactive-design` (via `trigger-design` when `needs-interactive-design` is set) | none — interactive | A human runs `/feature-design <N>` for Features that need foreground attention (UX, novel architecture); at end-of-flow the human chooses whether to trigger implementation, park at `designed`, or cancel |
+| `in-design` → `in-development` (autonomous) | `agentic-pipeline.yml` (Stage 4) | Walks each Task in order, writes code, runs tests, commits per task, pushes, opens the PR |
+| `designed` → `in-development` (via `trigger-implementation`) | `agentic-pipeline.yml` (Stage 4) | Same as above; this is the path for Features that were parked at `designed` after interactive design |
+| PR review submitted (changes requested) | `agentic-pipeline.yml` (Stage 4b) | Reads the review, implements requested changes, commits, pushes |
+| PR merged | `agentic-pipeline.yml` (Stage 5) | Closes the Feature; transitions parent Requirement to `done` if all child Features are complete |
 
-## Getting started
+### The framework discipline
 
-### 1. Clone or create a repo
+The skills aren't just instructions — they encode disciplines that make autonomous phases trustworthy:
 
-```bash
-git clone git@github.com:<owner>/<repo>.git
-cd <repo>
+- **Reuse audit** — before every new function, type, or module, the agent records one of three outcomes (reuse-as-is / reuse-via-refactor / do-not-reuse-because-X). "I didn't look" is never permitted.
+- **Contract rules** — Kafka schemas, GraphQL types, database-serialised structs are flagged as contracts. Any change requires explicit human approval and a `decision`-labelled issue.
+- **AC-traceability** — every Task issue cites at least one Feature acceptance criterion. The dev-session refuses to mark a Feature complete unless every AC is covered by a Task.
+- **Rationale-as-artefact** — every autonomous phase publishes its plan *before* the irreversible action (the design phase posts a Design Plan rationale comment before creating Task issues; the dev-session posts a per-task plan before committing).
+- **Per-task commit format** — `feat: <task description> — task K of M (#N)`, with `Reuse:` trailers documenting the reuse audit.
+- **Human gates between phases** — the agent never applies a trigger label autonomously; phase transitions are always a human's call.
+
+The full ruleset is in [`RULEBOOK.md`](RULEBOOK.md). The per-phase playbooks live under [`skills/`](skills/).
+
+### The mount model
+
+The framework is delivered as a **standard git submodule** at `.ai/`, pinned to a version tag. The submodule pointer is committed; `git submodule status` is the single source of truth for the framework version your repo runs at.
+
+```
+your-repo/
+  .ai/                  → tracked submodule pointing at eddiecarpenter/gh-agentic@vX.Y.Z
+    skills/             → playbooks
+    recipes/            → Goose recipes
+    standards/          → language/stack standards
+    concepts/           → reference material
+    RULEBOOK.md         → universal rules
+    .github/actions/    → composite actions used by the reusable workflows
+  .github/workflows/
+    agentic-pipeline.yml → calls the reusable workflow from this repo
+    release.yml          → calls the reusable release workflow
+  CLAUDE.md             → @AGENTS.md import
+  AGENTS.md             → bootstrap rule (@.ai/RULEBOOK.md and @.ai/AGENTS.md)
 ```
 
-### 2. Initialise the agentic environment
+Every checkout step in the workflow uses `submodules: recursive`, so the submodule is automatically populated on the runner — no separate "mount" step required, no copy of framework files committed into your repo.
 
-```bash
-gh agentic init
-```
+The `gh-agentic` repo itself uses a `.ai -> .` symlink as a documented self-mounting exception (the framework can't submodule itself). The CLI's `upgrade` command refuses to operate on this exception.
 
-The init wizard detects the current repo, collects configuration (stack, framework
-version), mounts the framework, generates agent entry files, and configures GitHub
-secrets and variables.
+### The workbench
 
-### 3. Verify the setup
+The interactive phases (Requirements, Scoping, interactive Design) run wherever the human is — Claude Code, Goose, or any other agentic workbench. The headless phases (`in-design`, `in-development`, `pr-review-session`) always run via Goose in GitHub Actions — that's hard-wired in the reusable workflows.
 
-```bash
-gh agentic check
-```
+`gh-agentic` is workbench-agnostic by design. Skills live in `.ai/skills/<name>/SKILL.md` and contain everything an agent needs to walk the phase: triggers, steps, error handling, exit blocks. The workbench just has to load the SKILL.md and follow it.
 
-All checks should pass. If any fail, run `gh agentic repair` to auto-fix the ones
-that can be fixed, and follow the remediation commands for the rest.
+---
 
-### 4. Start working
+### Runtime infrastructure
 
-Open the repo in your AI agent and begin a Requirements Session. The agent reads
-`CLAUDE.md` and `AGENTS.md` to load the framework rules and playbooks.
+Every phase transition fires a workflow, and a single Feature typically produces several runs end-to-end (design + dev-session + PR review). Each headless run is 10–60 minutes. On GitHub-hosted runners this consumes Actions minutes quickly and becomes the dominant cost at scale.
+
+For any non-trivial agentic project, **self-hosted runners via [Actions Runner Controller (ARC)](https://github.com/actions/actions-runner-controller)** are the recommended setup — Kubernetes-based, autoscaling, image-controlled. The reusable workflows pin every job to a `RUNNER_LABEL` repo variable, so switching from GitHub-hosted to ARC is a one-variable change.
+
+**Self-hosted runners are a hard prerequisite for using a local model** (Ollama, vLLM, llama.cpp, in-cluster model service). GitHub-hosted runners can't reach into your network to talk to a local model server; ARC + an in-cluster model deployment is the standard topology.
+
+Full setup guidance is in [GETTING_STARTED.md](GETTING_STARTED.md#recommended-self-hosted-runners-arc).
+
+---
+
+## See it run
+
+The `gh-agentic` repo **dogfoods its own framework** — a substantial portion of recent commits and pull requests were produced by agent sessions following the framework's own playbooks (the [merged PRs](https://github.com/eddiecarpenter/gh-agentic/pulls?q=is%3Apr+is%3Aclosed) carry the agent's `Co-Authored-By` trailer).
+
+For an unrelated downstream repo running the same pipeline, see [`eddiecarpenter/ocs-testbench`](https://github.com/eddiecarpenter/ocs-testbench), where Features are routinely scoped, designed, implemented, and PR'd by an agent walking this framework.
+
+---
+
+## Architecture at a glance
+
+| Layer | Lives at | Responsibility |
+|---|---|---|
+| **Your repo** | the consumer's repo | Source code; `.ai/` submodule pinned to a framework version; lifecycle labels; agent entry files |
+| **Framework mount** (`.ai/`) | tracked submodule pointing at this repo | Skills, recipes, standards, RULEBOOK, reusable workflow callers, composite actions |
+| **Reusable workflows** | [`.github/workflows/agentic-pipeline.yml`](.github/workflows/agentic-pipeline.yml) | Triggered by label changes / PR review events; check out your repo with `submodules: recursive` to populate `.ai/`; run agent recipes |
+| **CLI** (`gh agentic`) | this repo | Bootstrap, install, upgrade, check, repair, status, project membership |
+
+Detail in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+---
 
 ## Commands
 
+<details>
+<summary>Click to expand command reference</summary>
+
 | Command | Description |
 |---|---|
-| `gh agentic init` | Interactive wizard to initialise a new agentic environment |
-| `gh agentic check` | Verify project membership and pipeline readiness |
-| `gh agentic repair` | Auto-fix issues reported by `check` |
-| `gh agentic mount [version]` | Mount the AI-Native Delivery Framework at `.ai/` |
-| `gh agentic upgrade` | Change the framework version for the whole federation (control plane only) |
-| `gh agentic project` | Manage ongoing project membership — create, join, switch, unlink |
+| `gh agentic init` | First-time setup wizard — creates/joins a project, mounts the framework, configures secrets and variables |
+| `gh agentic upgrade [version]` | Bump the framework to a different version (also handles legacy gitignored-mount migration) |
+| `gh agentic check` | Verify project membership, framework mount, workflows, variables, secrets |
+| `gh agentic repair` | Auto-fix what `check` flags; prints remediation commands for the rest |
 | `gh agentic info` | Show the current state of this repo's agentic setup |
-| `gh agentic auth login` | Force Claude Code login and push credentials to repo secret |
-| `gh agentic auth refresh` | Push current local credentials to repo secret |
-| `gh agentic auth check` | Verify credentials are present and not expired |
-| `gh agentic status` | Show pipeline state across requirements and features |
-| `gh agentic status pipeline` | Render requirements and features as a side-by-side pipeline view |
+| `gh agentic project create / join / switch / unlink` | Manage GitHub Project membership |
+| `gh agentic auth login / refresh / check` | Manage Claude Code credentials |
+| `gh agentic status pipeline` | Side-by-side Kanban of requirements and features — the first-class "where are we?" answer |
+| `gh agentic status requirements / requirement <N>` | Pipeline state for requirements |
+| `gh agentic status features / feature <N>` | Pipeline state for features |
 
-## Mount
+Add `--raw` to any `status` subcommand for an agent-oriented TSV / frontmatter+verbatim payload suitable for scripting.
 
-The mount command downloads the AI-Native Delivery Framework and installs it at
-`.ai/` in the current repo. The `.ai/` directory is gitignored — it is populated
-on demand and not committed.
+</details>
 
-```bash
-gh agentic mount v2.0.0    # first-time mount at a specific version
-gh agentic mount            # remount / restore at the currently pinned version
-gh agentic mount v2.1.0    # switch to a new version (prompts for confirmation)
-```
-
-The pinned framework version is the `AGENTIC_FRAMEWORK_VERSION` repo variable
-on the control-plane repo (single or federated CP). Domain repos derive their
-version from the CP through the canonical `project.Resolve` resolver — no
-flat file at the repo root stores the pin.
-
-## Auth
-
-The auth command manages Claude Code credentials for CI runners.
-
-```bash
-gh agentic auth login      # force login and push credentials
-gh agentic auth refresh    # push current local credentials to repo secret
-gh agentic auth check      # verify credentials are present and not expired
-```
-
-## Upgrade
-
-```bash
-gh extension upgrade agentic
-```
+---
 
 ## Development
 
@@ -120,9 +168,9 @@ go build ./...
 go test ./...
 ```
 
-See [`docs/PROJECT_BRIEF.md`](docs/PROJECT_BRIEF.md) for full design documentation
-and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the package structure and
-mount model.
+See [`docs/PROJECT_BRIEF.md`](docs/PROJECT_BRIEF.md) for full design context and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the architectural baseline.
+
+---
 
 ## License
 


### PR DESCRIPTION
## Summary

Restructures the project documentation so a new reader (recruiter, evaluator, or first-time consumer) gets the conceptual model up front and the hands-on walkthrough in a separate companion doc.

### What changed

- **[README.md](README.md) is now concept-first.** What gh-agentic is, how the label-driven pipeline works (Mermaid diagram + per-transition trigger table), the framework's discipline (reuse audit, contract rules, AC traceability, rationale-as-artefact), the submodule mount model with a file-tree example, and a runtime-infrastructure section recommending ARC and flagging it as a hard prerequisite for local models.
- **[GETTING_STARTED.md](GETTING_STARTED.md) is new.** Step-by-step: prerequisites (incl. ARC subsection), install, `gh agentic init` walkthrough, architecture-baseline gate via `/solution-architecture`, a full first delivery cycle using Claude Code (Requirement → PR), daily commands, and a workbench-substitution table for Goose and generic agents.

### Corrections to load-bearing claims

- **Removed the retired `mount` command** from the commands table and from getting-started prose — `gh agentic init` mounts on first install; `gh agentic upgrade` handles version swaps and legacy migrations.
- **Fixed the `upgrade` description** — it was tagged "control plane only," which has been false since v2.5.6 (it's now the single idempotent entry point for any repo).
- **Corrected the gating model.** An earlier draft claimed every agent-phase transition was human-gated. In fact headless design auto-applies `in-development` via `trigger-implementation` — design hands off to implementation autonomously, no second human gate. Both docs now explain this and separate the headless / interactive paths cleanly.
- **Recommend the trigger primitives over hand-applying labels.** Both docs flag `trigger-design` and `trigger-implementation` as the canonical entry points; humans don't apply `in-design` / `interactive-design` / `in-development` by hand.

### Style touch-ups

- Renamed "domain repo" → "your repo" in the conversational text. The DDD-shaped term mainly carries weight in federated topology, which neither intro doc discusses; "your repo" is clearer and avoids clashing with "GitHub Project" terminology.
- Forward-pointer to [#673](https://github.com/eddiecarpenter/gh-agentic/issues/673) where the `solution-architecture` skill will be expanded into a Domain-Driven Design interview.

## Verification

- Both files render cleanly in Markdown preview.
- Mermaid diagram renders natively on GitHub.
- All internal links resolve to existing files in this repo.
- Command surface in the README's collapsed reference matches the actual `gh agentic --help` output (verified by running the binary).

## Test plan

- [ ] Read [README.md](README.md) cold — does it answer "what is this and why is it interesting" in the first 30 seconds?
- [ ] Walk through [GETTING_STARTED.md](GETTING_STARTED.md) in a fresh repo — do the steps work end-to-end?

🤖 Generated with [Claude Code](https://claude.com/claude-code)