### PR TITLE
feat(init): prompt for GitHub App client ID and private key PEM during init

### DIFF
--- a/internal/init/form.go
+++ b/internal/init/form.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -24,12 +25,19 @@ var DefaultFormRun FormRunFunc = func(f *huh.Form) error { return f.Run() }
 // DetectOwnerTypeFunc detects whether a GitHub owner is a personal account or an organisation.
 type DetectOwnerTypeFunc func(owner string) (string, error)
 
+// ReadFileFunc reads the contents of a file at the given path. Injected via
+// FormDeps so tests can supply a fake without touching the filesystem.
+type ReadFileFunc func(path string) ([]byte, error)
+
 // FormDeps holds injectable dependencies for the interactive form.
 type FormDeps struct {
 	RunForm         FormRunFunc
 	RunCommand      RunCommandFunc
 	DetectOwnerType DetectOwnerTypeFunc
 	FetchReleases   mount.FetchReleasesFunc
+	// ReadFile reads a file from disk. Defaults to os.ReadFile when nil.
+	// Injected by tests to avoid real filesystem access.
+	ReadFile ReadFileFunc
 	// Topology, when non-empty, pre-seeds cfg.Topology and suppresses the
 	// topology select in collectVersionTopology. The CLI captures topology
 	// first (single vs. federated routing decision) and passes it here so
@@ -123,6 +131,15 @@ func CollectConfigInteractive(w io.Writer, repoFullName string, deps FormDeps) (
 
 	// --- Phase 4: Credentials and Project ---
 	if err := collectCredentialsAndProject(cfg, deps.RunForm); err != nil {
+		return nil, err
+	}
+
+	// --- Phase 5: GitHub App credentials ---
+	readFile := deps.ReadFile
+	if readFile == nil {
+		readFile = func(path string) ([]byte, error) { return os.ReadFile(path) }
+	}
+	if err := collectAppCredentials(cfg, w, deps.RunForm, readFile); err != nil {
 		return nil, err
 	}
 
@@ -284,6 +301,43 @@ func collectCredentialsAndProject(cfg *InitConfig, runForm FormRunFunc) error {
 	if err := runForm(form); err != nil {
 		return fmt.Errorf("credentials form: %w", err)
 	}
+	return nil
+}
+
+// collectAppCredentials collects the GitHub App Client ID and the path to the
+// App's private key PEM file. The Client ID is stored as AGENTIC_APP_CLIENT_ID
+// (a non-sensitive variable); the PEM content is stored as AGENTIC_APP_PRIVATE_KEY
+// (a secret). Both are required by the agentic pipeline workflows to mint
+// short-lived installation tokens via actions/create-github-app-token.
+//
+// The Client ID (e.g. "Iv23li8K3O...") is found on the App settings page at
+// github.com/settings/apps/gh-agentic → "About → Client ID". The private key
+// PEM is downloaded from the same page → "Private keys → Generate a private key".
+func collectAppCredentials(cfg *InitConfig, w io.Writer, runForm FormRunFunc, readFile ReadFileFunc) error {
+	var pemPath string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("GitHub App Client ID").
+				Description("Found at github.com/settings/apps/gh-agentic — 'About → Client ID' (e.g. Iv23li8K3O...)").
+				Value(&cfg.AppClientID).
+				Validate(validateRequired("App Client ID")),
+			huh.NewInput().
+				Title("Private key PEM file path").
+				Description("Path to the .pem file downloaded from the App settings page → 'Private keys'").
+				Value(&pemPath).
+				Validate(validateRequired("private key path")),
+		),
+	)
+	if err := runForm(form); err != nil {
+		return fmt.Errorf("App credentials form: %w", err)
+	}
+	data, err := readFile(pemPath)
+	if err != nil {
+		return fmt.Errorf("reading private key from %q: %w", pemPath, err)
+	}
+	cfg.AppPrivateKey = string(data)
+	fmt.Fprintf(w, "  %s Private key loaded from %s\n", ui.SymbolInfo, pemPath)
 	return nil
 }
 

