### PR TITLE
fix(pipeline): inline libvulkan1 install in workflow — not composite action

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -125,6 +125,19 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
+
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools
         with:
@@ -394,6 +407,19 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
+
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools
         with:
@@ -573,6 +599,19 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: 'lts/*'
+
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
 
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools
@@ -803,6 +842,19 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
+
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools
         with:
@@ -898,6 +950,19 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: 'lts/*'
+
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
 
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools

--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -134,6 +134,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }
@@ -416,6 +417,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }
@@ -609,6 +611,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }
@@ -851,6 +854,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }
@@ -960,6 +964,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }


### PR DESCRIPTION
## Summary

v2.8.5 added `libvulkan1` to the `install-ai-tools` composite action, but the fix had no effect. Root cause:

- The composite action is loaded from `.agents/.github/actions/install-ai-tools` in the caller's (ocs-testbench's) workspace
- `.agents/` is gitignored — `actions/checkout` does not clean gitignored directories on self-hosted runners
- So `.agents/` persists from the last `gh agentic mount` (v2.8.3), and the composite always runs at that version regardless of the workflow's `@vX.Y.Z` ref

The `dpkg -s` check in the v2.8.3 composite only checks `gh bzip2 libgomp1`, not `libvulkan1`. It finds all three installed (from previous runs), returns `installed=true`, skips `apt-get install` entirely, and `libvulkan1` is never installed.

**Fix:** add an inline `Install system dependencies` step directly in the workflow file before `Install tools`. Inline steps are always loaded at the workflow's own ref, bypassing the stale composite. The `dpkg -s` guard makes it a no-op if the package is already present.

Added to all five goose-using jobs: Feature Design, Dev Session, Compliance Verify, PR Review Session, Issue Session.

## Why not fix the composite action?

The composite action is still worth fixing for completeness (it's already fixed in v2.8.5), but it cannot be the authoritative place for system dep additions — callers will always load the stale version. Future system dep changes must go in the workflow file.

## Test plan

- [ ] Trigger a dev-session run on ocs-testbench → `Install system dependencies` step runs, `libvulkan1` installed, goose starts cleanly

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)