### PR TITLE
fix(workflow): align Design Plan verifier with marker-based contract

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -189,11 +189,12 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Look for at least one comment on the Feature issue authored
-          # by the agentic bot whose body starts with the canonical
-          # Design Plan header. The header pattern matches what
-          # capture-design-plan.md prescribes: "## Design Plan".
+          # by the agentic bot whose body begins with the canonical
+          # Design Plan marker. feature-design and dev-session both key
+          # off this marker (`<!-- design-plan:v1 -->`); the workflow
+          # verifies the same contract so the three signals agree.
           COMMENT_COUNT=$(gh api "repos/${REPO}/issues/${ISSUE}/comments" \
-            --jq '[.[] | select(.user.type == "Bot") | select(.body | startswith("## Design Plan"))] | length')
+            --jq '[.[] | select(.user.type == "Bot") | select(.body | startswith("<!-- design-plan:v1 -->"))] | length')
           if [ "${COMMENT_COUNT}" -lt 1 ]; then
             echo "::error::Design Plan comment was not published on issue #${ISSUE} by the feature-design recipe."
             echo ""


### PR DESCRIPTION
## Summary

- The `Verify Design Plan comment was published` step in `agentic-pipeline.yml` checked for a body starting with `## Design Plan`, but `feature-design` and `dev-session` both produce/consume the canonical marker `<!-- design-plan:v1 -->`.
- Result: every design run failed the workflow's verification step even though the Design Plan comment was published successfully — observed across this repo and `ocs-testbench`.
- Hotfix: switch the workflow's check to `startswith("<!-- design-plan:v1 -->")` so the workflow, the `feature-design` skill, and the `dev-session` skill all agree on the contract.

## Test plan

- [ ] Once merged, re-trigger design on issue #715 (toggle `in-design` off and back on); the design phase should now pass verification and the dev phase should proceed.
- [ ] A separate Requirement will follow to capture the wider three-contract drift cleanup (skill-spec doc still references `^## Design Plan`; verifier could additionally check for the H1 line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)