### PR TITLE
fix(workflow): correct issue-session branch pattern and PR token

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -706,7 +706,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BRANCH=$(git branch --show-current)
-          if [[ "${BRANCH}" == fix/issue-* ]]; then
+          if [[ "${BRANCH}" == issue/* ]]; then
             git push origin ${BRANCH}
           else
             echo "No fix branch — question answered or issue skipped"
@@ -715,10 +715,13 @@ jobs:
       - name: Open PR
         if: success()
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Must use PROJECT_PAT (not github.token) so the pull_request event
+          # fires and triggers pr-review-session; github.token events cannot
+          # trigger other workflow runs (GitHub platform restriction).
+          GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
           BRANCH=$(git branch --show-current)
-          if [[ "${BRANCH}" == fix/issue-* ]]; then
+          if [[ "${BRANCH}" == issue/* ]]; then
             ISSUE_TITLE=$(gh issue view ${{ github.event.issue.number }} \
               --repo ${{ github.repository }} --json title --jq '.title')
             BODY=$(printf "Fixes #%s\n\n🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)" "${{ github.event.issue.number }}")


### PR DESCRIPTION
## Summary

Two bugs found during live end-to-end workflow test on issue #686:

**Bug 1 — Wrong branch pattern**
Both "Push fix branch" and "Open PR" steps checked for `fix/issue-*` but the issue-session recipe creates branches named `issue/N-description`. Both steps silently skipped — the branch was pushed by the recipe itself and the PR was never created by the workflow. Fixed to `issue/*`.

**Bug 2 — Open PR using github.token**
`github.token` events cannot trigger other GitHub Actions workflow runs. Changed "Open PR" to use `PROJECT_PAT` so the `pull_request` event fires correctly and can trigger pr-review-session.

## Found by

Live test run #25437514623 on issue #686 — workflow succeeded but left a manual PR link in the issue comment instead of opening the PR automatically.

## Test plan

- [ ] Re-trigger issue-session on #686 (or new issue) — verify branch is pushed and PR opened automatically

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)