### PR TITLE
docs(readme): drop repetition in tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go Version](https://img.shields.io/github/go-mod/go-version/eddiecarpenter/gh-agentic)](go.mod)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-> A GitHub CLI and delivery framework for **agentic software delivery**. Humans do the thinking; AI agents do the work.
+> A GitHub CLI and **agentic software delivery framework**. Humans do the thinking; AI agents do the work.
 
 > 📘 **For installation and a hands-on walkthrough → [GETTING_STARTED.md](GETTING_STARTED.md)**
 


### PR DESCRIPTION
Tightens the opening blockquote: "A GitHub CLI and **agentic software delivery framework**." — drops the repetition of "delivery" in the previous version ("delivery framework for agentic software delivery").

🤖 Generated with [Claude Code](https://claude.com/claude-code)