### PR TITLE
fix(upgrade): normalise version tag prefix when defaulting to CLI version

### DIFF
--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -311,18 +311,18 @@ func printInfo(w io.Writer, data *infoData) {
 		value = value + "  " + ui.Muted.Render("(this repo)")
 		fmt.Fprintf(w, "  %-*s %s\n", infoLabelWidth, "Framework source:", value)
 	} else if data.localVersion != "" {
-		fmt.Fprintf(w, "  %-*s %s\n", infoLabelWidth, "Framework (local):", data.localVersion)
+		fmt.Fprintf(w, "  %-*s %s\n", infoLabelWidth, "Framework (local):", mount.TrimVPrefix(data.localVersion))
 	} else {
 		fmt.Fprintf(w, "  %-*s %s\n", infoLabelWidth, "Framework (local):", ui.Muted.Render("not mounted"))
 	}
 
 	if data.remoteVersion != "" {
-		fmt.Fprintf(w, "  %-*s %s%s\n", infoLabelWidth, "Framework (remote):", data.remoteVersion, data.syncStatus)
+		fmt.Fprintf(w, "  %-*s %s%s\n", infoLabelWidth, "Framework (remote):", mount.TrimVPrefix(data.remoteVersion), data.syncStatus)
 	} else {
 		fmt.Fprintf(w, "  %-*s %s\n", infoLabelWidth, "Framework (remote):", ui.Muted.Render("not set"))
 	}
 
-	fmt.Fprintf(w, "  %-*s %s%s\n", infoLabelWidth, "Framework (latest):", data.latestVersion, data.latestStatus)
+	fmt.Fprintf(w, "  %-*s %s%s\n", infoLabelWidth, "Framework (latest):", mount.TrimVPrefix(data.latestVersion), data.latestStatus)
 
 	fmt.Fprintln(w, "")
 }

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -84,9 +85,11 @@ Use --list to browse available versions before choosing one.`,
 			}
 
 			// Resolve target version: explicit arg wins; fall back to CLI version.
-			target := cliVersion
+			// Tags always carry a "v" prefix; GoReleaser strips it from the
+			// binary version string, so we normalise before the tag lookup.
+			target := ensureVPrefix(cliVersion)
 			if len(args) > 0 {
-				target = args[0]
+				target = ensureVPrefix(args[0])
 			} else {
 				fmt.Fprintf(w, "  No version specified — using CLI version %s.\n", target)
 			}
@@ -119,4 +122,14 @@ Use --list to browse available versions before choosing one.`,
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "skip confirmation prompt")
 	cmd.Flags().BoolVarP(&list, "list", "l", false, "list available framework versions")
 	return cmd
