### PR TITLE
fix(init): scaffold AGENTS.md, CLAUDE.md, LOCALRULES.md, and workflows on init

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -125,6 +125,19 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
+
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools
         with:
@@ -394,6 +407,19 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
+
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools
         with:
@@ -573,6 +599,19 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: 'lts/*'
+
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
 
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools
@@ -803,6 +842,19 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
+
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools
         with:
@@ -898,6 +950,19 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: 'lts/*'
+
+      # System packages that the composite action cannot reliably install on
+      # self-hosted runners: the composite action is loaded from the locally-
+      # mounted .agents/ directory (gitignored, persists between runs), which
+      # may lag the workflow version. Inline steps are always at the current
+      # workflow ref and are the authoritative place for system dep changes.
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libvulkan1
+          }
 
       - name: Install tools
         uses: ./.agents/.github/actions/install-ai-tools

--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -134,6 +134,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }
@@ -416,6 +417,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }
@@ -609,6 +611,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }
@@ -851,6 +854,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }
@@ -960,6 +964,7 @@ jobs:
         shell: bash
         run: |
           dpkg -s libvulkan1 >/dev/null 2>&1 || {
+            sudo add-apt-repository -y universe
             sudo apt-get update -qq
             sudo apt-get install -y --no-install-recommends libvulkan1
           }

--- a/internal/mount/firsttime.go
+++ b/internal/mount/firsttime.go
@@ -10,9 +10,7 @@ import (
 // RunFirstTime orchestrates the first-time mount flow when no .agents/
 // directory exists yet. It:
 //  1. Installs the framework as a `.agents/` submodule
-//  2. Generates CLAUDE.md
-//  3. Generates AGENTS.md with bootstrap rule
-//  4. Generates wrapper workflows in .github/workflows/
+//  2. Generates CLAUDE.md, AGENTS.md, and wrapper workflows via ScaffoldProjectFiles
 //
 // The mounted version is recorded by the submodule's gitlink in the
 // parent repo's index. Callers that need to broadcast the version
@@ -29,28 +27,9 @@ func RunFirstTime(w io.Writer, root, version string, fetch CloneFunc) error {
 		return fmt.Errorf("installing framework: %w", err)
 	}
 
-	// Step 2: Generate CLAUDE.md (only if it doesn't exist).
-	claudePath := filepath.Join(root, "CLAUDE.md")
-	if _, err := os.Stat(claudePath); os.IsNotExist(err) {
-		fmt.Fprintln(w, "  ✓ CLAUDE.md created")
-		if err := os.WriteFile(claudePath, []byte(claudeMDTemplate), 0o644); err != nil {
-			return fmt.Errorf("creating CLAUDE.md: %w", err)
-		}
-	}
-
-	// Step 3: Generate AGENTS.md (only if it doesn't exist).
-	agentsPath := filepath.Join(root, "AGENTS.md")
-	if _, err := os.Stat(agentsPath); os.IsNotExist(err) {
-		fmt.Fprintln(w, "  ✓ AGENTS.md created")
-		if err := os.WriteFile(agentsPath, []byte(agentsMDTemplate), 0o644); err != nil {
-			return fmt.Errorf("creating AGENTS.md: %w", err)
-		}
-	}
-
-	// Step 4: Generate wrapper workflows.
-	fmt.Fprintln(w, "  ✓ Wrapper workflows created")
-	if err := generateWorkflows(w, root, version); err != nil {
-		return fmt.Errorf("creating workflows: %w", err)
+	// Steps 2-4: Generate CLAUDE.md, AGENTS.md, and wrapper workflows.
+	if err := ScaffoldProjectFiles(w, root, version); err != nil {
+		return err
 	}
 
 	fmt.Fprintln(w)
@@ -61,6 +40,58 @@ func RunFirstTime(w io.Writer, root, version string, fetch CloneFunc) error {
 	fmt.Fprintln(w, "  2. Run 'gh agentic init' to join or create an agentic project")
 	fmt.Fprintln(w, "  3. Run 'gh agentic check' to verify the full setup")
 
+	return nil
+}
+
+// ScaffoldProjectFiles creates the standard agent instruction files and
+// wrapper workflows for a domain repo. It is safe to call after
+// DownloadFramework — each file is only written when it does not already
+// exist (idempotent). project.Create and project.initFederated call this
+// after mounting the framework so that init always produces the full set
+// of required files regardless of which code path ran.
+func ScaffoldProjectFiles(w io.Writer, root, version string) error {
+	// CLAUDE.md — only if absent.
+	claudePath := filepath.Join(root, "CLAUDE.md")
+	if _, err := os.Stat(claudePath); os.IsNotExist(err) {
+		fmt.Fprintln(w, "  ✓ CLAUDE.md created")
+		if err := os.WriteFile(claudePath, []byte(claudeMDTemplate), 0o644); err != nil {
+			return fmt.Errorf("creating CLAUDE.md: %w", err)
+		}
+	}
+
+	// AGENTS.md — only if absent.
+	agentsPath := filepath.Join(root, "AGENTS.md")
+	if _, err := os.Stat(agentsPath); os.IsNotExist(err) {
+		fmt.Fprintln(w, "  ✓ AGENTS.md created")
+		if err := os.WriteFile(agentsPath, []byte(agentsMDTemplate), 0o644); err != nil {
+			return fmt.Errorf("creating AGENTS.md: %w", err)
+		}
+	}
+
+	// Wrapper workflows.
+	fmt.Fprintln(w, "  ✓ Wrapper workflows created")
+	if err := generateWorkflows(w, root, version); err != nil {
+		return fmt.Errorf("creating workflows: %w", err)
+	}
+
+	return nil
+}
+
+// ScaffoldLocalRules creates a starter LOCALRULES.md in root when none
+// exists. The file is pre-populated with the repo name, owner, and
+// topology so the developer has a ready-to-edit file rather than a blank
+// slate. It is safe to call multiple times — a no-op when LOCALRULES.md
+// already exists.
+func ScaffoldLocalRules(w io.Writer, root, repoName, owner, topology string) error {
+	path := filepath.Join(root, "LOCALRULES.md")
+	if _, err := os.Stat(path); err == nil {
+		return nil // already exists — preserve the user's overrides
+	}
+	content := localrulesMDTemplate(repoName, owner, topology)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("creating LOCALRULES.md: %w", err)
+	}
+	fmt.Fprintln(w, "  ✓ LOCALRULES.md created")
 	return nil
 }
 

--- a/internal/mount/firsttime_test.go
+++ b/internal/mount/firsttime_test.go
@@ -211,3 +211,106 @@ func TestReleaseWorkflowTemplate_ContainsVersion(t *testing.T) {
 		t.Errorf("release workflow should reference @v2.1.0, got: %s", content)
 	}
 }
