### PR TITLE
feat(standards): add TypeScript and React standards

### DIFF
--- a/standards/react.md
+++ b/standards/react.md
@@ -1,0 +1,125 @@
+# React — Framework Standards
+
+Apply these rules in addition to `standards/typescript.md` when working in any React project.
+
+---
+
+## Build Verification
+
+After any change to React source, components, or dependencies — run in this order:
+
+```bash
+npx prettier --check .
+npx tsc --noEmit
+npm test
+```
+
+Never claim an implementation is complete without all three passing.
+
+---
+
+## Component Rules
+
+- **Functional components only** — class components are prohibited
+- **One component per file** — the file name matches the component name (`UserCard.tsx`)
+- **Props must be typed** — define an explicit interface for every component's props; never use inline object types or `any`
+- **Default exports for components** — named exports for utilities and hooks in the same file
+
+```typescript
+interface UserCardProps {
+  userId: string;
+  displayName: string;
+  onSelect?: (id: string) => void;
+}
+
+export default function UserCard({ userId, displayName, onSelect }: UserCardProps) {
+  // ...
+}
+```
+
+---
+
+## Hooks
+
+- **Custom hooks** — extract any stateful or side-effect logic shared across two or more components into a custom hook (`use<Name>.ts`)
+- **`useEffect` discipline** — every `useEffect` must declare all dependencies in its array; never suppress the exhaustive-deps lint rule without a code comment explaining why
+- **No direct DOM manipulation** — use `useRef` where a DOM handle is needed; never query selectors inside components
+- **State shape** — keep state as flat as possible; derive computed values with `useMemo` rather than storing derived state
+
+---
+
+## File Structure
+
+```
+src/
+  components/         # presentational components
+  features/           # feature-scoped components and their hooks
+  hooks/              # shared custom hooks
+  services/           # API clients and external integrations
+  types/              # shared TypeScript types and interfaces
+```
+
+Components that are only used by one feature live under `features/<name>/` — they do not move to `components/` until they are used by a second feature.
+
+---
+
+## Styling
+
+- Co-locate styles with the component — CSS modules (`UserCard.module.css`) or a CSS-in-JS library already in use in the project
+- Never use inline `style` props for anything other than truly dynamic values (e.g. computed pixel widths)
+- Never use global class names that are not scoped to the component
+
+---
+
+## Testing
+
+**Frameworks:** Vitest + React Testing Library
+
+**Install:**
+```bash
+npm install --save-dev @testing-library/react @testing-library/user-event @testing-library/jest-dom
+```
+
+**Commands:**
+```bash
+npm test                        # run all tests
+npm test -- --watch             # watch mode
+npm test -- UserCard            # filter by component name
+```
+
+**Requirements:**
+- Every component file must have an accompanying `.test.tsx` file
+- Test behaviour from the user's perspective — query by role, label, or visible text; never by CSS class or test ID unless unavoidable
+- Unit tests must NOT require a real backend — mock `fetch` / API clients at the module boundary
+
+**Test structure:**
+```typescript
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import UserCard from "./UserCard";
+
+describe("UserCard", () => {
+  it("displays the user's name", () => {
+    render(<UserCard userId="1" displayName="Alice" />);
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+  });
+
+  it("calls onSelect with the userId when clicked", async () => {
+    const onSelect = vi.fn();
+    render(<UserCard userId="1" displayName="Alice" onSelect={onSelect} />);
+    await userEvent.click(screen.getByRole("button"));
+    expect(onSelect).toHaveBeenCalledWith("1");
+  });
+});
+```
+
+**Test naming:** `describe` block = component name; `it` block = what the user sees or does, in plain English.
+
+---
+
+## Accessibility
+
+- Every interactive element must be reachable by keyboard and have an accessible name
+- Use semantic HTML elements (`<button>`, `<nav>`, `<main>`) before reaching for `<div>` with an `onClick`
+- Images must have descriptive `alt` text; decorative images use `alt=""`

