### PR TITLE
fix: use --global when unsetting actions/checkout extraheader

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -416,7 +416,7 @@ jobs:
             git rebase --abort
             exit 1
           }
-          git config --unset-all http.https://github.com/.extraheader || true
+          git config --global --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${PIPELINE_PAT}@github.com/${{ github.repository }}.git"
           git push origin HEAD:${{ steps.branch.outputs.name }} --force-with-lease
         env:
@@ -460,7 +460,7 @@ jobs:
         run: |
           # actions/checkout injects github.token via http.extraheader — unset it
           # so the PIPELINE_PAT embedded in the remote URL is used instead.
-          git config --unset-all http.https://github.com/.extraheader || true
+          git config --global --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${PIPELINE_PAT}@github.com/${{ github.repository }}.git"
           git push origin ${{ steps.branch.outputs.name }}
         env:


### PR DESCRIPTION
## Summary

- `actions/checkout` sets the credential via `git config --global "http.https://github.com/.extraheader"`, not at local scope
- The previous fix called `git config --unset-all` without `--global`, leaving the global credential in place — it was still overriding the PIPELINE_PAT embedded in the remote URL
- Fix: add `--global` to both unset calls (rebase step and push branch step)

## Test plan
- [ ] Merge and trigger dev-session for #746 Tasks 3 & 4 — Push branch should succeed

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)