### PR TITLE
fix(doctor): report Warning not Fail when token lacks variable-read permission

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -212,25 +212,28 @@ Run 'gh agentic repair' to auto-fix any issues that can be fixed automatically.`
 				ctx, _ := project.Resolve(projectDeps)
 				projectID := ""
 				topology := ""
+				projectIDReadFailed := false
 				if ctx != nil {
 					projectID = ctx.ProjectID
 					topology = ctx.Topology
+					projectIDReadFailed = ctx.ProjectIDReadFailed
 				}
 
 				pipelineCheckDeps := doctor.CheckDeps{
-					Root:              root,
-					RepoFullName:      info.FullName,
-					Owner:             info.Owner,
-					RepoName:          info.RepoName,
-					OwnerType:         info.OwnerType,
-					Topology:          topology,
-					ProjectID:         projectID,
-					Run:               deps.run,
-					ReadCreds:         deps.readCreds,
-					FetchProjectTitle:       project.DefaultFetchProjectTitle,
-					FetchProjectFields:       project.DefaultFetchProjectFields,
-					UpdateStatusFieldOptions: project.DefaultUpdateStatusFieldOptions,
-					FrameworkSource:          isFrameworkSource,
+					Root:                root,
+					RepoFullName:        info.FullName,
+					Owner:               info.Owner,
+					RepoName:            info.RepoName,
+					OwnerType:           info.OwnerType,
+					Topology:            topology,
+					ProjectID:           projectID,
+					ProjectIDReadFailed: projectIDReadFailed,
+					Run:                 deps.run,
+					ReadCreds:           deps.readCreds,
+					FetchProjectTitle:        project.DefaultFetchProjectTitle,
+					FetchProjectFields:        project.DefaultFetchProjectFields,
+					UpdateStatusFieldOptions:  project.DefaultUpdateStatusFieldOptions,
+					FrameworkSource:           isFrameworkSource,
 				}
 				pipelineReport = doctor.RunAllChecksWithProgress(pipelineCheckDeps, setLabel)
 				return nil

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -199,26 +199,29 @@ func buildPipelineCheckDeps(pdeps project.Deps) (doctor.CheckDeps, error) {
 	ctx, _ := project.Resolve(pdeps)
 	projectID := ""
 	topology := ""
+	projectIDReadFailed := false
 	if ctx != nil {
 		projectID = ctx.ProjectID
 		topology = ctx.Topology
+		projectIDReadFailed = ctx.ProjectIDReadFailed
 	}
 
 	return doctor.CheckDeps{
-		Root:         root,
-		RepoFullName: pdeps.RepoFullName,
-		Owner:        pdeps.Owner,
-		RepoName:     pdeps.RepoName,
-		OwnerType:    ownerType,
-		Topology:     topology,
-		ProjectID:    projectID,
-		Run:          run,
+		Root:                root,
+		RepoFullName:        pdeps.RepoFullName,
+		Owner:               pdeps.Owner,
+		RepoName:            pdeps.RepoName,
+		OwnerType:           ownerType,
+		Topology:            topology,
+		ProjectID:           projectID,
+		ProjectIDReadFailed: projectIDReadFailed,
+		Run:                 run,
 		ReadCreds: func(r auth.RunCommandFunc) ([]byte, error) {
 			return auth.ReadClaudeCredentialsDefault(r)
 		},
-		FetchProjectTitle:       project.DefaultFetchProjectTitle,
-		FetchProjectFields:       project.DefaultFetchProjectFields,
-		UpdateStatusFieldOptions: project.DefaultUpdateStatusFieldOptions,
+		FetchProjectTitle:        project.DefaultFetchProjectTitle,
+		FetchProjectFields:        project.DefaultFetchProjectFields,
+		UpdateStatusFieldOptions:  project.DefaultUpdateStatusFieldOptions,
 	}, nil
 }
 

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -21,7 +21,8 @@ type CheckDeps struct {
 	RepoName     string
 	OwnerType    string
 	Topology     string // "single", "federated-cp", "federated-domain", "" (unknown)
-	ProjectID    string // value of AGENTIC_PROJECT_ID if set
+	ProjectID           string // value of AGENTIC_PROJECT_ID if set
+	ProjectIDReadFailed bool   // true when AGENTIC_PROJECT_ID could not be read due to token permission error
 	Run          auth.RunCommandFunc
 	ReadCreds    auth.ReadCredentialsFunc
 	// FetchProjectTitle is used by checkProjectReachability to confirm the
@@ -497,11 +498,21 @@ func checkProjectAffiliation(deps CheckDeps) Group {
 	g := Group{Name: "Agentic project membership"}
 
 	if strings.TrimSpace(deps.ProjectID) == "" {
-		g.Results = append(g.Results, CheckResult{
-			Name: "AGENTIC_PROJECT_ID", Status: Fail,
-			Message:     "AGENTIC_PROJECT_ID not configured",
-			Remediation: remediationSet("variable", "AGENTIC_PROJECT_ID", deps),
-		})
+		if deps.ProjectIDReadFailed {
+			// Token lacked Variables:Read (Actions:Read) permission — the variable
+			// may be set but we cannot verify it from this token. Surface as Warning
+			// so CI pipelines using a scoped PIPELINE_PAT don't report false failures.
+			g.Results = append(g.Results, CheckResult{
+				Name: "AGENTIC_PROJECT_ID", Status: Warning,
+				Message: "AGENTIC_PROJECT_ID — unable to verify (token lacks variable-read permission)",
+			})
+		} else {
+			g.Results = append(g.Results, CheckResult{
+				Name: "AGENTIC_PROJECT_ID", Status: Fail,
+				Message:     "AGENTIC_PROJECT_ID not configured",
+				Remediation: remediationSet("variable", "AGENTIC_PROJECT_ID", deps),
+			})
+		}
 	} else {
 		g.Results = append(g.Results, CheckResult{
 			Name: "AGENTIC_PROJECT_ID", Status: Pass,
@@ -845,7 +856,8 @@ func isPermissionError(out string) bool {
 	return strings.Contains(lower, "403") ||
 		strings.Contains(lower, "resource not accessible") ||
 		strings.Contains(lower, "insufficient scopes") ||
-		strings.Contains(lower, "must have admin rights")
+		strings.Contains(lower, "must have admin rights") ||
+		strings.Contains(lower, "forbidden")
 }
 
 // containsVariableName returns true if the gh output from

--- a/internal/project/context.go
+++ b/internal/project/context.go
@@ -48,6 +48,13 @@ type Context struct {
 	// ProjectDeleted is true when ProjectID is set but the project node
 	// no longer resolves — the affiliation is stale.
 	ProjectDeleted bool
+	// ProjectIDReadFailed is true when the AGENTIC_PROJECT_ID variable could
+	// not be read due to a token permission error (HTTP 403). The variable may
+	// be set; the token simply lacked Variables:Read (Actions:Read) permission.
+	// Distinguishes "not configured" from "couldn't check" so the doctor can
+	// emit Warning rather than Fail in CI contexts where PIPELINE_PAT has
+	// limited scopes.
+	ProjectIDReadFailed bool
 
 	// --- Topology ---
 
@@ -134,10 +141,19 @@ func Resolve(deps Deps) (*Context, error) {
 	}
 
 	// Read AGENTIC_PROJECT_ID. Empty means unaffiliated — a safe default,
-	// not an error (see doc comment).
+	// not an error (see doc comment). A permission error (HTTP 403) means
+	// the token lacks Variables:Read scope; record that separately so the
+	// doctor can emit Warning rather than Fail.
 	if deps.GetRepoVariable != nil {
-		pid, _ := deps.GetRepoVariable(deps.Owner, deps.RepoName, ProjectVarName)
-		ctx.ProjectID = strings.TrimSpace(pid)
+		pid, err := deps.GetRepoVariable(deps.Owner, deps.RepoName, ProjectVarName)
+		if err != nil {
+			if isVariablePermissionError(err) {
+				ctx.ProjectIDReadFailed = true
+			}
+			// else: genuine absence or transient error — leave ProjectID empty
+		} else {
+			ctx.ProjectID = strings.TrimSpace(pid)
+		}
 	}
 
 	// Resolve topology — the canonical precedence: explicit
@@ -392,3 +408,21 @@ func ensureContextValid(ctx *Context, err error) (*Context, error) {
 // deliberately lean) can share the same whitespace-normalisation rule Resolve
 // uses on variable values.
 func trim(s string) string { return strings.TrimSpace(s) }
+
+// isVariablePermissionError returns true when a GetRepoVariable error indicates
+// a token-permission failure (HTTP 403) rather than a genuinely absent variable
+// (HTTP 404) or a transient error. Fine-grained PATs that lack Actions:Read
+// (Variables:Read) and GitHub App installation tokens without that scope both
+// produce 403 errors; the doctor must not report these as "variable not
+// configured" — they should be surfaced as "unable to verify".
+func isVariablePermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "403") ||
+		strings.Contains(s, "resource not accessible") ||
+		strings.Contains(s, "insufficient scopes") ||
+		strings.Contains(s, "must have admin rights") ||
+		strings.Contains(s, "forbidden")
+}


### PR DESCRIPTION
## Summary

- Fixes `gh agentic check` reporting `AGENTIC_PROJECT_ID`, `AGENT_USER`, and `RUNNER_LABEL` as **hard failures** in CI when the `PIPELINE_PAT` lacks `Actions:Read` (Variables:Read) permission — the variables are set, the token simply can't verify them

## Root cause

Two separate failure paths:

**1. `AGENTIC_PROJECT_ID` (via `project.Resolve`):**
`DefaultGetRepoVariable` → 403 → error silently discarded (`pid, _ :=`) → `ProjectID = ""` → `checkProjectAffiliation` reports **Fail** with no permission-error detection.

**2. `AGENT_USER` / `RUNNER_LABEL` (via `checkVariable`):**
`gh variable get` → 403 → `isPermissionError` was missing `"forbidden"` as a variant, so some token types fell through to **Fail** instead of **Warning**.

## Changes

- **`project/context.go`**: `Resolve()` now detects permission errors from `GetRepoVariable` and sets `Context.ProjectIDReadFailed` instead of silently discarding the error. Adds `isVariablePermissionError()` helper covering all 403/forbidden variants.
- **`doctor/checks.go`**: `checkProjectAffiliation` emits **Warning** (not Fail) when `ProjectIDReadFailed` is true. Adds `"forbidden"` to `isPermissionError`. Adds `ProjectIDReadFailed` to `CheckDeps`.
- **`cli/check.go` + `cli/repair.go`**: propagate `ctx.ProjectIDReadFailed` into `CheckDeps`.

## Result

After this fix, a CI run with a scoped `PIPELINE_PAT` that lacks `Variables:Read` will see:
```
⚠ AGENTIC_PROJECT_ID — unable to verify (token lacks variable-read permission)
⚠ AGENT_USER — unable to check (token lacks variable-read permission)
⚠ RUNNER_LABEL — unable to check (token lacks variable-read permission)
```
instead of failures that block the pipeline session from proceeding cleanly.

## Test plan
- [ ] `go test ./internal/doctor/... ./internal/project/... ./internal/cli/...` — all pass ✅ (confirmed locally)
- [ ] After merge and release: re-run an ocs-testbench pipeline session and confirm the warnings are gone / downgraded to informational

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)