### PR TITLE
fix(pipeline): fix YAML syntax in safety net step

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -686,11 +686,14 @@ jobs:
             --json comments \
             --jq '[.comments[] | select(.body | startswith("<!-- compliance-feedback:v1 -->"))] | length')
           if [ "${FEEDBACK_COUNT}" -eq 0 ]; then
-            gh issue comment "${ISSUE_NUMBER}" --repo ${{ github.repository }} --body \
-"<!-- compliance-feedback:v1 -->
-## Compliance Feedback
-
-The compliance-verify session exited before completing the feedback step. See the \`<!-- compliance-report:v1 -->\` comment above for the full FAIL verdict and required fixes. Address all items marked **PARTIAL** or **FAIL** before the next verification run."
+            FALLBACK_BODY=$(printf '%s\n' \
+              '<!-- compliance-feedback:v1 -->' \
+              '## Compliance Feedback' \
+              '' \
+              'The compliance-verify session exited before completing the feedback step.' \
+              'See the compliance-report comment above for the full FAIL verdict and required fixes.' \
+              'Address all items marked PARTIAL or FAIL before the next verification run.')
+            gh issue comment "${ISSUE_NUMBER}" --repo ${{ github.repository }} --body "${FALLBACK_BODY}"
             echo "Posted fallback compliance-feedback:v1 comment."
           fi
           gh issue edit "${ISSUE_NUMBER}" --repo ${{ github.repository }} \


### PR DESCRIPTION
## Summary

- Fixes YAML parse error introduced in PR #784 (v2.8.2)

## Problem

The multi-line double-quoted shell string beginning with `"<!--` on a new line inside the `run: |` block triggered GitHub's YAML workflow parser error at line 690:

```
You have an error in your yaml syntax on line 690
```

## Fix

Replaced the bare multi-line quoted shell string with a `printf`-based variable assignment (`FALLBACK_BODY`), which is syntactically safe in YAML block scalars.

## Test plan
- [ ] Workflow file parses without error after merge (confirmed locally with Ruby YAML parser)

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)