--- a/internal/init/form_test.go
+++ b/internal/init/form_test.go
@@ -26,6 +26,15 @@ func fakeFormRun(callCount *int, setValues func(callIndex int)) FormRunFunc {
 	}
 }
 
+// fakeReadFile returns a ReadFileFunc that serves a canned PEM regardless of
+// path. Tests use this to avoid real filesystem access in the App credentials
+// phase.
+func fakeReadFile() ReadFileFunc {
+	return func(_ string) ([]byte, error) {
+		return []byte("-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"), nil
+	}
+}
+
 func TestCollectConfigInteractive_Success(t *testing.T) {
 	var buf bytes.Buffer
 	callCount := 0
@@ -50,6 +59,8 @@ func TestCollectConfigInteractive_Success(t *testing.T) {
 				cfg.AgentModel = "default"
 			case 3: // Phase 4: credentials (PAT only — Claude creds are auto-read from local machine)
 				cfg.GooseAgentPAT = "ghp_test123"
+			case 4: // Phase 5: GitHub App credentials
+				cfg.AppClientID = "Iv1.test123"
 			}
 			return nil
 		},
@@ -62,6 +73,7 @@ func TestCollectConfigInteractive_Success(t *testing.T) {
 		DetectOwnerType: func(owner string) (string, error) {
 			return auth.OwnerTypeUser, nil
 		},
+		ReadFile: fakeReadFile(),
 	}
 
 	result, err := CollectConfigInteractive(&buf, "", deps)
@@ -83,6 +95,10 @@ func TestCollectConfigInteractive_Success(t *testing.T) {
 	}
 	if result.OwnerType != auth.OwnerTypeUser {
 		t.Errorf("expected OwnerType %q, got %q", auth.OwnerTypeUser, result.OwnerType)
+	}
+	// AppPrivateKey is set by readFile (code path, not form binding) — verify it.
+	if !strings.Contains(result.AppPrivateKey, "BEGIN RSA PRIVATE KEY") {
+		t.Errorf("expected AppPrivateKey to contain PEM content, got %q", result.AppPrivateKey)
 	}
 
 	output := buf.String()
@@ -112,12 +128,15 @@ func TestCollectConfigInteractive_WithExplicitRepo(t *testing.T) {
 				// defaults
 			case 3:
 				// empty creds
+			case 4:
+				cfg.AppClientID = "Iv1.test"
 			}
 			return nil
 		},
 		DetectOwnerType: func(owner string) (string, error) {
 			return auth.OwnerTypeOrg, nil
 		},
+		ReadFile: fakeReadFile(),
 	}
 
 	result, err := CollectConfigInteractive(&buf, "acme/my-repo", deps)
@@ -158,12 +177,15 @@ func TestCollectConfigInteractive_OrgSetsAgentUserScope(t *testing.T) {
 				// pipeline defaults
 			case 3:
 				// empty creds
+			case 4:
+				cfg.AppClientID = "Iv1.test"
 			}
 			return nil
 		},
 		DetectOwnerType: func(owner string) (string, error) {
 			return auth.OwnerTypeOrg, nil
 		},
+		ReadFile: fakeReadFile(),
 	}
 
 	result, err := CollectConfigInteractive(&buf, "acme/repo", deps)
@@ -195,12 +217,15 @@ func TestCollectConfigInteractive_SetsAppBotAsAgentUser(t *testing.T) {
 				// pipeline defaults
 			case 4:
 				// creds
+			case 5:
+				cfg.AppClientID = "Iv1.test"
 			}
 			return nil
 		},
 		DetectOwnerType: func(owner string) (string, error) {
 			return auth.OwnerTypeUser, nil
 		},
+		ReadFile: fakeReadFile(),
 	}
 
 	result, err := CollectConfigInteractive(&buf, "alice/repo", deps)
@@ -237,12 +262,15 @@ func TestCollectConfigInteractive_NoRepoContext(t *testing.T) {
 				// pipeline defaults
 			case 4:
 				// creds
+			case 5:
+				cfg.AppClientID = "Iv1.test"
 			}
 			return nil
 		},
 		RunCommand: func(name string, args ...string) (string, error) {
 			return "", fmt.Errorf("no remote")
 		},