+}
+
+// ensureVPrefix normalises a version string to have a "v" prefix.
+// GoReleaser injects {{.Version}} (e.g. "2.6.2") into the binary, but git
+// tags and GitHub releases use the full tag name (e.g. "v2.6.2").
+func ensureVPrefix(v string) string {
+	if strings.HasPrefix(v, "v") {
+		return v
+	}
+	return "v" + v
 }

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -78,7 +78,7 @@ Use --list to browse available versions before choosing one.`,
 				fmt.Fprintln(w, "  "+ui.SectionHeading.Render("Available framework versions"))
 				fmt.Fprintln(w, "  "+ui.Divider(48))
 				for _, r := range releases {
-					fmt.Fprintf(w, "  %s\n", r.TagName)
+					fmt.Fprintf(w, "  %s\n", mount.TrimVPrefix(r.TagName))
 				}
 				fmt.Fprintln(w, "")
 				return nil
@@ -91,7 +91,7 @@ Use --list to browse available versions before choosing one.`,
 			if len(args) > 0 {
 				target = ensureVPrefix(args[0])
 			} else {
-				fmt.Fprintf(w, "  No version specified — using CLI version %s.\n", target)
+				fmt.Fprintf(w, "  No version specified — using CLI version %s.\n", mount.TrimVPrefix(target))
 			}
 
 			deps, err := resolveProjectDeps()

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -1,0 +1,21 @@
+package cli
+
+import "testing"
+
+func TestEnsureVPrefix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"2.6.2", "v2.6.2"},
+		{"v2.6.2", "v2.6.2"},
+		{"2.6.2-rc1", "v2.6.2-rc1"},
+		{"v2.6.2-rc1", "v2.6.2-rc1"},
+		{"dev", "vdev"},
+	}
+	for _, c := range cases {
+		if got := ensureVPrefix(c.in); got != c.want {
+			t.Errorf("ensureVPrefix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -188,7 +188,7 @@ func checkFramework(deps CheckDeps) Group {
 			version = v
 		}
 		g.Results = append(g.Results, CheckResult{
-			Name: "ai-mounted", Status: Pass, Message: fmt.Sprintf(".ai/ mounted (%s)", version),
+			Name: "ai-mounted", Status: Pass, Message: fmt.Sprintf(".ai/ mounted (%s)", mount.TrimVPrefix(version)),
 		})
 	} else {
 		g.Results = append(g.Results, CheckResult{
@@ -204,7 +204,7 @@ func checkFramework(deps CheckDeps) Group {
 	v, err := mount.ReadAIVersionFromGit(deps.Root)
 	if err == nil {
 		g.Results = append(g.Results, CheckResult{
-			Name: "ai-version", Status: Pass, Message: fmt.Sprintf("framework version pinned (%s)", v),
+			Name: "ai-version", Status: Pass, Message: fmt.Sprintf("framework version pinned (%s)", mount.TrimVPrefix(v)),
 		})
 	} else {
 		g.Results = append(g.Results, CheckResult{
@@ -339,12 +339,12 @@ func checkWorkflows(deps CheckDeps) Group {
 			})
 		case strings.Contains(string(data), "@"+version):
 			g.Results = append(g.Results, CheckResult{
-				Name: wf, Status: Pass, Message: fmt.Sprintf("%s → @%s", wf, version),
+				Name: wf, Status: Pass, Message: fmt.Sprintf("%s → @%s", wf, mount.TrimVPrefix(version)),
 			})
 		default:
 			g.Results = append(g.Results, CheckResult{
 				Name: wf, Status: Fail,
-				Message:     fmt.Sprintf("%s — version tag mismatch (expected @%s)", wf, version),
+				Message:     fmt.Sprintf("%s — version tag mismatch (expected @%s)", wf, mount.TrimVPrefix(version)),
 				Remediation: "Run 'gh agentic mount'",
 			})
 		}

--- a/internal/doctor/repair.go
+++ b/internal/doctor/repair.go
@@ -330,7 +330,7 @@ func RepairPipeline(deps CheckDeps, setLabel func(string)) RepairResult {
 				default:
 					result.Lines = append(result.Lines,
 						fmt.Sprintf("  %s  Workflow version tags updated to %s (%d file(s))",
-							ui.StatusOK.Render("✓"), version, rewrites))
+							ui.StatusOK.Render("✓"), mount.TrimVPrefix(version), rewrites))
 					result.Repaired++
 				}
 

--- a/internal/mount/version.go
+++ b/internal/mount/version.go
@@ -1,0 +1,11 @@
+package mount
+
+import "strings"
+
+// TrimVPrefix strips a leading "v" from a version string for display.
+// Git tags and GitHub releases carry a "v" prefix (e.g. "v2.6.2"); we
+// display versions without it for consistency with the CLI binary version
+// that GoReleaser injects (e.g. "2.6.2").
+func TrimVPrefix(v string) string {
+	return strings.TrimPrefix(v, "v")
+}


### PR DESCRIPTION
## Summary

- GoReleaser injects `{{.Version}}` (e.g. `2.6.2`) into the binary but git tags and GitHub releases use the full tag name (e.g. `v2.6.2`).
- Without normalisation, `gh agentic upgrade` with no argument searches for a non-existent tag.
- `ensureVPrefix()` guarantees the `v` prefix on both the CLI-version fallback and any explicit version argument — so users can pass `v2.6.1` or `2.6.1` interchangeably.
- Covered by `TestEnsureVPrefix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)