### PR TITLE
fix(init): auto-read Claude credentials; fix app slug and default model

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -136,10 +136,14 @@ change membership, or --force to re-run setup from scratch.`,
 					}
 				}
 
-				return project.InitRepo(w, deps, project.InitRepoConfig{
+				if err := project.InitRepo(w, deps, project.InitRepoConfig{
 					Mode:    project.InitModeSingle,
 					InitCfg: initCfg,
-				})
+				}); err != nil {
+					return err
+				}
+				tryUploadClaudeCredentials(w, deps, initCfg.OwnerType)
+				return nil
 			}
 
 			// Federated path: list federated projects, user picks one.
@@ -192,17 +196,42 @@ change membership, or --force to re-run setup from scratch.`,
 				}
 			}
 
-			return project.InitRepo(w, deps, project.InitRepoConfig{
+			if err := project.InitRepo(w, deps, project.InitRepoConfig{
 				Mode:      project.InitModeFederated,
 				ProjectID: projectID,
 				InitCfg:   initCfg,
-			})
+			}); err != nil {
+				return err
+			}
+			tryUploadClaudeCredentials(w, deps, initCfg.OwnerType)
+			return nil
 		},
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing configuration")
 	cmd.Flags().BoolVar(&skipAppInstall, "skip-app-install", false, "skip the agentic GitHub App install-state check and install guidance")
 	return cmd
+}
+
+// tryUploadClaudeCredentials reads Claude credentials from the local machine
+// and uploads them as the CLAUDE_CREDENTIALS_JSON secret, using the same
+// mechanism as 'gh agentic auth refresh'. If credentials are not found locally
+// (e.g. the user has never logged in to Claude Code on this machine), a guidance
+// message is printed and init continues — the user can upload credentials later
+// with 'gh agentic auth refresh'.
+func tryUploadClaudeCredentials(w io.Writer, deps project.Deps, ownerType string) {
+	fmt.Fprintf(w, "\n")
+	authDeps := auth.Deps{
+		Run:             auth.DefaultRunCommand,
+		ReadCredentials: auth.ReadClaudeCredentialsDefault,
+		RepoFullName:    deps.RepoFullName,
+		Owner:           deps.Owner,
+		RepoName:        deps.RepoName,
+		OwnerType:       ownerType,
+	}
+	if err := auth.Refresh(w, authDeps); err != nil {
+		fmt.Fprintf(w, "  %s  Claude credentials not found locally — run 'gh agentic auth refresh' to upload them\n", ui.StatusWarning.Render("⚠"))
+	}
 }
 
 // buildAppInstaller returns the EnsureAppInstalled hook wired to the

--- a/internal/cli/project_appinstall_test.go
+++ b/internal/cli/project_appinstall_test.go
@@ -60,7 +60,7 @@ func TestRunAppInstallStep_Skipped_NoCalls(t *testing.T) {
 	checker := &fakeChecker{}
 	withProjectFlow(t, &githubapp.Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return true },
 	})
 
@@ -88,7 +88,7 @@ func TestRunAppInstallStep_OrgOwner_UsesOrgEndpoint(t *testing.T) {
 	checker := &fakeChecker{orgInstalled: true}
 	withProjectFlow(t, &githubapp.Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return true },
 	})
 
@@ -109,7 +109,7 @@ func TestRunAppInstallStep_UserOwner_UsesRepoEndpoint(t *testing.T) {
 	checker := &fakeChecker{repoInstalled: true}
 	withProjectFlow(t, &githubapp.Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return true },
 	})
 
@@ -135,7 +135,7 @@ func TestRunAppInstallStep_DetectOwnerTypeError_FallsBackToRepo(t *testing.T) {
 	checker := &fakeChecker{repoInstalled: true}
 	withProjectFlow(t, &githubapp.Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return true },
 	})
 
@@ -157,7 +157,7 @@ func TestRunAppInstallStep_HeadlessMissingApp_PrintsURLAndContinues(t *testing.T
 	checker := &fakeChecker{orgInstalled: false}
 	withProjectFlow(t, &githubapp.Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return true },
 	})
 