+		ReadFile: fakeReadFile(),
 	}
 
 	result, err := CollectConfigInteractive(&buf, "", deps)
@@ -296,12 +324,15 @@ func TestCollectConfigInteractive_PipelineDefaults(t *testing.T) {
 				// Don't set — verify defaults are pre-filled
 			case 4:
 				// creds
+			case 5:
+				cfg.AppClientID = "Iv1.test"
 			}
 			return nil
 		},
 		DetectOwnerType: func(owner string) (string, error) {
 			return auth.OwnerTypeUser, nil
 		},
+		ReadFile: fakeReadFile(),
 	}
 
 	result, err := CollectConfigInteractive(&buf, "owner/repo", deps)
@@ -317,6 +348,118 @@ func TestCollectConfigInteractive_PipelineDefaults(t *testing.T) {
 	}
 	if result.AgentModel != DefaultAgentModel {
 		t.Errorf("expected default model %q, got %q", DefaultAgentModel, result.AgentModel)
+	}
+}
+
+func TestCollectConfigInteractive_AppCredentials(t *testing.T) {
+	// Verifies that Phase 5 populates AppPrivateKey via the ReadFile code
+	// path. AppClientID is form-bound (set by huh at runtime) so it stays
+	// empty under the fake RunForm — that binding is not re-tested here.
+	var buf bytes.Buffer
+	callCount := 0
+	cfg := &InitConfig{}
+
+	fakePEM := "-----BEGIN RSA PRIVATE KEY-----\nMIItest\n-----END RSA PRIVATE KEY-----\n"
+
+	deps := FormDeps{
+		RunForm: func(f *huh.Form) error {
+			callCount++
+			switch callCount {
+			case 1:
+				cfg.Version = "v2.0.0"
+				cfg.Topology = "Single"
+			case 2:
+				cfg.Stacks = []string{"Go"}
+			case 3:
+				// pipeline defaults
+			case 4:
+				// creds
+			case 5:
+				// App credentials — form binding not triggered by fake RunForm
+			}
+			return nil
+		},
+		DetectOwnerType: func(owner string) (string, error) { return auth.OwnerTypeUser, nil },
+		ReadFile: func(_ string) ([]byte, error) {
+			return []byte(fakePEM), nil
+		},
+	}
+
+	result, err := CollectConfigInteractive(&buf, "owner/repo", deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// AppPrivateKey is populated by the readFile code path — verifiable.
+	if result.AppPrivateKey != fakePEM {
+		t.Errorf("AppPrivateKey = %q, want fake PEM", result.AppPrivateKey)
+	}
+}
+
+func TestCollectAppCredentials_Direct(t *testing.T) {
+	// Unit test for collectAppCredentials: verifies AppClientID is captured
+	// from form binding and AppPrivateKey is read from the injected ReadFile.
+	// We simulate huh form binding by directly setting cfg.AppClientID in
+	// the RunForm callback (mimicking what huh would do when Value() binding
+	// fires on f.Run()).
+	var buf bytes.Buffer
+	fakePEM := "-----BEGIN RSA PRIVATE KEY-----\nMIItest\n-----END RSA PRIVATE KEY-----\n"
+
+	cfg := &InitConfig{}
+	runForm := func(f *huh.Form) error {
+		// Simulate huh binding the form-bound AppClientID field.
+		cfg.AppClientID = "Iv23liABCDEF"
+		return nil
+	}
+	readFile := func(_ string) ([]byte, error) { return []byte(fakePEM), nil }
+
+	if err := collectAppCredentials(cfg, &buf, runForm, readFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AppClientID != "Iv23liABCDEF" {
+		t.Errorf("AppClientID = %q, want 'Iv23liABCDEF'", cfg.AppClientID)
+	}
+	if cfg.AppPrivateKey != fakePEM {
+		t.Errorf("AppPrivateKey = %q, want fake PEM", cfg.AppPrivateKey)
+	}
+}
+
+func TestCollectConfigInteractive_AppCredentials_ReadFileError(t *testing.T) {
+	// When ReadFile fails (e.g. bad path), CollectConfigInteractive must
+	// return an error.
+	var buf bytes.Buffer
+	callCount := 0
+	cfg := &InitConfig{}
+
+	deps := FormDeps{
+		RunForm: func(f *huh.Form) error {
+			callCount++
+			switch callCount {
+			case 1:
+				cfg.Version = "v2.0.0"
+				cfg.Topology = "Single"
+			case 2:
+				cfg.Stacks = []string{"Go"}
+			case 3:
+				// pipeline defaults
+			case 4:
+				// creds
+			case 5:
+				cfg.AppClientID = "Iv1.test"
+			}
+			return nil
+		},
+		DetectOwnerType: func(owner string) (string, error) { return auth.OwnerTypeUser, nil },
+		ReadFile: func(path string) ([]byte, error) {
+			return nil, fmt.Errorf("no such file: %s", path)
+		},
+	}
+
+	_, err := CollectConfigInteractive(&buf, "owner/repo", deps)
+	if err == nil {
+		t.Fatal("expected error when ReadFile fails")
+	}
+	if !strings.Contains(err.Error(), "reading private key") {
+		t.Errorf("expected 'reading private key' in error, got: %v", err)
 	}
 }
 
@@ -463,12 +606,15 @@ func TestCollectConfigInteractive_OwnerTypeDetectionFailure(t *testing.T) {
 				// defaults
 			case 4:
 				// creds
+			case 5:
+				cfg.AppClientID = "Iv1.test"
 			}
 			return nil
 		},
 		DetectOwnerType: func(owner string) (string, error) {
 			return "", fmt.Errorf("API error")
 		},
+		ReadFile: fakeReadFile(),
 	}
 
 	result, err := CollectConfigInteractive(&buf, "owner/repo", deps)

