### PR TITLE
fix(doctor): treat 403 from gh variable get as unable-to-check

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -577,6 +577,18 @@ func checkVariable(deps CheckDeps, name string) CheckResult {
 	repoOut, repoErr := deps.Run("gh", "variable", "get", name, "--repo", deps.RepoFullName)
 	repoHit := repoErr == nil && strings.TrimSpace(repoOut) != ""
 
+	// Distinguish an auth/permission failure from a genuine missing variable.
+	// GitHub App tokens used in CI often lack the Actions:Read permission
+	// required to read variables, producing a 403. Treat that as "unable to
+	// check" rather than "not configured" so the check doesn't emit false
+	// positives when the variable is set but the token can't read it.
+	if !repoHit && repoErr != nil && isPermissionError(repoOut) {
+		return CheckResult{
+			Name: name, Status: Warning,
+			Message: name + " — unable to check (token lacks variable-read permission)",
+		}
+	}
+
 	// Org scope — only consulted for shared names under federated topology.
 	// Identity names stay repo-only even under federated.
 	orgHit := false
@@ -665,6 +677,19 @@ func checkSecret(deps CheckDeps, name string) CheckResult {
 // the repo (and the caller must not waste an API call on the org list).
 func shouldConsultOrg(name, topology string) bool {
 	return scope.IsSharedName(name) && scope.IsFederatedTopology(topology)
+}
+
+// isPermissionError returns true when gh CLI output indicates an auth/permission
+// failure (HTTP 403) rather than a genuine missing resource (HTTP 404). Used by
+// checkVariable to avoid false-positive "not configured" results when the token
+// lacks the Actions:Read permission required to read repo variables (common with
+// GitHub App installation tokens in CI).
+func isPermissionError(out string) bool {
+	lower := strings.ToLower(out)
+	return strings.Contains(lower, "403") ||
+		strings.Contains(lower, "resource not accessible") ||
+		strings.Contains(lower, "insufficient scopes") ||
+		strings.Contains(lower, "must have admin rights")
 }
 
 // containsVariableName returns true if the gh output from

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -950,6 +951,40 @@ func TestCheckVariable_Federated_SharedAtNeither_FailWithOrgRemediation(t *testi
 	wantHint := "gh variable set AGENT_USER --org acme"
 	if res.Remediation != wantHint {
 		t.Errorf("remediation: got %q, want %q", res.Remediation, wantHint)
+	}
+}
+
+// TestCheckVariable_PermissionError_Warns verifies that a 403 from gh CLI is
+// reported as "unable to check" rather than "not configured", preventing
+// false-positive failures when the token lacks Actions:Read (common with GitHub
+// App installation tokens in CI runners).
+func TestCheckVariable_PermissionError_Warns(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		output string
+	}{
+		{"HTTP 403", "HTTP 403: Resource not accessible by integration"},
+		{"insufficient scopes", "error: insufficient scopes"},
+		{"resource not accessible", "Resource not accessible"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := CheckDeps{
+				RepoFullName: "acme/repo", Owner: "acme", Topology: "single",
+				Run: func(name string, args ...string) (string, error) {
+					return tc.output, fmt.Errorf("gh: exit status 1")
+				},
+			}
+			res := checkVariable(deps, "AGENT_USER")
+			if res.Status != Warning {
+				t.Fatalf("status: got %d (%s), want Warning", res.Status, res.Message)
+			}
+			if !strings.Contains(res.Message, "unable to check") {
+				t.Errorf("message: got %q, want 'unable to check'", res.Message)
+			}
+			if res.Remediation != "" {
+				t.Errorf("remediation: want empty for auth error, got %q", res.Remediation)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- GitHub App installation tokens in CI runners commonly lack the **Actions: Read** permission required to read repo variables. Previously, any failed `gh variable get` was treated as "variable not configured", producing false-positive warnings (e.g., `AGENT_USER`, `RUNNER_LABEL`, `AGENTIC_APP_CLIENT_ID` appearing unset even when set).
- `checkVariable` now detects 403/auth error signals in the combined output and returns `Warning("unable to check — token lacks variable-read permission")` instead of falling through to the "not configured" path. Genuine missing-variable failures (empty output, 404) still report as before.
- Tests added for the three common 403 message patterns.

## Test plan

- [ ] Merge and include in next release; domain repos pick it up via `gh agentic mount`.
- [ ] After #715 design/dev completes, verify the false-positive variable warnings are gone from future design run logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)