### PR TITLE
feat: Fix auth login command from claude -p Say Hi to claude auth login

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -27,10 +27,16 @@ func newAuthCmd() *cobra.Command {
 			return auth.ReadClaudeCredentialsDefault(run)
 		},
 		claudeRefresh: func() error {
-			cmd := exec.Command("claude", "-p", "Say Hi")
-			return cmd.Run()
+			return defaultClaudeRefreshCmd().Run()
 		},
 	})
+}
+
+// defaultClaudeRefreshCmd returns the exec.Cmd used by the production
+// claudeRefresh wiring in newAuthCmd. Extracted so tests can inspect
+// the command and args without invoking the real claude binary.
+func defaultClaudeRefreshCmd() *exec.Cmd {
+	return exec.Command("claude", "auth", "login") //nolint:gosec
 }
 
 // warnIfFederatedControlPlane prints an advisory when the current repo is the

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -166,5 +167,18 @@ func TestAuthRefresh_NoCredentials(t *testing.T) {
 	err := auth.Refresh(&buf, deps)
 	if err == nil {
 		t.Fatal("expected error when credentials missing")
+	}
+}
+
+func TestDefaultClaudeRefreshCmd(t *testing.T) {
+	cmd := defaultClaudeRefreshCmd()
+	if len(cmd.Args) < 3 {
+		t.Fatalf("expected at least 3 args, got %v", cmd.Args)
+	}
+	if filepath.Base(cmd.Args[0]) != "claude" {
+		t.Errorf("expected binary 'claude', got %q", cmd.Args[0])
+	}
+	if cmd.Args[1] != "auth" || cmd.Args[2] != "login" {
+		t.Errorf("expected args [auth login], got %v", cmd.Args[1:])
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `gh agentic auth login` command where the authentication flow was invoking `claude -p "Say Hi"` instead of `claude auth login`. The fix rewires the `claudeRefresh` production closure in `newAuthCmd()` to call `exec.Command("claude", "auth", "login")`, and adds a testability seam (`defaultClaudeRefreshCmd()`) so that the wiring can be pinned by a regression test without executing the actual binary.

## Changes

- `internal/cli/auth.go` — Replaced inline `exec.Command("claude", "-p", "Say Hi")` closure with a call to `defaultClaudeRefreshCmd().Run()`; added `defaultClaudeRefreshCmd()` helper returning `exec.Command("claude", "auth", "login")`
- `internal/cli/auth_test.go` — Added `TestDefaultClaudeRefreshCmd` that verifies the binary is `claude` and args are `["auth", "login"]`; added `path/filepath` import

## Acceptance Criteria

| AC | Status |
|---|---|
| `newAuthCmd()` wires `claudeRefresh` using `exec.Command("claude", "auth", "login")` | ✅ PASS |
| Unit test in `internal/cli/` verifies default `claudeRefresh` closure invokes `claude` with args `["auth", "login"]` | ✅ PASS |
| All existing tests in `internal/auth/auth_test.go` and `internal/cli/auth_test.go` continue to pass | ✅ PASS |
| `go build ./...` passes cleanly | ✅ PASS |

## Static Analysis

✅ PASS — AI code review: 0 blockers, 0 critical, 0 major (1 informational)

> SonarQube deep analysis will run on this PR via CI (`sonarcloud.yml`).

Closes #774

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)