### PR TITLE
fix(pipeline): fail compliance-verify job when cycle cap or skill abort occurs

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -699,7 +699,24 @@ jobs:
           gh issue edit "${ISSUE_NUMBER}" --repo ${{ github.repository }} \
             --remove-label "in-verification" \
             --add-label "in-development"
-          echo "::warning::compliance-verify skill exited without completing FAIL path — safety net swapped in-verification → in-development on #${ISSUE_NUMBER}."
+          echo "::error::compliance-verify skill aborted before completing the FAIL path — safety net recovered the pipeline by cycling #${ISSUE_NUMBER} back to in-development. Investigate the session log above."
+          exit 1
+
+      # Fail the job when the skill reached the cycle cap and applied
+      # needs-human-review. The automated pipeline has halted; a red job
+      # makes this visible at a glance rather than silently green.
+      - name: Fail if cycle cap reached — human review required
+        if: success() && steps.open_pr.outputs.opened == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
+        run: |
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+          LABELS=$(gh issue view "${ISSUE_NUMBER}" --repo ${{ github.repository }} --json labels --jq '[.labels[].name]')
+          if echo "${LABELS}" | jq -e 'contains(["needs-human-review"])' > /dev/null; then
+            echo "::error::Compliance verification cycle cap reached on Feature #${ISSUE_NUMBER} — 3 successive FAIL verdicts. Automated cycling halted. Human review required before the pipeline can restart."
+            exit 1
+          fi
+          echo "Compliance cycle continuing normally — feature cycling back to in-development for next dev session."
 
       # Must use PIPELINE_PAT so the label event triggers pr-review-session.
       - name: Apply in-review label


### PR DESCRIPTION
## Summary

- **Cycle cap** (`needs-human-review` applied): previously the Compliance Verify job concluded green even though the skill logged "Human intervention is required" and halted automated cycling. A new step after the safety net checks for `needs-human-review` and exits 1, turning the job red.
- **Safety net fires** (skill aborted before completing FAIL path): previously emitted only a `::warning::`. Now escalated to `::error::` + `exit 1`, making the abort visible as a red job.
- **Normal FAIL cycle** (skill completed FAIL path, feature cycles back to `in-development`): unaffected — remains green as expected automated behaviour.

Closes #788 (implicit — observed in ocs-testbench run 25793667439 where cycle cap on Feature #178 showed green despite "Human intervention needed" in the log).

## Test plan

- [ ] Trigger a compliance-verify run that reaches PASS → job stays green, PR opens, in-review label applied
- [ ] Trigger a compliance-verify run where the skill executes FAIL path cleanly → job stays green, feature cycles to in-development
- [ ] Observe a cycle-cap run (or simulate by applying `needs-human-review` manually) → job is now red with `::error::` annotation
- [ ] Observe a safety-net-fires run (skill aborts mid-FAIL-path) → job is now red with `::error::` annotation

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)