### PR TITLE
fix(githubapp): treat 401/403 on install check as cannot-verify, not error

### DIFF
--- a/internal/githubapp/installation.go
+++ b/internal/githubapp/installation.go
@@ -109,8 +109,18 @@ func (c *Checker) check(ctx context.Context, endpoint string) (bool, int64, erro
 	var resp installationResponse
 	if err := c.Client.DoWithContext(ctx, http.MethodGet, endpoint, nil, &resp); err != nil {
 		var httpErr *api.HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			return false, 0, nil
+		if errors.As(err, &httpErr) {
+			switch httpErr.StatusCode {
+			case http.StatusNotFound:
+				// 404 — App is definitively not installed on this target.
+				return false, 0, nil
+			case http.StatusUnauthorized, http.StatusForbidden:
+				// 401/403 — the installation endpoint requires a GitHub App JWT;
+				// a regular user OAuth token is rejected here. Treat as
+				// "cannot verify" so the flow offers the install URL
+				// interactively rather than aborting the wizard.
+				return false, 0, nil
+			}
 		}
 		return false, 0, fmt.Errorf("checking installation at %s: %w", endpoint, err)
 	}

--- a/internal/githubapp/installation_test.go
+++ b/internal/githubapp/installation_test.go
@@ -115,6 +115,35 @@ func TestCheckRepoInstallation_NotFound_ReturnsNotInstalled(t *testing.T) {
 	}
 }
 
+func TestCheckRepoInstallation_Unauthorized_ReturnsNotInstalled(t *testing.T) {
+	// 401 means the endpoint requires App JWT auth; a regular user token is
+	// rejected. Treat as "cannot verify" — return not-installed with no error
+	// so the wizard can offer the install URL interactively.
+	f := &fakeClient{result: httpError(http.StatusUnauthorized)}
+	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+
+	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("expected no error on 401, got: %v", err)
+	}
+	if installed || id != 0 {
+		t.Fatalf("expected installed=false id=0 on 401, got installed=%v id=%d", installed, id)
+	}
+}
+
+func TestCheckRepoInstallation_Forbidden_ReturnsNotInstalled(t *testing.T) {
+	f := &fakeClient{result: httpError(http.StatusForbidden)}
+	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+
+	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("expected no error on 403, got: %v", err)
+	}
+	if installed || id != 0 {
+		t.Fatalf("expected installed=false id=0 on 403, got installed=%v id=%d", installed, id)
+	}
+}
+
 func TestCheckRepoInstallation_ServerError_ReturnsWrappedError(t *testing.T) {
 	f := &fakeClient{result: httpError(http.StatusInternalServerError)}
 	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
@@ -204,6 +233,32 @@ func TestCheckOrgInstallation_NotFound_ReturnsNotInstalled(t *testing.T) {
 	}
 	if installed {
 		t.Fatalf("expected installed=false on 404")
+	}
+}
+
+func TestCheckOrgInstallation_Unauthorized_ReturnsNotInstalled(t *testing.T) {
+	f := &fakeClient{result: httpError(http.StatusUnauthorized)}
+	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+
+	installed, id, err := c.CheckOrgInstallation(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("expected no error on 401, got: %v", err)
+	}
+	if installed || id != 0 {
+		t.Fatalf("expected installed=false id=0 on 401, got installed=%v id=%d", installed, id)
+	}
+}
+
+func TestCheckOrgInstallation_Forbidden_ReturnsNotInstalled(t *testing.T) {
+	f := &fakeClient{result: httpError(http.StatusForbidden)}
+	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+
+	installed, _, err := c.CheckOrgInstallation(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("expected no error on 403, got: %v", err)
+	}
+	if installed {
+		t.Fatalf("expected installed=false on 403")
 	}
 }
 


### PR DESCRIPTION
## Summary
- The GitHub App installation endpoint (`/repos/{owner}/{repo}/installation`) requires a **GitHub App JWT** to authenticate. A regular user OAuth token is always rejected with HTTP 401.
- During `gh agentic init`, if the user skips Claude credentials, no App JWT is available, so the checker gets a 401 and was propagating it as a hard error: `App install check: checking App installation: ... HTTP 401: A JSON web token could not be decoded`.
- Fix: treat 401 and 403 the same as 404 — "cannot verify" — so the flow falls through to the interactive prompt and shows the App install URL instead of aborting init.

## Test plan
- [ ] `go test ./internal/githubapp/...` — four new tests cover 401/403 on both repo and org endpoints
- [ ] `go test ./...` passes
- [ ] Run `gh agentic init` without setting Claude credentials — no 401 error, App install URL is shown interactively

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)