### PR TITLE
fix(action): add libvulkan1 system dependency for Goose v1.34.0+

### DIFF
--- a/.github/actions/install-ai-tools/action.yml
+++ b/.github/actions/install-ai-tools/action.yml
@@ -37,7 +37,7 @@ runs:
       id: sys-check
       shell: bash
       run: |
-        dpkg -s gh bzip2 libgomp1 >/dev/null 2>&1 \
+        dpkg -s gh bzip2 libgomp1 libvulkan1 >/dev/null 2>&1 \
           && echo "installed=true" >> $GITHUB_OUTPUT \
           || echo "installed=false" >> $GITHUB_OUTPUT
 
@@ -50,7 +50,8 @@ runs:
         GH_VER=$(apt-cache show gh 2>/dev/null | grep '^Version:' | head -1 | awk '{print $2}' || echo "latest")
         BZIP2_VER=$(apt-cache show bzip2 2>/dev/null | grep '^Version:' | head -1 | awk '{print $2}' || echo "latest")
         LIBGOMP_VER=$(apt-cache show libgomp1 2>/dev/null | grep '^Version:' | head -1 | awk '{print $2}' || echo "latest")
-        echo "key=apt-sys-deps-${{ runner.os }}-${{ runner.arch }}-gh${GH_VER}-bzip2${BZIP2_VER}-gomp${LIBGOMP_VER}" >> $GITHUB_OUTPUT
+        LIBVULKAN_VER=$(apt-cache show libvulkan1 2>/dev/null | grep '^Version:' | head -1 | awk '{print $2}' || echo "latest")
+        echo "key=apt-sys-deps-${{ runner.os }}-${{ runner.arch }}-gh${GH_VER}-bzip2${BZIP2_VER}-gomp${LIBGOMP_VER}-vulkan${LIBVULKAN_VER}" >> $GITHUB_OUTPUT
 
     - name: Cache apt archives
       if: steps.sys-check.outputs.installed != 'true'
@@ -66,7 +67,7 @@ runs:
       run: |
         sudo rm -rf /var/lib/apt/lists/*
         sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends --fix-missing gh bzip2 libgomp1
+        sudo apt-get install -y --no-install-recommends --fix-missing gh bzip2 libgomp1 libvulkan1
 
     - name: Resolve Goose version
       id: goose-version


### PR DESCRIPTION
## Summary

Goose v1.34.0 shipped "Linux Vulkan support for local inference" ([block/goose#9038](https://github.com/block/goose/pull/9038)), which linked the Linux binary against `libvulkan.so.1`. The package is not installed by default on the GitHub Actions Ubuntu runner, causing goose to fail at startup with a missing-library error.

- Adds `libvulkan1` to the `dpkg -s` presence check so runners without it are not incorrectly marked as "already installed"
- Adds `libvulkan1` to the apt cache key so existing caches are busted and the package is pulled in on the next run
- Adds `libvulkan1` to the `apt-get install` line

## Test plan

- [ ] Trigger a dev-session or compliance-verify pipeline run after merge — Goose should start cleanly without a `libvulkan.so.1: cannot open shared object file` error

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)