### PR TITLE
fix: use PIPELINE_PAT for dev-session branch push

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -450,9 +450,15 @@ jobs:
 
       - name: Push branch
         if: success()
-        run: git push origin ${{ steps.branch.outputs.name }}
+        run: |
+          # github.token (GitHub App) cannot push .github/workflows/ changes.
+          # Reconfigure the remote to use PIPELINE_PAT, which has the workflows
+          # permission, so commits touching agentic-pipeline.yml are accepted.
+          git remote set-url origin "https://x-access-token:${PIPELINE_PAT}@github.com/${{ github.repository }}.git"
+          git push origin ${{ steps.branch.outputs.name }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          PIPELINE_PAT: ${{ secrets.PIPELINE_PAT }}
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
 
       - name: Open PR
         if: success()


### PR DESCRIPTION
## Summary

- The dev-session **Push branch** step was using `github.token` (GitHub App installation token) for `git push`
- GitHub App tokens cannot push changes to `.github/workflows/` files — this is a platform-level restriction, independent of PAT scopes
- Feature #746's dev-session writes to `agentic-pipeline.yml` (Tasks 3 & 4), causing the push to be rejected on every attempt
- Fix: reconfigure the git remote to use `PIPELINE_PAT` (fine-grained PAT with `workflows` read/write) before pushing

## Test plan

- [ ] Merge this PR to main
- [ ] Re-run the failed dev-session workflow run for #746 (`gh run rerun 25498441491 --repo eddiecarpenter/gh-agentic --failed`)
- [ ] Confirm "Push branch" step succeeds

Closes #746 blocker

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)