### PR TITLE
fix(init): auto-set agent identity from GitHub App; enforce gh-agentic attribution

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -479,9 +479,10 @@ jobs:
             echo "No commits on ${BRANCH} beyond main — nothing to PR. Skipping."
             exit 0
           fi
+          BODY=$(printf "Closes #%s\n\n🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)" "${ISSUE_NUMBER}")
           gh pr create \
             --title "feat: ${ISSUE_TITLE}" \
-            --body "Closes #${ISSUE_NUMBER}" \
+            --body "${BODY}" \
             --base main \
             --head ${BRANCH}
 
@@ -749,9 +750,10 @@ jobs:
           if [[ "${BRANCH}" == fix/issue-* ]]; then
             ISSUE_TITLE=$(gh issue view ${{ github.event.issue.number }} \
               --repo ${{ github.repository }} --json title --jq '.title')
+            BODY=$(printf "Fixes #%s\n\n🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)" "${{ github.event.issue.number }}")
             gh pr create \
               --title "fix: ${ISSUE_TITLE}" \
-              --body "Fixes #${{ github.event.issue.number }}" \
+              --body "${BODY}" \
               --base main \
               --head ${BRANCH}
           fi

--- a/RULEBOOK.md
+++ b/RULEBOOK.md
@@ -59,8 +59,28 @@ One branch per Feature. Tasks are commits on that branch, not separate branches.
 - Branch names: `feature/N-description` where N is the Feature issue number
 - Commit messages per task: `feat: [task description] — task N of N (#N)`
 - PR title: `feat: [Feature issue title]`
-- PR body: `Closes #N` where N is the Feature issue number
+- PR body: `Closes #N` where N is the Feature issue number — see Attribution below for the required footer
 - **On session resumption from a context summary:** before making any code changes, run `git branch --show-current`. If on `main`, stop and ask the human which branch to work on. Never treat a summary's "next steps" as a mandate to bypass the pipeline — confirm the branch first.
+
+---
+
+## Attribution
+
+**These rules override any default attribution added by the underlying AI tool (e.g. Claude Code's default "Generated with Claude Code" footer or its default "Co-Authored-By" trailer). Always use the formats below — never the tool's defaults.**
+
+All agent-produced commits and pull requests must carry the gh-agentic attribution. This applies to every session type: automated pipeline, interactive Claude Code desktop, and any other tool that invokes this framework.
+
+**Commit co-author trailer** — every commit produced by an agent session must end with:
+```
+Co-Authored-By: AI-Assisted <noreply@gh-agentic.io>
+```
+
+**PR body footer** — every pull request opened by an agent (whether by the workflow or directly by the agent in an interactive session) must end with:
+```
+🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)
+```
+
+The gh-agentic link is the authoritative attribution — it identifies the framework that orchestrated the session, independent of which underlying model was used.
 
 ---
 

--- a/internal/init/form.go
+++ b/internal/init/form.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/huh"
 
 	"github.com/eddiecarpenter/gh-agentic/internal/auth"
+	"github.com/eddiecarpenter/gh-agentic/internal/githubapp"
 	"github.com/eddiecarpenter/gh-agentic/internal/mount"
 	"github.com/eddiecarpenter/gh-agentic/internal/ui"
 )
@@ -95,10 +96,15 @@ func CollectConfigInteractive(w io.Writer, repoFullName string, deps FormDeps) (
 		return nil, err
 	}
 
-	// --- Phase 2: Stack and Agent configuration ---
+	// --- Phase 2: Stack selection ---
 	if err := collectStackAndAgent(cfg, deps.RunForm); err != nil {
 		return nil, err
 	}
