### PR TITLE
fix(upgrade): skip confirm prompt when defaulting to CLI version

### DIFF
--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -88,7 +88,8 @@ Use --list to browse available versions before choosing one.`,
 			// Tags always carry a "v" prefix; GoReleaser strips it from the
 			// binary version string, so we normalise before the tag lookup.
 			target := ensureVPrefix(cliVersion)
-			if len(args) > 0 {
+			explicitVersion := len(args) > 0
+			if explicitVersion {
 				target = ensureVPrefix(args[0])
 			} else {
 				fmt.Fprintf(w, "  No version specified — using CLI version %s.\n", mount.TrimVPrefix(target))
@@ -99,8 +100,13 @@ Use --list to browse available versions before choosing one.`,
 				return err
 			}
 
+			// Confirm only when an explicit version was supplied — the user is
+			// making a deliberate pin choice (upgrade or downgrade) and should
+			// acknowledge the switch. When defaulting to the CLI version the
+			// intent is unambiguous, so skip the prompt unless --yes was given
+			// (which would be a no-op here anyway).
 			var confirm func(string) (bool, error)
-			if !yes {
+			if !yes && explicitVersion {
 				confirm = deps.Confirm
 			}
 

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -19,3 +19,35 @@ func TestEnsureVPrefix(t *testing.T) {
 		}
 	}
 }
+
+// TestUpgradeConfirmBehaviour verifies the confirm-wiring logic:
+// no explicit version → confirm skipped; explicit version → confirm wired;
+// --yes → confirm skipped regardless.
+func TestUpgradeConfirmBehaviour(t *testing.T) {
+	fakeConfirm := func(string) (bool, error) { return true, nil }
+
+	cases := []struct {
+		name            string
+		yes             bool
+		explicitVersion bool
+		wantConfirm     bool
+	}{
+		{"no arg skips confirm", false, false, false},
+		{"explicit version wires confirm", false, true, true},
+		{"yes flag suppresses confirm with explicit version", true, true, false},
+		{"yes flag suppresses confirm without explicit version", true, false, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var confirm func(string) (bool, error)
+			if !c.yes && c.explicitVersion {
+				confirm = fakeConfirm
+			}
+			got := confirm != nil
+			if got != c.wantConfirm {
+				t.Errorf("confirm wired=%v, want %v", got, c.wantConfirm)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Skips the confirmation prompt when `gh agentic upgrade` is run with no version argument (defaults to CLI version)
- Keeps the prompt when an explicit version is supplied — the user is making a deliberate pin choice and should acknowledge the switch
- `--yes` continues to suppress the prompt in all cases

## Behaviour

| Invocation | Before | After |
|---|---|---|
| `gh agentic upgrade` | prompts | no prompt |
| `gh agentic upgrade v2.5.0` | prompts | prompts |
| `gh agentic upgrade --yes` | no prompt | no prompt |
| `gh agentic upgrade v2.5.0 --yes` | no prompt | no prompt |

## Test plan

- [ ] `go test ./internal/cli/...` passes
- [ ] `go build ./...` passes