@@ -166,7 +166,7 @@ func TestRunAppInstallStep_HeadlessMissingApp_PrintsURLAndContinues(t *testing.T
 	if err := runAppInstallStep(context.Background(), &buf, deps, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(buf.String(), "https://github.com/apps/gh-agentic-app/installations/new") {
+	if !strings.Contains(buf.String(), "https://github.com/apps/gh-agentic/installations/new") {
 		t.Errorf("expected install URL to be printed in headless mode; got %q", buf.String())
 	}
 }
@@ -175,7 +175,7 @@ func TestRunAppInstallStep_InteractiveDecline_PrintsURLAndContinues(t *testing.T
 	checker := &fakeChecker{}
 	withProjectFlow(t, &githubapp.Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return false },
 		Confirm: func(string, string) (bool, error) { return false, nil },
 	})
@@ -197,7 +197,7 @@ func TestRunAppInstallStep_InteractiveAccept_InvokesBrowser(t *testing.T) {
 	var openedURL string
 	withProjectFlow(t, &githubapp.Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return false },
 		Confirm: func(string, string) (bool, error) { return true, nil },
 		OpenURL: func(u string) error { openedURL = u; return nil },
@@ -211,7 +211,7 @@ func TestRunAppInstallStep_InteractiveAccept_InvokesBrowser(t *testing.T) {
 	if openedURL == "" {
 		t.Fatalf("expected OpenURL to be called in interactive-accept path")
 	}
-	if !strings.Contains(openedURL, "apps/gh-agentic-app") {
+	if !strings.Contains(openedURL, "apps/gh-agentic") {
 		t.Errorf("expected install URL in %q", openedURL)
 	}
 }

--- a/internal/githubapp/flow_test.go
+++ b/internal/githubapp/flow_test.go
@@ -48,7 +48,7 @@ func TestEnsureInstalled_AlreadyInstalled_ReturnsAlreadyInstalled(t *testing.T) 
 	checker := &fakeChecker{repoResults: []checkOutcome{{installed: true, id: 42}}}
 	flow := &Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return false },
 	}
 	var w bytes.Buffer
@@ -72,7 +72,7 @@ func TestEnsureInstalled_Headless_PrintsURLAndContinues(t *testing.T) {
 	checker := &fakeChecker{}
 	flow := &Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return true },
 	}
 	var w bytes.Buffer
@@ -85,7 +85,7 @@ func TestEnsureInstalled_Headless_PrintsURLAndContinues(t *testing.T) {
 		t.Fatalf("expected ResultHeadless, got %v", got)
 	}
 	out := w.String()
