### PR TITLE
fix(workflows): remove redundant delete-feature-branch step

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -937,10 +937,7 @@ jobs:
           OPTION_ID=$(echo "${FIELDS}" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id')
           gh api graphql -f query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { projectV2Item { id } } }' -f projectId="${AGENTIC_PROJECT_ID}" -f itemId="${ITEM_ID}" -f fieldId="${FIELD_ID}" -f optionId="${OPTION_ID}"
 
-      - name: Delete feature branch
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          gh api repos/${{ github.repository }}/git/refs/heads/${HEAD_REF} --method DELETE
-          echo "Deleted branch ${HEAD_REF}"
+      # Branch deletion is handled by GitHub's "Automatically delete head
+      # branches" repo setting, which fires on merge before this job runs.
+      # The previous explicit `gh api ... DELETE` step is gone — it raced
+      # the auto-delete and failed with 422 on every successful merge.


### PR DESCRIPTION
The explicit `Delete feature branch` step in Stage 5 of agentic-pipeline.yml races GitHub's repo-level "Automatically delete head branches" setting (enabled on this repo). The setting fires on merge first, the explicit `gh api ... DELETE` then 422s because the ref is already gone — every successful merge logged a confusing failure.

Drop the step; replace with a short comment documenting that branch deletion is handled by the repo setting, so it isn't accidentally reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)