### PR TITLE
fix(init): remove topology double-ask and project ID prompt

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -97,11 +96,6 @@ change membership, or --force to re-run setup from scratch.`,
 				}
 			}
 
-			root, err := os.Getwd()
-			if err != nil {
-				return fmt.Errorf("resolving working directory: %w", err)
-			}
-
 			// Step 1: Ask single or federated.
 			var topology string
 			topoForm := huh.NewForm(huh.NewGroup(
@@ -119,34 +113,36 @@ change membership, or --force to re-run setup from scratch.`,
 			}
 
 			if topology == "single" {
-				// Single path: full wizard via the init package.
-				initDeps := initpkg.Deps{
-					Run:   auth.DefaultRunCommand,
-					Clone: mount.DefaultClone,
-					CollectConfig: func(w io.Writer, repo string) (*initpkg.InitConfig, error) {
-						return initpkg.CollectConfigInteractive(w, repo, initpkg.FormDeps{
-							RunForm:         initpkg.DefaultFormRun,
-							RunCommand:      auth.DefaultRunCommand,
-							DetectOwnerType: defaultDetectOwnerType,
-							FetchReleases:   mount.DefaultFetchReleases,
-						})
-					},
-					EnsureAppInstalled: buildAppInstaller(cmd, skipAppInstall),
+				// Single path: collect config (topology already known, project
+				// created automatically by project.InitRepo — no project ID
+				// prompt), then delegate to project.InitRepo(InitModeSingle)
+				// which calls project.Create to build the board and mount the
+				// framework.
+				initCfg, err := initpkg.CollectConfigInteractive(w, deps.RepoFullName, initpkg.FormDeps{
+					RunForm:         initpkg.DefaultFormRun,
+					RunCommand:      auth.DefaultRunCommand,
+					DetectOwnerType: defaultDetectOwnerType,
+					FetchReleases:   mount.DefaultFetchReleases,
+					Topology:        "single",
+				})
+				if err != nil {
+					return fmt.Errorf("configuration: %w", err)
 				}
-				if err := initpkg.Run(w, root, force, initDeps); err != nil {
-					if errors.Is(err, initpkg.ErrAlreadyInitialised) {
-						return ErrSilent
+
+				// Run the App-install guidance step before identity writes.
+				if installer := buildAppInstaller(cmd, skipAppInstall); installer != nil {
+					if err := installer(w, initCfg); err != nil {
+						return fmt.Errorf("App install check: %w", err)
 					}
-					return err
 				}
-				// Single-topology init no longer writes AGENTIC_TOPOLOGY
-				// automatically (task #585). The resolver infers topology
-				// from the project-linked-repo graph; the variable remains
-				// an optional explicit override only.
-				return nil
+
+				return project.InitRepo(w, deps, project.InitRepoConfig{
+					Mode:    project.InitModeSingle,
+					InitCfg: initCfg,
+				})
 			}
 
-			// Federated path: list federated projects, user picks.
+			// Federated path: list federated projects, user picks one.
 			fmt.Fprintf(w, "\n  Fetching federated projects for %s...\n\n", deps.Owner)
 			projects, err := project.ListFederatedProjects(deps)
 			if err != nil {
@@ -172,12 +168,14 @@ change membership, or --force to re-run setup from scratch.`,
 				return fmt.Errorf("project selection: %w", err)
 			}
 
-			// Collect configuration.
+			// Collect configuration — topology is federated (already captured),
+			// project ID comes from the list picker above (not a form field).
 			initCfg, err := initpkg.CollectConfigInteractive(w, deps.RepoFullName, initpkg.FormDeps{
 				RunForm:         initpkg.DefaultFormRun,
 				RunCommand:      auth.DefaultRunCommand,
 				DetectOwnerType: defaultDetectOwnerType,
 				FetchReleases:   mount.DefaultFetchReleases,
+				Topology:        "federated",
 			})
 			if err != nil {
 				return fmt.Errorf("configuration: %w", err)
@@ -187,10 +185,7 @@ change membership, or --force to re-run setup from scratch.`,
 			// initpkg.ConfigureRepo. Tests inject their own ConfirmFunc.
 			initCfg.Confirm = initpkg.HuhConfirm
 
-			// Federated path: run the App-install guidance step before
-			// handing off to project.InitRepo, so the pipeline-facing
-			// guarantee (App installed before identity writes) holds
-			// symmetrically with the single path.
+			// Run the App-install guidance step before identity writes.
 			if installer := buildAppInstaller(cmd, skipAppInstall); installer != nil {
 				if err := installer(w, initCfg); err != nil {
 					return fmt.Errorf("App install check: %w", err)

--- a/internal/init/form.go
+++ b/internal/init/form.go
@@ -30,6 +30,11 @@ type FormDeps struct {
 	RunCommand      RunCommandFunc
 	DetectOwnerType DetectOwnerTypeFunc
 	FetchReleases   mount.FetchReleasesFunc
+	// Topology, when non-empty, pre-seeds cfg.Topology and suppresses the
+	// topology select in collectVersionTopology. The CLI captures topology
+	// first (single vs. federated routing decision) and passes it here so
+	// the form does not ask a second time.
+	Topology string
 }
 
 // DefaultFormDeps returns production dependencies for the interactive form.
@@ -80,6 +85,11 @@ func CollectConfigInteractive(w io.Writer, repoFullName string, deps FormDeps) (
 		cfg.OwnerType = auth.OwnerTypeUser
 	}
 	fmt.Fprintln(w)
+
+	// --- Pre-seed topology when the caller already captured it ---
+	if deps.Topology != "" {
+		cfg.Topology = deps.Topology
+	}
 
 	// --- Fetch available releases for version dropdown ---
 	var releases []mount.Release
@@ -147,19 +157,23 @@ func collectVersionTopology(cfg *InitConfig, releases []mount.Release, runForm F
 			Validate(validateVersion)
 	}
 
-	form := huh.NewForm(
-		huh.NewGroup(
-			versionField,
-			huh.NewSelect[string]().
-				Title("Project topology").
-				Description("How your project repos are structured").
-				Options(
-					huh.NewOption("Single      — one repo, everything in one place", "Single"),
-					huh.NewOption("Federated   — separate control plane + domain repos", "Federated"),
-				).
-				Value(&cfg.Topology),
-		),
-	)
+	// Include the topology select only when the caller has not pre-seeded it.
+	// The CLI captures topology first (to route single vs. federated) and
+	// passes it through FormDeps.Topology so the user is not asked twice.
+	var fields []huh.Field
+	fields = append(fields, versionField)
+	if cfg.Topology == "" {
+		fields = append(fields, huh.NewSelect[string]().
+			Title("Project topology").
+			Description("How your project repos are structured").
+			Options(
+				huh.NewOption("Single      — one repo, everything in one place", "Single"),
+				huh.NewOption("Federated   — separate control plane + domain repos", "Federated"),
+			).
+			Value(&cfg.Topology))
+	}
+
+	form := huh.NewForm(huh.NewGroup(fields...))
 	if err := runForm(form); err != nil {
 		return fmt.Errorf("version/topology form: %w", err)
 	}
@@ -246,7 +260,11 @@ func collectPipelineConfig(cfg *InitConfig, runForm FormRunFunc) error {
 	return nil
 }
 
-// collectCredentialsAndProject collects PAT, Claude credentials, and project ID.
+// collectCredentialsAndProject collects the PROJECT_PAT and Claude credentials.
+// The AGENTIC_PROJECT_ID is never prompted here — for single topology it is
+// created automatically by project.Create; for federated topology it is
+// selected from the project list by the CLI before CollectConfigInteractive
+// is called. Both paths set the variable through their own code paths.
 func collectCredentialsAndProject(cfg *InitConfig, runForm FormRunFunc) error {
 	form := huh.NewForm(
 		huh.NewGroup(
@@ -260,10 +278,6 @@ func collectCredentialsAndProject(cfg *InitConfig, runForm FormRunFunc) error {
 				Description("Base64-encoded Claude credentials (leave empty to skip)").
 				Value(&cfg.ClaudeCreds).
 				EchoMode(huh.EchoModePassword),
-			huh.NewInput().
-				Title("GitHub Project ID").
-				Description("The GitHub Project number for pipeline tracking (e.g. PVT_123)").
-				Value(&cfg.ProjectID),
 		),
 	)
 	if err := runForm(form); err != nil {


### PR DESCRIPTION
## Summary
- **Topology asked twice**: The CLI asks topology first (to decide single vs. federated routing), then `CollectConfigInteractive` asked it again inside `collectVersionTopology`. Fixed by adding `Topology string` to `FormDeps` — when pre-set, the topology select is skipped in the form.
- **Project ID prompt on single**: Single topology prompted "GitHub Project ID" — a value the user cannot know before running init. For single topology the project is created automatically by `project.Create`; for federated it's picked from a list. Removed the field from `collectCredentialsAndProject` and rewired the single path to use `project.InitRepo(InitModeSingle)` instead of the legacy `initpkg.Run`.

## Test plan
- [ ] `go test ./...` passes
- [ ] Run `gh agentic init` — topology asked exactly once; single topology flows into project creation with no project ID prompt; federated topology shows project picker then goes straight to stack/runner/creds

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)