-	if !strings.Contains(out, "https://github.com/apps/gh-agentic-app/installations/new") {
+	if !strings.Contains(out, "https://github.com/apps/gh-agentic/installations/new") {
 		t.Errorf("expected install URL in output; got %q", out)
 	}
 	// Must not prompt in headless mode — Confirm absent means nothing was
@@ -99,7 +99,7 @@ func TestEnsureInstalled_Headless_NonTTYFallback(t *testing.T) {
 	confirmCalled := false
 	flow := &Flow{
 		Checker:       checker,
-		Slug:          "gh-agentic-app",
+		Slug:          "gh-agentic",
 		IsCI:          func() bool { return false },
 		IsInteractive: func(_ io.Writer) bool { return false },
 		Confirm: func(string, string) (bool, error) {
@@ -122,7 +122,7 @@ func TestEnsureInstalled_InteractiveDecline_PrintsURLAndContinues(t *testing.T) 
 	checker := &fakeChecker{}
 	flow := &Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return false },
 		Confirm: func(string, string) (bool, error) { return false, nil },
 	}
@@ -151,7 +151,7 @@ func TestEnsureInstalled_InteractiveAccept_OpenConfirmed(t *testing.T) {
 
 	flow := &Flow{
 		Checker:   checker,
-		Slug:      "gh-agentic-app",
+		Slug:      "gh-agentic",
 		IsCI:      func() bool { return false },
 		Confirm:   func(string, string) (bool, error) { return true, nil },
 		OpenURL:   func(u string) error { openedURL = u; return nil },
@@ -166,7 +166,7 @@ func TestEnsureInstalled_InteractiveAccept_OpenConfirmed(t *testing.T) {
 	if got != ResultInstalledInteractive {
 		t.Fatalf("expected ResultInstalledInteractive, got %v", got)
 	}
-	if openedURL == "" || !strings.Contains(openedURL, "apps/gh-agentic-app") {
+	if openedURL == "" || !strings.Contains(openedURL, "apps/gh-agentic") {
 		t.Errorf("expected browser-open with install URL; got %q", openedURL)
 	}
 	if !waitCalled {
@@ -186,7 +186,7 @@ func TestEnsureInstalled_InteractiveAccept_PendingWhenReCheckStillMissing(t *tes
 	}}
 	flow := &Flow{
 		Checker:   checker,
-		Slug:      "gh-agentic-app",
+		Slug:      "gh-agentic",
 		IsCI:      func() bool { return false },
 		Confirm:   func(string, string) (bool, error) { return true, nil },
 		OpenURL:   func(string) error { return nil },
@@ -216,7 +216,7 @@ func TestEnsureInstalled_InteractiveAccept_BrowserOpenError_ContinuesWithURL(t *
 	}}
 	flow := &Flow{
 		Checker: checker,
-		Slug:    "gh-agentic-app",
+		Slug:    "gh-agentic",
 		IsCI:    func() bool { return false },
 		Confirm: func(string, string) (bool, error) { return true, nil },
 		OpenURL: func(string) error { return errors.New("no display") },
@@ -234,7 +234,7 @@ func TestEnsureInstalled_InteractiveAccept_BrowserOpenError_ContinuesWithURL(t *
 
 func TestEnsureInstalled_OrgTarget_UsesOrgEndpoint(t *testing.T) {
 	checker := &fakeChecker{orgResults: []checkOutcome{{installed: true, id: 1}}}
-	flow := &Flow{Checker: checker, Slug: "gh-agentic-app", IsCI: func() bool { return false }}
+	flow := &Flow{Checker: checker, Slug: "gh-agentic", IsCI: func() bool { return false }}
 	var w bytes.Buffer
 
 	_, err := EnsureInstalled(context.Background(), &w, nil, flow, Target{Type: TargetOrg, Owner: "acme"})
@@ -252,7 +252,7 @@ func TestEnsureInstalled_OrgTarget_UsesOrgEndpoint(t *testing.T) {
 func TestEnsureInstalled_DetectionError_PropagatesWrapped(t *testing.T) {
 	sentinel := errors.New("boom")
 	checker := &fakeChecker{repoResults: []checkOutcome{{err: sentinel}}}
-	flow := &Flow{Checker: checker, Slug: "gh-agentic-app", IsCI: func() bool { return false }}
+	flow := &Flow{Checker: checker, Slug: "gh-agentic", IsCI: func() bool { return false }}
 	var w bytes.Buffer
 
 	_, err := EnsureInstalled(context.Background(), &w, nil, flow, Target{Type: TargetRepo, Owner: "o", Repo: "r"})
@@ -275,7 +275,7 @@ func TestEnsureInstalled_NilFlow_ReturnsError(t *testing.T) {
 }
 
 func TestEnsureInstalled_IncompleteTarget_ReturnsError(t *testing.T) {
-	flow := &Flow{Checker: &fakeChecker{}, Slug: "gh-agentic-app"}
+	flow := &Flow{Checker: &fakeChecker{}, Slug: "gh-agentic"}
 	tests := []Target{
 		{Type: TargetRepo, Owner: "", Repo: "r"},
 		{Type: TargetRepo, Owner: "o", Repo: ""},

--- a/internal/githubapp/installation.go
+++ b/internal/githubapp/installation.go
@@ -25,7 +25,7 @@ import (
 // value used by the canonical App listed on GitHub and is the default value
 // Checker instances are constructed with. Tests may override it via
 // NewChecker to exercise the "wrong app installed" path.
-const DefaultAppSlug = "gh-agentic-app"
+const DefaultAppSlug = "gh-agentic"
 
 // RESTClient is the minimal surface the installation checks need from a
 // GitHub REST client. It is satisfied by *api.RESTClient from

--- a/internal/githubapp/installation.go
+++ b/internal/githubapp/installation.go
@@ -109,8 +109,18 @@ func (c *Checker) check(ctx context.Context, endpoint string) (bool, int64, erro
 	var resp installationResponse
 	if err := c.Client.DoWithContext(ctx, http.MethodGet, endpoint, nil, &resp); err != nil {
 		var httpErr *api.HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			return false, 0, nil
+		if errors.As(err, &httpErr) {
+			switch httpErr.StatusCode {
+			case http.StatusNotFound:
+				// 404 — App is definitively not installed on this target.
+				return false, 0, nil
+			case http.StatusUnauthorized, http.StatusForbidden:
+				// 401/403 — the installation endpoint requires a GitHub App JWT;
+				// a regular user OAuth token is rejected here. Treat as
+				// "cannot verify" so the flow offers the install URL
+				// interactively rather than aborting the wizard.
+				return false, 0, nil
+			}
 		}
 		return false, 0, fmt.Errorf("checking installation at %s: %w", endpoint, err)
 	}

--- a/internal/githubapp/installation_test.go
+++ b/internal/githubapp/installation_test.go
@@ -115,6 +115,35 @@ func TestCheckRepoInstallation_NotFound_ReturnsNotInstalled(t *testing.T) {
 	}
 }
 
+func TestCheckRepoInstallation_Unauthorized_ReturnsNotInstalled(t *testing.T) {
+	// 401 means the endpoint requires App JWT auth; a regular user token is
+	// rejected. Treat as "cannot verify" — return not-installed with no error
+	// so the wizard can offer the install URL interactively.
+	f := &fakeClient{result: httpError(http.StatusUnauthorized)}
+	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+
+	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("expected no error on 401, got: %v", err)
+	}
+	if installed || id != 0 {
+		t.Fatalf("expected installed=false id=0 on 401, got installed=%v id=%d", installed, id)
+	}
+}
+
+func TestCheckRepoInstallation_Forbidden_ReturnsNotInstalled(t *testing.T) {
+	f := &fakeClient{result: httpError(http.StatusForbidden)}
+	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+
+	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("expected no error on 403, got: %v", err)
+	}
+	if installed || id != 0 {
+		t.Fatalf("expected installed=false id=0 on 403, got installed=%v id=%d", installed, id)
+	}
+}
+
 func TestCheckRepoInstallation_ServerError_ReturnsWrappedError(t *testing.T) {
 	f := &fakeClient{result: httpError(http.StatusInternalServerError)}
 	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
@@ -204,6 +233,32 @@ func TestCheckOrgInstallation_NotFound_ReturnsNotInstalled(t *testing.T) {
 	}
 	if installed {
 		t.Fatalf("expected installed=false on 404")
+	}
+}
+
+func TestCheckOrgInstallation_Unauthorized_ReturnsNotInstalled(t *testing.T) {
+	f := &fakeClient{result: httpError(http.StatusUnauthorized)}
+	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+
+	installed, id, err := c.CheckOrgInstallation(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("expected no error on 401, got: %v", err)
+	}
+	if installed || id != 0 {
+		t.Fatalf("expected installed=false id=0 on 401, got installed=%v id=%d", installed, id)
+	}
+}
+
+func TestCheckOrgInstallation_Forbidden_ReturnsNotInstalled(t *testing.T) {
+	f := &fakeClient{result: httpError(http.StatusForbidden)}
+	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+
+	installed, _, err := c.CheckOrgInstallation(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("expected no error on 403, got: %v", err)
+	}
+	if installed {
+		t.Fatalf("expected installed=false on 403")
 	}
 }
 

--- a/internal/githubapp/installation_test.go
+++ b/internal/githubapp/installation_test.go
@@ -58,9 +58,9 @@ func TestCheckRepoInstallation_MatchingApp_ReturnsInstalled(t *testing.T) {
 	f := &fakeClient{result: jsonResult(map[string]interface{}{
 		"id":       int64(12345),
 		"app_id":   int64(999),
-		"app_slug": "gh-agentic-app",
+		"app_slug": "gh-agentic",
 	})}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
 	if err != nil {
@@ -85,7 +85,7 @@ func TestCheckRepoInstallation_WrongApp_ReturnsNotInstalled(t *testing.T) {
 		"id":       int64(42),
 		"app_slug": "some-other-app",
 	})}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
 	if err != nil {
@@ -101,7 +101,7 @@ func TestCheckRepoInstallation_WrongApp_ReturnsNotInstalled(t *testing.T) {
 
 func TestCheckRepoInstallation_NotFound_ReturnsNotInstalled(t *testing.T) {
 	f := &fakeClient{result: httpError(http.StatusNotFound)}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
 	if err != nil {
@@ -120,7 +120,7 @@ func TestCheckRepoInstallation_Unauthorized_ReturnsNotInstalled(t *testing.T) {
 	// rejected. Treat as "cannot verify" — return not-installed with no error
 	// so the wizard can offer the install URL interactively.
 	f := &fakeClient{result: httpError(http.StatusUnauthorized)}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
 	if err != nil {
@@ -133,7 +133,7 @@ func TestCheckRepoInstallation_Unauthorized_ReturnsNotInstalled(t *testing.T) {
 
 func TestCheckRepoInstallation_Forbidden_ReturnsNotInstalled(t *testing.T) {
 	f := &fakeClient{result: httpError(http.StatusForbidden)}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
 	if err != nil {
@@ -146,7 +146,7 @@ func TestCheckRepoInstallation_Forbidden_ReturnsNotInstalled(t *testing.T) {
 
 func TestCheckRepoInstallation_ServerError_ReturnsWrappedError(t *testing.T) {
 	f := &fakeClient{result: httpError(http.StatusInternalServerError)}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, id, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
 	if err == nil {
@@ -170,7 +170,7 @@ func TestCheckRepoInstallation_ServerError_ReturnsWrappedError(t *testing.T) {
 func TestCheckRepoInstallation_NetworkError_Bubbles(t *testing.T) {
 	sentinel := errors.New("boom: no route to host")
 	f := &fakeClient{result: func(string, string, interface{}) error { return sentinel }}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	_, _, err := c.CheckRepoInstallation(context.Background(), "owner", "repo")
 	if err == nil {
@@ -182,7 +182,7 @@ func TestCheckRepoInstallation_NetworkError_Bubbles(t *testing.T) {
 }
 
 func TestCheckRepoInstallation_EmptyOwnerOrRepo_Error(t *testing.T) {
-	c := &Checker{Client: &fakeClient{}, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: &fakeClient{}, AppSlug: "gh-agentic"}
 	if _, _, err := c.CheckRepoInstallation(context.Background(), "", "repo"); err == nil {
 		t.Fatalf("expected error for empty owner")
 	}
@@ -194,9 +194,9 @@ func TestCheckRepoInstallation_EmptyOwnerOrRepo_Error(t *testing.T) {
 func TestCheckOrgInstallation_MatchingApp_ReturnsInstalled(t *testing.T) {
 	f := &fakeClient{result: jsonResult(map[string]interface{}{
 		"id":       int64(777),
-		"app_slug": "gh-agentic-app",
+		"app_slug": "gh-agentic",
 	})}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, id, err := c.CheckOrgInstallation(context.Background(), "acme")
 	if err != nil {
@@ -212,7 +212,7 @@ func TestCheckOrgInstallation_MatchingApp_ReturnsInstalled(t *testing.T) {
 
 func TestCheckOrgInstallation_WrongApp_ReturnsNotInstalled(t *testing.T) {
 	f := &fakeClient{result: jsonResult(map[string]interface{}{"id": int64(5), "app_slug": "other"})}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, _, err := c.CheckOrgInstallation(context.Background(), "acme")
 	if err != nil {
@@ -225,7 +225,7 @@ func TestCheckOrgInstallation_WrongApp_ReturnsNotInstalled(t *testing.T) {
 
 func TestCheckOrgInstallation_NotFound_ReturnsNotInstalled(t *testing.T) {
 	f := &fakeClient{result: httpError(http.StatusNotFound)}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, _, err := c.CheckOrgInstallation(context.Background(), "acme")
 	if err != nil {
@@ -238,7 +238,7 @@ func TestCheckOrgInstallation_NotFound_ReturnsNotInstalled(t *testing.T) {
 
 func TestCheckOrgInstallation_Unauthorized_ReturnsNotInstalled(t *testing.T) {
 	f := &fakeClient{result: httpError(http.StatusUnauthorized)}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, id, err := c.CheckOrgInstallation(context.Background(), "acme")
 	if err != nil {
@@ -251,7 +251,7 @@ func TestCheckOrgInstallation_Unauthorized_ReturnsNotInstalled(t *testing.T) {
 
 func TestCheckOrgInstallation_Forbidden_ReturnsNotInstalled(t *testing.T) {
 	f := &fakeClient{result: httpError(http.StatusForbidden)}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	installed, _, err := c.CheckOrgInstallation(context.Background(), "acme")
 	if err != nil {
@@ -264,7 +264,7 @@ func TestCheckOrgInstallation_Forbidden_ReturnsNotInstalled(t *testing.T) {
 
 func TestCheckOrgInstallation_ServerError_ReturnsWrappedError(t *testing.T) {
 	f := &fakeClient{result: httpError(http.StatusBadGateway)}
-	c := &Checker{Client: f, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: f, AppSlug: "gh-agentic"}
 
 	_, _, err := c.CheckOrgInstallation(context.Background(), "acme")
 	if err == nil {
@@ -276,7 +276,7 @@ func TestCheckOrgInstallation_ServerError_ReturnsWrappedError(t *testing.T) {
 }
 
 func TestCheckOrgInstallation_EmptyOrg_Error(t *testing.T) {
-	c := &Checker{Client: &fakeClient{}, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: &fakeClient{}, AppSlug: "gh-agentic"}
 	if _, _, err := c.CheckOrgInstallation(context.Background(), ""); err == nil {
 		t.Fatalf("expected error for empty org")
 	}
@@ -299,7 +299,7 @@ func TestCheck_EmptyAppSlug_AcceptsAnyInstalledApp(t *testing.T) {
 }
 
 func TestCheck_NilClient_ReturnsError(t *testing.T) {
-	c := &Checker{Client: nil, AppSlug: "gh-agentic-app"}
+	c := &Checker{Client: nil, AppSlug: "gh-agentic"}
 	if _, _, err := c.CheckRepoInstallation(context.Background(), "o", "r"); err == nil {
 		t.Fatalf("expected error when Client is nil")
 	}

--- a/internal/githubapp/installurl_test.go
+++ b/internal/githubapp/installurl_test.go
@@ -7,21 +7,21 @@ import (
 )
 
 func TestInstallURL_RepoTarget_HasCanonicalPrefix(t *testing.T) {
-	got := InstallURL("gh-agentic-app", TargetRepo, "owner/repo")
-	if !strings.HasPrefix(got, "https://github.com/apps/gh-agentic-app/installations/new") {
+	got := InstallURL("gh-agentic", TargetRepo, "owner/repo")
+	if !strings.HasPrefix(got, "https://github.com/apps/gh-agentic/installations/new") {
 		t.Fatalf("expected canonical prefix in %q", got)
 	}
 }
 
 func TestInstallURL_OrgTarget_HasCanonicalPrefix(t *testing.T) {
-	got := InstallURL("gh-agentic-app", TargetOrg, "acme")
-	if !strings.HasPrefix(got, "https://github.com/apps/gh-agentic-app/installations/new") {
+	got := InstallURL("gh-agentic", TargetOrg, "acme")
+	if !strings.HasPrefix(got, "https://github.com/apps/gh-agentic/installations/new") {
 		t.Fatalf("expected canonical prefix in %q", got)
 	}
 }
 
 func TestInstallURL_EncodesTargetNameInState(t *testing.T) {
-	got := InstallURL("gh-agentic-app", TargetRepo, "owner/repo")
+	got := InstallURL("gh-agentic", TargetRepo, "owner/repo")
 	u, err := url.Parse(got)
 	if err != nil {
 		t.Fatalf("could not parse URL %q: %v", got, err)
@@ -33,7 +33,7 @@ func TestInstallURL_EncodesTargetNameInState(t *testing.T) {
 }
 
 func TestInstallURL_OrgStatePrefix(t *testing.T) {
-	got := InstallURL("gh-agentic-app", TargetOrg, "acme")
+	got := InstallURL("gh-agentic", TargetOrg, "acme")
 	u, err := url.Parse(got)
 	if err != nil {
 		t.Fatalf("could not parse URL %q: %v", got, err)
@@ -44,8 +44,8 @@ func TestInstallURL_OrgStatePrefix(t *testing.T) {
 }
 
 func TestInstallURL_EmptyTargetName_NoStateParam(t *testing.T) {
-	got := InstallURL("gh-agentic-app", TargetRepo, "")
-	if got != "https://github.com/apps/gh-agentic-app/installations/new" {
+	got := InstallURL("gh-agentic", TargetRepo, "")
+	if got != "https://github.com/apps/gh-agentic/installations/new" {
 		t.Fatalf("expected bare URL without query, got %q", got)
 	}
 }

--- a/internal/init/form.go
+++ b/internal/init/form.go
@@ -260,7 +260,13 @@ func collectPipelineConfig(cfg *InitConfig, runForm FormRunFunc) error {
 	return nil
 }
 
-// collectCredentialsAndProject collects the PROJECT_PAT and Claude credentials.
+// collectCredentialsAndProject collects the PROJECT_PAT.
+// Claude credentials are no longer prompted here — they are read automatically
+// from the local machine (~/.claude/.credentials.json or macOS Keychain) after
+// init completes, using the same mechanism as 'gh agentic auth refresh'. If
+// credentials are not found locally, the user is prompted to run
+// 'gh agentic auth refresh' manually.
+//
 // The AGENTIC_PROJECT_ID is never prompted here — for single topology it is
 // created automatically by project.Create; for federated topology it is
 // selected from the project list by the CLI before CollectConfigInteractive
@@ -272,11 +278,6 @@ func collectCredentialsAndProject(cfg *InitConfig, runForm FormRunFunc) error {
 				Title("PROJECT_PAT").
 				Description("Personal Access Token for Projects v2 mutations (scopes: repo, project, read:org)").
 				Value(&cfg.GooseAgentPAT).
-				EchoMode(huh.EchoModePassword),
-			huh.NewInput().
-				Title("Claude credentials JSON").
-				Description("Base64-encoded Claude credentials (leave empty to skip)").
-				Value(&cfg.ClaudeCreds).
 				EchoMode(huh.EchoModePassword),
 		),
 	)

--- a/internal/init/form_test.go
+++ b/internal/init/form_test.go
@@ -48,10 +48,8 @@ func TestCollectConfigInteractive_Success(t *testing.T) {
 				cfg.RunnerLabel = "ubuntu-latest"
 				cfg.AgentProvider = "claude-code"
 				cfg.AgentModel = "default"
-			case 3: // Phase 4: credentials + project
+			case 3: // Phase 4: credentials (PAT only — Claude creds are auto-read from local machine)
 				cfg.GooseAgentPAT = "ghp_test123"
-				cfg.ClaudeCreds = "base64creds"
-				cfg.ProjectID = "PVT_123"
 			}
 			return nil
 		},

--- a/internal/init/runner.go
+++ b/internal/init/runner.go
@@ -18,10 +18,9 @@ const (
 	// stays "claude-code" — this is the identifier the Goose CLI recognises
 	// for the Claude Code provider; only the constant name changes.
 	DefaultAgentProvider = "claude-code"
-	// DefaultAgentModel is the default agent model override. The value
-	// stays "default" — it is the literal Goose CLI sentinel meaning
-	// "use the provider default"; only the constant name changes.
-	DefaultAgentModel = "default"
+	// DefaultAgentModel is the default agent model. Uses claude-sonnet-4.6 as
+	// the canonical model for the agentic pipeline.
+	DefaultAgentModel = "claude-sonnet-4.6"
 )
 
 // RunnerDefaultForTopology returns the smart default runner label based on topology.


### PR DESCRIPTION
## Summary

- Removes the 'Claude credentials JSON' prompt from `gh agentic init` — credentials are now read automatically from the local machine (~/.claude/.credentials.json or macOS Keychain) after init completes, using the same path as `gh agentic auth refresh`. If credentials are not found, the user is guided to run `gh agentic auth refresh` manually.
- Fixes `DefaultAppSlug` from `"gh-agentic-app"` to `"gh-agentic"` (the correct GitHub App slug) across all source and test files.
- Fixes `DefaultAgentModel` from `"default"` to `"claude-sonnet-4.6"` as the canonical model for the agentic pipeline.

## Test plan

- [ ] `go test ./internal/githubapp/... ./internal/init/... ./internal/cli/...` passes
- [ ] `gh agentic init` no longer prompts for Claude credentials
- [ ] After init, CLAUDE_CREDENTIALS_JSON is set if local credentials exist
- [ ] After init, a warning is shown if local credentials are not found
- [ ] App install URL uses `apps/gh-agentic` (not `apps/gh-agentic-app`)
- [ ] New repos get `claude-sonnet-4.6` as the default model

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)