--- a/standards/typescript.md
+++ b/standards/typescript.md
@@ -1,0 +1,142 @@
+# TypeScript — Language and Framework Standards
+
+Apply these rules when working in any TypeScript package in this repository.
+
+---
+
+## Project Initialisation
+
+```bash
+npm init -y
+npm install --save-dev typescript @types/node
+npx tsc --init
+```
+
+`tsconfig.json` must enable strict mode — never disable it:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+---
+
+## Build Verification
+
+After any change to TypeScript source, imports, or dependencies — run in this order:
+
+```bash
+npx prettier --check .
+npx tsc --noEmit
+npm test
+```
+
+Never claim an implementation is complete without all three passing.
+
+To auto-fix formatting before committing:
+
+```bash
+npx prettier --write .
+```
+
+---
+
+## Dependency Management
+
+```bash
+npm install <package>          # runtime dependency
+npm install --save-dev <pkg>   # dev-only dependency
+npm ci                         # clean install (CI / reproducible)
+```
+
+- Prefer libraries already used in the project over introducing new ones
+- Never edit `package-lock.json` by hand — it is managed by npm
+- Pin major versions in `package.json` — avoid unbound `*` ranges
+- Verify package names on [npmjs.com](https://www.npmjs.com) before adding — do not assume import paths
+
+---
+
+## Coding Standards
+
+- **No `any`** — use `unknown` and narrow with type guards, or define a proper type
+- **Explicit return types** — all exported functions and class methods must declare their return type
+- **Null safety** — use optional chaining (`?.`) and nullish coalescing (`??`); never assert non-null (`!`) without a code comment explaining why it cannot be null
+- **Immutability** — prefer `const` over `let`; never use `var`; prefer `readonly` on interface fields where the value is not intended to mutate
+- **Enums** — use `const enum` or string literal union types (`type Status = "active" | "inactive"`) over numeric enums
+- **Error handling** — never `throw` raw strings; define typed error classes or use a discriminated union result type (`{ ok: true; value: T } | { ok: false; error: Error }`)
+- **Async** — use `async`/`await` exclusively; never mix `.then()`/`.catch()` chains with `await` in the same function
+- **Sensitive data** — never log personally identifiable information, credentials, or financial values
+
+---
+
+## Naming Conventions
+
+| Construct | Convention | Example |
+|---|---|---|
+| Variables / functions | `camelCase` | `getUserById` |
+| Classes / interfaces / types | `PascalCase` | `UserService`, `ApiResponse` |
+| Constants | `UPPER_SNAKE_CASE` | `MAX_RETRY_COUNT` |
+| Files | `kebab-case.ts` | `user-service.ts` |
+| Test files | `<name>.test.ts` | `user-service.test.ts` |
+
+---
+
+## Testing
+
+**Framework:** Vitest
+
+**Commands:**
+```bash
+npm test                        # run all tests
+npm test -- --watch             # watch mode
+npm test -- --coverage          # with coverage report
+npm test -- user-service        # filter by name
+```
+
+**Requirements:**
+- Every `.ts` file with exported functions must have an accompanying `.test.ts` file
+- Files that only declare types, interfaces, or re-export are exempt
+- Tests must run and pass — writing without running does not satisfy this rule
+- Unit tests must NOT require external services (databases, APIs) — mock at the boundary
+
+**Test structure:**
+```typescript
+import { describe, it, expect, vi } from "vitest";
+
+describe("getUserById", () => {
+  it("returns the user when found", async () => {
+    // arrange
+    // act
+    // assert
+  });
+
+  it("throws NotFoundError when user does not exist", async () => {
+    await expect(getUserById("unknown")).rejects.toThrow(NotFoundError);
+  });
+});
+```
+
+**Test naming:** `describe` block = function or module name; `it` block = scenario in plain English.
+
+---
+
+## Architecture Boundaries
+
+- Keep business logic out of HTTP handlers — delegate to service functions
+- All external I/O (HTTP clients, database, queues) must be injectable for testing
+- Configuration from environment variables at the entry point only — never read `process.env` inside business logic
+
+---
+
+## Documentation
+
+- All exported functions, classes, and types must have a JSDoc comment
+- Comments describe what and why — not restate the code


### PR DESCRIPTION
## Summary

- Adds `standards/typescript.md` — build verification (prettier → tsc → vitest), strict mode config, coding rules, naming conventions, dependency management, testing patterns
- Adds `standards/react.md` — extends TypeScript standard with functional-component rules, hooks discipline, file structure, React Testing Library patterns, and accessibility baseline

Both files follow the same structure and tone as `standards/go.md`.

## Test plan

- [ ] Review content for accuracy against npm/vitest/RTL current conventions
- [ ] Confirm prettier is the formatter of choice (confirmed by @eddiecarpenter)
- [ ] Confirm vitest is the test framework (confirmed by @eddiecarpenter)