--- a/internal/init/wizard.go
+++ b/internal/init/wizard.go
@@ -39,6 +39,14 @@ type InitConfig struct {
 	Owner          string
 	RepoName       string
 	OwnerType      string
+	// AppClientID is the GitHub App client ID, set as AGENTIC_APP_CLIENT_ID.
+	// Collected during init and required by the pipeline to authenticate as
+	// the GitHub App.
+	AppClientID string
+	// AppPrivateKey is the PEM content of the GitHub App's private key, set
+	// as the AGENTIC_APP_PRIVATE_KEY secret. The wizard reads this from the
+	// .pem file path the user supplies.
+	AppPrivateKey string
 	// Confirm optionally gates the federated-visibility confirmation in
 	// ConfigureRepo. When set and topology is any federated variant,
 	// ConfigureRepo emits the org-visibility note and calls Confirm before
@@ -180,10 +188,11 @@ func ConfigureRepo(w io.Writer, cfg *InitConfig, run RunCommandFunc) error {
 
 	// Set variables.
 	variables := map[string]string{
-		"AGENT_USER":     cfg.AgentUser,
-		"RUNNER_LABEL":   cfg.RunnerLabel,
-		"AGENT_PROVIDER": cfg.AgentProvider,
-		"AGENT_MODEL":    cfg.AgentModel,
+		"AGENT_USER":            cfg.AgentUser,
+		"RUNNER_LABEL":          cfg.RunnerLabel,
+		"AGENT_PROVIDER":        cfg.AgentProvider,
+		"AGENT_MODEL":           cfg.AgentModel,
+		"AGENTIC_APP_CLIENT_ID": cfg.AppClientID,
 	}
 
 	for name, value := range variables {
@@ -198,6 +207,14 @@ func ConfigureRepo(w io.Writer, cfg *InitConfig, run RunCommandFunc) error {
 	}
 
 	// Set secrets.
+	if cfg.AppPrivateKey != "" {
+		flag, target := scope.ScopeFor("AGENTIC_APP_PRIVATE_KEY", topology, owner, repo)
+		if _, err := run("gh", "secret", "set", "AGENTIC_APP_PRIVATE_KEY", "--body", cfg.AppPrivateKey, flag, target); err != nil {
+			return fmt.Errorf("setting AGENTIC_APP_PRIVATE_KEY: %w", err)
+		}
+		fmt.Fprintf(w, "  ✓ AGENTIC_APP_PRIVATE_KEY saved as %s\n", describeScope(flag, "secret"))
+	}
+
 	if cfg.GooseAgentPAT != "" {
 		flag, target := scope.ScopeFor("PROJECT_PAT", topology, owner, repo)
 		if _, err := run("gh", "secret", "set", "PROJECT_PAT", "--body", cfg.GooseAgentPAT, flag, target); err != nil {

--- a/internal/init/wizard_test.go
+++ b/internal/init/wizard_test.go
@@ -60,6 +60,8 @@ func TestRun_Success(t *testing.T) {
 		RepoFullName:  "owner/repo",
 		Owner:         "owner",
 		RepoName:      "repo",
+		AppClientID:   "Iv1.testclientid",
+		AppPrivateKey: "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n",
 	}
 
 	deps := Deps{
@@ -205,6 +207,8 @@ func TestConfigureRepo_SetsVariables(t *testing.T) {
 		GooseAgentPAT: "ghp_test",
 		ClaudeCreds:   "creds",
 		ProjectID:     "PVT_123",
+		AppClientID:   "Iv1.testclientid",
+		AppPrivateKey: "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n",
 	}
 
 	run := func(name string, args ...string) (string, error) {
@@ -234,7 +238,19 @@ func TestConfigureRepo_SetsVariables(t *testing.T) {
 		}
 	}
 
-	for _, expected := range []string{"AGENT_USER", "PROJECT_PAT", "CLAUDE_CREDENTIALS_JSON", "AGENTIC_PROJECT_ID"} {
+	for _, cmd := range commands {
+		if strings.Contains(cmd, "AGENTIC_APP_CLIENT_ID") {
+			found["AGENTIC_APP_CLIENT_ID"] = true
+		}
+		if strings.Contains(cmd, "AGENTIC_APP_PRIVATE_KEY") {
+			found["AGENTIC_APP_PRIVATE_KEY"] = true
+		}
+	}
+
+	for _, expected := range []string{
+		"AGENT_USER", "PROJECT_PAT", "CLAUDE_CREDENTIALS_JSON", "AGENTIC_PROJECT_ID",
+		"AGENTIC_APP_CLIENT_ID", "AGENTIC_APP_PRIVATE_KEY",
+	} {
 		if !found[expected] {
 			t.Errorf("expected %s to be configured", expected)
 		}


### PR DESCRIPTION
## Summary

- Adds Phase 5 to `CollectConfigInteractive`: prompts for the GitHub App Client ID and the path to the downloaded private key PEM file
- `ConfigureRepo` now writes `AGENTIC_APP_CLIENT_ID` as a repo/org variable and `AGENTIC_APP_PRIVATE_KEY` as a repo/org secret, both routed through `scope.ScopeFor` (org scope under federated topology)
- `FormDeps` gains a `ReadFile` injectable so tests can supply a fake without touching the filesystem

## Why the client ID must be prompted

`/apps/{slug}` returns 404 for private apps. `/user/installations` requires a GitHub App OAuth token (not the standard `gh` PAT) and returns 403 with normal credentials. The client ID is only available from the App settings page, so the user must supply it.

## Test plan

- [x] `TestCollectConfigInteractive_AppCredentials` — verifies `AppPrivateKey` set via injected `ReadFile`
- [x] `TestCollectAppCredentials_Direct` — directly exercises `collectAppCredentials`, simulates huh binding for `AppClientID`
- [x] `TestCollectConfigInteractive_AppCredentials_ReadFileError` — verifies error propagation when `ReadFile` fails
- [x] `TestConfigureRepo_SetsVariables` — asserts `AGENTIC_APP_CLIENT_ID` variable and `AGENTIC_APP_PRIVATE_KEY` secret are set
- [x] All existing tests pass

Closes #737

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)