+
+func TestScaffoldProjectFiles_CreatesAllFiles(t *testing.T) {
+	root := t.TempDir()
+	var buf bytes.Buffer
+
+	if err := ScaffoldProjectFiles(&buf, root, "v2.5.0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	claude, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("CLAUDE.md not created: %v", err)
+	}
+	if !strings.Contains(string(claude), "@AGENTS.md") {
+		t.Errorf("CLAUDE.md should reference @AGENTS.md")
+	}
+
+	agents, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("AGENTS.md not created: %v", err)
+	}
+	if !strings.Contains(string(agents), "@.agents/RULEBOOK.md") {
+		t.Errorf("AGENTS.md should reference @.agents/RULEBOOK.md")
+	}
+
+	pipeline, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "agentic-pipeline.yml"))
+	if err != nil {
+		t.Fatalf("agentic-pipeline.yml not created: %v", err)
+	}
+	if !strings.Contains(string(pipeline), "@v2.5.0") {
+		t.Errorf("pipeline workflow should reference @v2.5.0")
+	}
+
+	if _, err := os.Stat(filepath.Join(root, ".github", "workflows", "release.yml")); os.IsNotExist(err) {
+		t.Error("release.yml should exist")
+	}
+}
+
+func TestScaffoldProjectFiles_IdempotentWhenFilesExist(t *testing.T) {
+	root := t.TempDir()
+	var buf bytes.Buffer
+
+	_ = os.WriteFile(filepath.Join(root, "CLAUDE.md"), []byte("# Custom\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("# Custom AGENTS\n"), 0o644)
+
+	if err := ScaffoldProjectFiles(&buf, root, "v2.5.0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Existing files must be preserved.
+	data, _ := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if string(data) != "# Custom\n" {
+		t.Errorf("CLAUDE.md should be preserved, got: %s", data)
+	}
+	data, _ = os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if string(data) != "# Custom AGENTS\n" {
+		t.Errorf("AGENTS.md should be preserved, got: %s", data)
+	}
+}
+
+func TestScaffoldLocalRules_CreatesFile(t *testing.T) {
+	root := t.TempDir()
+	var buf bytes.Buffer
+
+	if err := ScaffoldLocalRules(&buf, root, "my-repo", "myorg", "single"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "LOCALRULES.md"))
+	if err != nil {
+		t.Fatalf("LOCALRULES.md not created: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "my-repo") {
+		t.Error("LOCALRULES.md should contain repo name")
+	}
+	if !strings.Contains(content, "myorg") {
+		t.Error("LOCALRULES.md should contain owner")
+	}
+	if !strings.Contains(content, "single") {
+		t.Error("LOCALRULES.md should contain topology")
+	}
+	if !strings.Contains(buf.String(), "LOCALRULES.md created") {
+		t.Error("output should confirm LOCALRULES.md creation")
+	}
+}
+
+func TestScaffoldLocalRules_PreservesExisting(t *testing.T) {
+	root := t.TempDir()
+	var buf bytes.Buffer
+
+	existing := "# My custom rules\n"
+	_ = os.WriteFile(filepath.Join(root, "LOCALRULES.md"), []byte(existing), 0o644)
+
+	if err := ScaffoldLocalRules(&buf, root, "my-repo", "myorg", "single"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, "LOCALRULES.md"))
+	if string(data) != existing {
+		t.Errorf("existing LOCALRULES.md should be preserved, got: %s", data)
+	}
+}

--- a/internal/mount/templates.go
+++ b/internal/mount/templates.go
@@ -1,6 +1,9 @@
 package mount
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // claudeMDTemplate is the standard CLAUDE.md content for domain repos.
 const claudeMDTemplate = `# CLAUDE.md
@@ -72,6 +75,41 @@ jobs:
       issues: write
       pull-requests: write
 `, "{{VERSION}}", version)
+}
+
+// localrulesMDTemplate returns a starter LOCALRULES.md for a domain repo.
+// The known fields (repo name, owner, topology) are pre-populated; the
+// developer fills in the stack, description, module, and custom commands.
+func localrulesMDTemplate(repoName, owner, topology string) string {
+	return fmt.Sprintf("# LOCALRULES.md — Local Overrides\n"+
+		"\n"+
+		"This file contains project-specific rules and overrides that extend or\n"+
+		"supersede the global protocol defined in `.agents/RULEBOOK.md`.\n"+
+		"\n"+
+		"This file is never overwritten by a template sync.\n"+
+		"\n"+
+		"---\n"+
+		"\n"+
+		"## Project\n"+
+		"\n"+
+		"- **Name:** %s\n"+
+		"- **Topology:** %s\n"+
+		"- **Stack:** <!-- TODO: e.g. Go, TypeScript, Python -->\n"+
+		"- **Description:** <!-- TODO: short description of this project -->\n"+
+		"\n"+
+		"## Repo\n"+
+		"\n"+
+		"- **GitHub:** https://github.com/%s/%s\n"+
+		"- **Module:** <!-- TODO: module/package path if applicable -->\n"+
+		"\n"+
+		"## Commands\n"+
+		"\n"+
+		"<!-- TODO: add project-specific CLI commands and their descriptions here -->\n"+
+		"\n"+
+		"## Notes\n"+
+		"\n"+
+		"<!-- TODO: add any project-specific rules, conventions, or notes here -->\n",
+		repoName, topology, owner, repoName)
 }
 
 // releaseWorkflowTemplate returns the release wrapper workflow content

