### PR TITLE
fix(workflow): use PROJECT_PAT for Setup Agent Auth credential rotation

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -133,7 +133,7 @@ jobs:
           agent-provider: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
-          gh-token: ${{ github.token }}
+          gh-token: ${{ secrets.PROJECT_PAT }}
 
       - name: Configure Goose
         run: |
@@ -398,7 +398,7 @@ jobs:
           agent-provider: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
-          gh-token: ${{ github.token }}
+          gh-token: ${{ secrets.PROJECT_PAT }}
 
       - name: Rebase feature branch onto main
         run: |
@@ -581,7 +581,7 @@ jobs:
           agent-provider: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
-          gh-token: ${{ github.token }}
+          gh-token: ${{ secrets.PROJECT_PAT }}
 
       - name: Configure Goose
         run: |
@@ -677,7 +677,7 @@ jobs:
           agent-provider: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
-          gh-token: ${{ github.token }}
+          gh-token: ${{ secrets.PROJECT_PAT }}
 
       - name: Configure Goose
         run: |


### PR DESCRIPTION
## Summary

The `setup-agent-auth` action writes a rotated `CLAUDE_CREDENTIALS_JSON` secret back to the repo when Claude refreshes its credentials. The GitHub Secrets API requires `repo` scope — `github.token` only has the permissions listed in the job's `permissions:` block, which does not include secrets write access.

**Failure observed in run #25472307890:**
```
failed to fetch public key: HTTP 403: Resource not accessible by integration
```

Fixed by passing `PROJECT_PAT` (which has `repo` scope) as `gh-token` to the `Setup Agent Auth` step in all four jobs. The `Install tools` step immediately before it is unchanged — downloading tools does not need secrets access.

## Test plan

- [ ] Re-trigger issue-session on #686 — verify Setup Agent Auth step succeeds without 403

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)