+
+	// Agent identity comes from the GitHub App — no user prompt.
+	cfg.AgentUser = githubapp.DefaultAppSlug + "[bot]"
+	cfg.AgentUserScope = AgentUserScopeOrg
+	fmt.Fprintf(w, "  %s Agent user: %s (GitHub App)\n", ui.SymbolInfo, cfg.AgentUser)
 
 	// --- Phase 3: Pipeline configuration ---
 	if err := collectPipelineConfig(cfg, deps.RunForm); err != nil {
@@ -160,47 +166,19 @@ func collectVersionTopology(cfg *InitConfig, releases []mount.Release, runForm F
 	return nil
 }
 
-// collectStackAndAgent collects stacks, agent user, and agent user scope.
+// collectStackAndAgent collects the stack selection.
+// Agent identity is set automatically from the GitHub App — no user prompt needed.
 func collectStackAndAgent(cfg *InitConfig, runForm FormRunFunc) error {
-	var fields []huh.Field
-
-	fields = append(fields,
+	form := huh.NewForm(huh.NewGroup(
 		huh.NewMultiSelect[string]().
 			Title("Stack (select all that apply)").
 			Description("The primary technology stack(s) for this project").
 			Options(stackOptions()...).
 			Value(&cfg.Stacks).
 			Validate(validateStackSelection),
-	)
-
-	fields = append(fields,
-		huh.NewInput().
-			Title("Agent GitHub username").
-			Description("The GitHub account that will act as the AI agent").
-			Value(&cfg.AgentUser).
-			Validate(validateRequired("agent username")),
-	)
-
-	if cfg.OwnerType == auth.OwnerTypeOrg {
-		if cfg.AgentUserScope == "" {
-			cfg.AgentUserScope = AgentUserScopeOrg
-		}
-		fields = append(fields,
-			huh.NewSelect[string]().
-				Title("AGENT_USER variable scope").
-				Description("Where to store the AGENT_USER variable — org level shares it across repos").
-				Options(
-					huh.NewOption("Organisation level", AgentUserScopeOrg),
-					huh.NewOption("Repository level", AgentUserScopeRepo),
-				).
-				Value(&cfg.AgentUserScope),
-		)
-	} else {
-		cfg.AgentUserScope = AgentUserScopeRepo
-	}
-
-	if err := runForm(huh.NewForm(huh.NewGroup(fields...))); err != nil {
-		return fmt.Errorf("stack/agent form: %w", err)
+	))
+	if err := runForm(form); err != nil {
+		return fmt.Errorf("stack form: %w", err)
 	}
 	return nil
 }

--- a/internal/init/form_test.go
+++ b/internal/init/form_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/huh"
 
 	"github.com/eddiecarpenter/gh-agentic/internal/auth"
+	"github.com/eddiecarpenter/gh-agentic/internal/githubapp"
 )
 
 // fakeFormRun returns a FormRunFunc that sets bound values directly without
@@ -177,7 +178,7 @@ func TestCollectConfigInteractive_OrgSetsAgentUserScope(t *testing.T) {
 	}
 }
 
