### PR TITLE
fix: use PIPELINE_PAT in feature-design recipe step

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -158,7 +158,10 @@ jobs:
           GOOSE_MODEL: ${{ vars.AGENT_MODEL || 'default' }}
           GOOSE_MODE: auto
           GOOSE_DISABLE_SESSION_NAMING: "true"
-          GH_TOKEN: ${{ github.token }}
+          # Must use PIPELINE_PAT so the in-development label event triggers
+          # the dev-session workflow; github.token events cannot trigger
+          # other workflow runs (GitHub platform restriction).
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
 
       # Structural enforcement of the Design Plan publication contract
       # introduced by #652 (under #632). The skill (feature-design.md)


### PR DESCRIPTION
## Summary

- The feature-design recipe applies `in-development` at the end of the design phase to trigger the dev-session
- The "Run feature-design recipe" step was using `github.token` as `GH_TOKEN`, so the resulting label event was invisible to the workflow engine — dev-session never fired
- Fix: switch to `PIPELINE_PAT`, consistent with all other trigger-label steps in the workflow

## Test plan
- [ ] Merge, then re-trigger design on a feature — dev-session should fire automatically after design completes

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)