--- a/internal/project/create.go
+++ b/internal/project/create.go
@@ -133,6 +133,14 @@ func Create(w io.Writer, deps Deps, cfg CreateConfig) error {
 	}
 	fmt.Fprintf(w, "  %s  Framework mounted at %s\n", ui.StatusOK.Render("✓"), cfg.Version)
 
+	// Step 8a: Scaffold agent instruction files and wrapper workflows.
+	if err := mount.ScaffoldProjectFiles(w, deps.Root, cfg.Version); err != nil {
+		return fmt.Errorf("scaffolding project files: %w", err)
+	}
+	if err := mount.ScaffoldLocalRules(w, deps.Root, deps.RepoName, deps.Owner, topology); err != nil {
+		return fmt.Errorf("scaffolding LOCALRULES.md: %w", err)
+	}
+
 	// Step 9: Scaffold project from template (description, readme, status options, views).
 	fmt.Fprintf(w, "  Scaffolding project from template...\n")
 	scaffoldProject(w, deps, projectID, ownerType)

--- a/internal/project/init.go
+++ b/internal/project/init.go
@@ -134,18 +134,31 @@ func initFederated(w io.Writer, deps Deps, cfg InitRepoConfig) error {
 	// is tracked via .agents/.git metadata — no flat .ai-version file is
 	// written (removed by feature #571 / task #585).
 	aiDir := filepath.Join(deps.Root, ".agents")
+	freshMount := false
 	if _, err := os.Stat(aiDir); os.IsNotExist(err) {
 		fmt.Fprintf(w, "  Mounting framework %s...\n", cpVersion)
 		if err := mount.DownloadFramework(deps.Root, cpVersion, deps.Clone); err != nil {
 			return fmt.Errorf("mounting framework: %w", err)
 		}
 		fmt.Fprintf(w, "  %s  Framework mounted at %s\n", ui.StatusOK.Render("✓"), cpVersion)
+		freshMount = true
 	} else {
 		localVersion, _ := mount.ReadAIVersionFromGit(deps.Root)
 		if localVersion == "" {
 			localVersion = "(unknown)"
 		}
 		fmt.Fprintf(w, "  %s  Framework already mounted at %s\n", ui.StatusOK.Render("✓"), localVersion)
+	}
+
+	// Scaffold agent instruction files and wrapper workflows on fresh mounts.
+	// Skipped when the framework was already present to avoid clobbering edits.
+	if freshMount {
+		if err := mount.ScaffoldProjectFiles(w, deps.Root, cpVersion); err != nil {
+			return fmt.Errorf("scaffolding project files: %w", err)
+		}
+		if err := mount.ScaffoldLocalRules(w, deps.Root, deps.RepoName, deps.Owner, "federated"); err != nil {
+			return fmt.Errorf("scaffolding LOCALRULES.md: %w", err)
+		}
 	}
 
 	// Configure secrets, variables, and agent access.


### PR DESCRIPTION
## Summary

`gh agentic init` was setting up the project (board, secrets, variables, framework mount) but leaving the repo with no agent instruction files or wrapper workflows.

**Root cause:** The current init flow calls `project.InitRepo → project.Create / initFederated`. Both call `mount.DownloadFramework` directly. The file scaffolding (CLAUDE.md, AGENTS.md, workflows) lived only in `mount.RunFirstTime`, which the new CLI init flow no longer invokes.

**Fix:**
- Extract steps 2–4 of `RunFirstTime` into `mount.ScaffoldProjectFiles` — callable after any `DownloadFramework` call to create CLAUDE.md, AGENTS.md, and the wrapper workflows (idempotent; skips existing files)
- Add `mount.ScaffoldLocalRules` — generates a starter LOCALRULES.md pre-populated with repo name, owner, and topology; no-op if already present
- Call both from `project.Create` (single topology) and `project.initFederated` (federated, fresh mounts only — skips re-scaffold when framework was already present)
- Refactor `RunFirstTime` to delegate to `ScaffoldProjectFiles` (no behaviour change for `gh agentic mount`)

## Files created by init after this fix

| File | Created? |
|---|---|
| `CLAUDE.md` | ✅ (only if absent) |
| `AGENTS.md` | ✅ (only if absent) |
| `LOCALRULES.md` | ✅ (only if absent — pre-filled with repo/topology) |
| `.github/workflows/agentic-pipeline.yml` | ✅ |
| `.github/workflows/release.yml` | ✅ |

## Test plan

- [ ] `gh agentic init` on a fresh repo (single topology) → all five files created
- [ ] `gh agentic init` on a repo with existing CLAUDE.md → CLAUDE.md preserved, other files created
- [ ] `gh agentic init` federated join on a fresh repo → all five files created
- [ ] `gh agentic mount` unaffected (RunFirstTime delegates to ScaffoldProjectFiles, behaviour unchanged)
- [ ] Unit tests: `TestScaffoldProjectFiles_*`, `TestScaffoldLocalRules_*` (4 new tests, all passing)

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)