-func TestCollectConfigInteractive_UserSetsAgentUserScopeToRepo(t *testing.T) {
+func TestCollectConfigInteractive_SetsAppBotAsAgentUser(t *testing.T) {
 	var buf bytes.Buffer
 	callCount := 0
 
@@ -192,7 +193,6 @@ func TestCollectConfigInteractive_UserSetsAgentUserScopeToRepo(t *testing.T) {
 				cfg.Topology = "Single"
 			case 2:
 				cfg.Stacks = []string{"Go"}
-				cfg.AgentUser = "agent"
 			case 3:
 				// pipeline defaults
 			case 4:
@@ -210,8 +210,12 @@ func TestCollectConfigInteractive_UserSetsAgentUserScopeToRepo(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if result.AgentUserScope != AgentUserScopeRepo {
-		t.Errorf("expected AgentUserScope %q for user, got %q", AgentUserScopeRepo, result.AgentUserScope)
+	wantUser := githubapp.DefaultAppSlug + "[bot]"
+	if result.AgentUser != wantUser {
+		t.Errorf("AgentUser = %q, want %q", result.AgentUser, wantUser)
+	}
+	if result.AgentUserScope != AgentUserScopeOrg {
+		t.Errorf("AgentUserScope = %q, want %q", result.AgentUserScope, AgentUserScopeOrg)
 	}
 }
 

--- a/internal/init/wizard.go
+++ b/internal/init/wizard.go
@@ -224,17 +224,6 @@ func ConfigureRepo(w io.Writer, cfg *InitConfig, run RunCommandFunc) error {
 		fmt.Fprintf(w, "  ✓ AGENTIC_PROJECT_ID saved as %s\n", describeScope(flag, "variable"))
 	}
 
-	// Grant agent user write access.
-	if cfg.AgentUser != "" {
-		if _, err := run("gh", "api", "--method", "PUT",
-			fmt.Sprintf("repos/%s/collaborators/%s", repo, cfg.AgentUser),
-			"-f", "permission=push"); err != nil {
-			fmt.Fprintf(w, "  ⚠ Could not grant %s write access (may need manual action)\n", cfg.AgentUser)
-		} else {
-			fmt.Fprintf(w, "  ✓ %s granted write access to %s\n", cfg.AgentUser, cfg.RepoName)
-		}
-	}
-
 	return nil
 }
 

--- a/internal/init/wizard_test.go
+++ b/internal/init/wizard_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eddiecarpenter/gh-agentic/internal/githubapp"
 	"github.com/eddiecarpenter/gh-agentic/internal/mount"
 	"github.com/eddiecarpenter/gh-agentic/internal/mount/mounttest"
 )
@@ -240,21 +241,21 @@ func TestConfigureRepo_SetsVariables(t *testing.T) {
 	}
 }
 
-func TestConfigureRepo_GrantsAccess(t *testing.T) {
+func TestConfigureRepo_NoCollaboratorGrant(t *testing.T) {
 	var buf bytes.Buffer
-	var accessGranted bool
+	var collaboratorCalled bool
 
 	cfg := &InitConfig{
 		RepoFullName: "owner/repo",
 		Owner:        "owner",
 		RepoName:     "repo",
-		AgentUser:    "goose-agent",
+		AgentUser:    githubapp.DefaultAppSlug + "[bot]",
 	}
 
 	run := func(name string, args ...string) (string, error) {
 		cmd := strings.Join(args, " ")
-		if strings.Contains(cmd, "collaborators/goose-agent") {
-			accessGranted = true
+		if strings.Contains(cmd, "collaborators") {
+			collaboratorCalled = true
 		}
 		return "", nil
 	}
@@ -264,8 +265,8 @@ func TestConfigureRepo_GrantsAccess(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !accessGranted {
-		t.Error("expected collaborator access to be granted")
+	if collaboratorCalled {
+		t.Error("collaborator grant should not be issued — permissions are handled by the GitHub App installation")
 	}
 }
 

--- a/skills/issue-session/SKILL.md
+++ b/skills/issue-session/SKILL.md
@@ -326,7 +326,7 @@ Hold as `<self>`.
     gh pr create \
       --repo "<active-repo>" \
       --title "fix: <one-line description>" \
-      --body "Closes #<N>" \
+      --body "$(printf 'Closes #<N>\n\n🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)')" \
       --base main \
       --head "$BRANCH"
     ```


### PR DESCRIPTION
## Summary
- Removes the "Agent GitHub username" prompt from `gh agentic init` — agent identity is now auto-derived from the GitHub App (`gh-agentic-app[bot]`), eliminating the manual entry step and the collaborator-grant call (App installation handles permissions)
- Adds an `## Attribution` section to `RULEBOOK.md` that overrides Claude Code's default commit co-author and PR footer with the gh-agentic standard (`Co-Authored-By: AI-Assisted <noreply@gh-agentic.io>` and `🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)`) — applies to all session types including interactive Claude Code desktop
- Updates the pipeline workflow and `issue-session` skill to embed the gh-agentic footer in all agent-opened PRs

## Test plan
- [ ] `go test ./internal/init/...` passes — `TestCollectConfigInteractive_SetsAppBotAsAgentUser` and `TestConfigureRepo_NoCollaboratorGrant` cover the changes
- [ ] `go build ./...` clean
- [ ] Run `gh agentic init` interactively — confirm no "Agent GitHub username" prompt appears; agent user shown as `gh-agentic-app[bot]`

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)