### PR TITLE
fix: unset actions/checkout credential helper before PAT push

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -416,6 +416,7 @@ jobs:
             git rebase --abort
             exit 1
           }
+          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${PIPELINE_PAT}@github.com/${{ github.repository }}.git"
           git push origin HEAD:${{ steps.branch.outputs.name }} --force-with-lease
         env:
@@ -457,9 +458,9 @@ jobs:
       - name: Push branch
         if: success()
         run: |
-          # github.token (GitHub App) cannot push .github/workflows/ changes.
-          # Reconfigure the remote to use PIPELINE_PAT, which has the workflows
-          # permission, so commits touching agentic-pipeline.yml are accepted.
+          # actions/checkout injects github.token via http.extraheader — unset it
+          # so the PIPELINE_PAT embedded in the remote URL is used instead.
+          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${PIPELINE_PAT}@github.com/${{ github.repository }}.git"
           git push origin ${{ steps.branch.outputs.name }}
         env:


### PR DESCRIPTION
## Summary

- `actions/checkout` injects `github.token` via `http.https://github.com/.extraheader`, which silently overrides any token embedded in a remote URL
- Both the rebase force-push and post-recipe push branch steps were setting the remote URL with `PIPELINE_PAT` but git was still authenticating as the GitHub App installation token, hence the "refusing to allow a GitHub App" rejection
- Fix: call `git config --unset-all http.https://github.com/.extraheader || true` before the remote set-url in both steps

## Test plan
- [ ] Merge and trigger dev-session for #746 — Push branch step should succeed with the PAT's `workflow` scope

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)