### PR TITLE
fix(standards): add gofmt to Go build verification sequence

### DIFF
--- a/standards/go.md
+++ b/standards/go.md
@@ -29,12 +29,13 @@ git add go.mod cmd/ internal/
 After any change to Go source, imports, or dependencies — run in this order:
 
 ```bash
+gofmt -w ./...
 go mod tidy
 go build ./...
 go test ./...
 ```
 
-Never claim an implementation is complete without all three passing.
+Never claim an implementation is complete without all four passing.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `gofmt -w ./...` as the first step in the Go Build Verification sequence
- CI enforces `gofmt` but the standard omitted it, causing dev sessions to commit unformatted files that then fail CI
- Seen concretely in ocs-testbench `orchestrator_test.go`

## Test plan

- [ ] Merge and verify dev sessions on Go repos run `gofmt` before build