### PR TITLE
fix: use PIPELINE_PAT for Open PR step

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -416,6 +416,7 @@ jobs:
             git rebase --abort
             exit 1
           }
+          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${PIPELINE_PAT}@github.com/${{ github.repository }}.git"
           git push origin HEAD:${{ steps.branch.outputs.name }} --force-with-lease
         env:
@@ -457,9 +458,9 @@ jobs:
       - name: Push branch
         if: success()
         run: |
-          # github.token (GitHub App) cannot push .github/workflows/ changes.
-          # Reconfigure the remote to use PIPELINE_PAT, which has the workflows
-          # permission, so commits touching agentic-pipeline.yml are accepted.
+          # actions/checkout injects github.token via http.extraheader — unset it
+          # so the PIPELINE_PAT embedded in the remote URL is used instead.
+          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${PIPELINE_PAT}@github.com/${{ github.repository }}.git"
           git push origin ${{ steps.branch.outputs.name }}
         env:

--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -470,7 +470,9 @@ jobs:
       - name: Open PR
         if: success()
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Must use PIPELINE_PAT — github.token cannot create PRs when the
+          # "Allow GitHub Actions to create pull requests" repo setting is off.
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |


### PR DESCRIPTION
## Summary

- `github.token` cannot create PRs when the repo's "Allow GitHub Actions to create and approve pull requests" setting is disabled
- Switch `Open PR` step to use `PIPELINE_PAT`, consistent with all other elevated-permission steps in the dev-session job
- Also carries the previous fix: unset `actions/checkout` credential helper before PAT push (extraheader fix)

## Test plan
- [ ] Merge and trigger dev-session for #746 — Open PR step should succeed

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)