### PR TITLE
fix: remove Bot author filter from Design Plan verification

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -184,13 +184,15 @@ jobs:
           ISSUE: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Look for at least one comment on the Feature issue authored
-          # by the agentic bot whose body begins with the canonical
-          # Design Plan marker. feature-design and dev-session both key
-          # off this marker (`<!-- design-plan:v1 -->`); the workflow
-          # verifies the same contract so the three signals agree.
+          # Look for at least one comment on the Feature issue whose body
+          # begins with the canonical Design Plan marker. feature-design
+          # and dev-session both key off this marker
+          # (`<!-- design-plan:v1 -->`); the workflow verifies the same
+          # contract so the three signals agree. Author type is not
+          # checked — the recipe may post as a Bot (App token) or as a
+          # human user (PIPELINE_PAT), depending on config.
           COMMENT_COUNT=$(gh api "repos/${REPO}/issues/${ISSUE}/comments" \
-            --jq '[.[] | select(.user.type == "Bot") | select(.body | startswith("<!-- design-plan:v1 -->"))] | length')
+            --jq '[.[] | select(.body | startswith("<!-- design-plan:v1 -->"))] | length')
           if [ "${COMMENT_COUNT}" -lt 1 ]; then
             echo "::error::Design Plan comment was not published on issue #${ISSUE} by the feature-design recipe."
             echo ""

--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -158,7 +158,10 @@ jobs:
           GOOSE_MODEL: ${{ vars.AGENT_MODEL || 'default' }}
           GOOSE_MODE: auto
           GOOSE_DISABLE_SESSION_NAMING: "true"
-          GH_TOKEN: ${{ github.token }}
+          # Must use PIPELINE_PAT so the in-development label event triggers
+          # the dev-session workflow; github.token events cannot trigger
+          # other workflow runs (GitHub platform restriction).
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
 
       # Structural enforcement of the Design Plan publication contract
       # introduced by #652 (under #632). The skill (feature-design.md)


### PR DESCRIPTION
## Summary

- Removes `.user.type == "Bot"` filter from the **Verify Design Plan comment** step in the feature-design job
- The marker `<!-- design-plan:v1 -->` is the authoritative signal — author type should not matter
- Root cause: PR #764 switched the feature-design recipe step to `PIPELINE_PAT`; comments are now posted by the human account (type `"User"`), not a Bot, so the old filter returned 0 and failed the run
- Updates the inline comment to document why author type is intentionally unchecked

## Test plan

- [ ] Trigger feature #748 design phase — "Verify Design Plan comment was published" step should pass
- [ ] Confirm the Design Plan comment on #748 (already present, authored by `eddiecarpenter`) is detected

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)