### PR TITLE
fix(doctor): remove AGENT_USER legacy variable from checks and repair

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -437,7 +437,7 @@ func checkVariablesAndSecrets(deps CheckDeps) Group {
 
 	// Check variables via gh CLI.
 	variables := []string{
-		"AGENT_USER", "RUNNER_LABEL",
+		"RUNNER_LABEL",
 		"AGENT_PROVIDER", "AGENT_MODEL",
 	}
 	for _, v := range variables {
@@ -726,7 +726,7 @@ func checkProjectStatusOptions(deps CheckDeps) Group {
 
 // checkVariable checks if a GitHub variable exists.
 //
-// Under federated topology the shared names (AGENT_USER, RUNNER_LABEL,
+// Under federated topology the shared names (RUNNER_LABEL,
 // AGENT_PROVIDER, AGENT_MODEL) live at the organisation level and are not
 // visible via `gh variable list --repo OWNER/REPO`. The check therefore
 // consults the org scope for shared names under federated topology, treating
@@ -945,7 +945,6 @@ func FindShadowValues(deps CheckDeps) []ShadowValue {
 	// on map iteration order. The names themselves come from scope's
 	// canonical shared set; we iterate a stable slice here.
 	shared := []string{
-		"AGENT_USER",
 		"RUNNER_LABEL",
 		"AGENT_PROVIDER",
 		"AGENT_MODEL",

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -937,7 +937,7 @@ func TestCheckSecret_Single_SecretAtOrgOnly_Fail(t *testing.T) {
 func TestCheckVariable_Federated_SharedName_QueriesOrg(t *testing.T) {
 	r := &ghRun{
 		Outputs: map[string]string{
-			"variable|--org": "AGENT_USER\tsome-value",
+			"variable|--org": "RUNNER_LABEL\tsome-value",
 			// repo variable get returns empty (not set)
 		},
 	}
@@ -945,7 +945,7 @@ func TestCheckVariable_Federated_SharedName_QueriesOrg(t *testing.T) {
 		RepoFullName: "acme/domain", Owner: "acme", Topology: "federated-domain",
 		Run: r.fn(),
 	}
-	res := checkVariable(deps, "AGENT_USER")
+	res := checkVariable(deps, "RUNNER_LABEL")
 	if res.Status != Pass {
 		t.Fatalf("got %d (%s), want Pass", res.Status, res.Message)
 	}
@@ -994,7 +994,7 @@ func (s shadowScenario) ghRun() *ghRun {
 func TestCheckShadowVars_Federated_NoShadows_Pass(t *testing.T) {
 	r := shadowScenario{
 		// Shared name present only at org — correct federated placement.
-		VarOrg: "AGENT_USER\tvalue",
+		VarOrg: "RUNNER_LABEL\tvalue",
 		SecOrg: "PROJECT_PAT\tupdated",
 	}.ghRun()
 	deps := CheckDeps{
@@ -1012,15 +1012,15 @@ func TestCheckShadowVars_Federated_NoShadows_Pass(t *testing.T) {
 
 func TestCheckShadowVars_Federated_VariableShadow_FailWithDeleteCommand(t *testing.T) {
 	r := shadowScenario{
-		VarRepo: "AGENT_USER\tshadow",
-		VarOrg:  "AGENT_USER\ttrue-value",
+		VarRepo: "RUNNER_LABEL\tshadow",
+		VarOrg:  "RUNNER_LABEL\ttrue-value",
 	}.ghRun()
 	deps := CheckDeps{
 		RepoFullName: "acme/cp", Owner: "acme", Topology: "federated-cp",
 		Run: r.fn(),
 	}
 	g := checkShadowVars(deps)
-	// Expect: 1 summary Fail + 1 per-item Fail for AGENT_USER variable.
+	// Expect: 1 summary Fail + 1 per-item Fail for RUNNER_LABEL variable.
 	if len(g.Results) != 2 {
 		t.Fatalf("expected 2 results (summary + item), got %d: %+v", len(g.Results), g.Results)
 	}
@@ -1031,10 +1031,10 @@ func TestCheckShadowVars_Federated_VariableShadow_FailWithDeleteCommand(t *testi
 	if !ok || len(data) != 1 {
 		t.Fatalf("expected []ShadowValue of length 1 on summary, got %v", g.Results[0].Data)
 	}
-	if data[0].Kind != "variable" || data[0].Name != "AGENT_USER" {
-		t.Errorf("structured data: got %+v, want variable/AGENT_USER", data[0])
+	if data[0].Kind != "variable" || data[0].Name != "RUNNER_LABEL" {
+		t.Errorf("structured data: got %+v, want variable/RUNNER_LABEL", data[0])
 	}
-	wantCmd := "gh variable delete --repo acme/cp AGENT_USER"
+	wantCmd := "gh variable delete --repo acme/cp RUNNER_LABEL"
 	if data[0].DeleteCommand != wantCmd {
 		t.Errorf("structured delete command: got %q, want %q", data[0].DeleteCommand, wantCmd)
 	}
@@ -1068,8 +1068,8 @@ func TestCheckShadowVars_Federated_SecretShadow_FailWithDeleteCommand(t *testing
 
 func TestCheckShadowVars_Federated_MixedShadows_AllListed(t *testing.T) {
 	r := shadowScenario{
-		VarRepo: "AGENT_USER\tx\nRUNNER_LABEL\ty",
-		VarOrg:  "AGENT_USER\tx\nRUNNER_LABEL\ty",
+		VarRepo: "RUNNER_LABEL\tx\nAGENT_PROVIDER\ty",
+		VarOrg:  "RUNNER_LABEL\tx\nAGENT_PROVIDER\ty",
 		SecRepo: "PROJECT_PAT\tz\nCLAUDE_CREDENTIALS_JSON\tw",
 		SecOrg:  "PROJECT_PAT\tz\nCLAUDE_CREDENTIALS_JSON\tw",
 	}.ghRun()
@@ -1159,10 +1159,10 @@ func TestFindShadowValues_DeterministicOrder(t *testing.T) {
 	// should emit the variable entry before the secret entry (declaration
 	// order in the canonical shared list).
 	r := shadowScenario{
-		VarRepo: "AGENT_USER\tv",
-		VarOrg:  "AGENT_USER\tv",
-		SecRepo: "AGENT_USER\ts", // Same name, different kind.
-		SecOrg:  "AGENT_USER\ts",
+		VarRepo: "RUNNER_LABEL\tv",
+		VarOrg:  "RUNNER_LABEL\tv",
+		SecRepo: "RUNNER_LABEL\ts", // Same name, different kind.
+		SecOrg:  "RUNNER_LABEL\ts",
 	}.ghRun()
 	deps := CheckDeps{
 		RepoFullName: "acme/cp", Owner: "acme", Topology: "federated-cp",
@@ -1206,11 +1206,11 @@ func TestCheckVariable_Federated_SharedAtNeither_FailWithOrgRemediation(t *testi
 		RepoFullName: "acme/domain", Owner: "acme", Topology: "federated-domain",
 		Run: r.fn(),
 	}
-	res := checkVariable(deps, "AGENT_USER")
+	res := checkVariable(deps, "RUNNER_LABEL")
 	if res.Status != Fail {
 		t.Fatalf("got %d (%s), want Fail", res.Status, res.Message)
 	}
-	wantHint := "gh variable set AGENT_USER --org acme"
+	wantHint := "gh variable set RUNNER_LABEL --org acme"
 	if res.Remediation != wantHint {
 		t.Errorf("remediation: got %q, want %q", res.Remediation, wantHint)
 	}
@@ -1236,7 +1236,7 @@ func TestCheckVariable_PermissionError_Warns(t *testing.T) {
 					return tc.output, fmt.Errorf("gh: exit status 1")
 				},
 			}
-			res := checkVariable(deps, "AGENT_USER")
+			res := checkVariable(deps, "RUNNER_LABEL")
 			if res.Status != Warning {
 				t.Fatalf("status: got %d (%s), want Warning", res.Status, res.Message)
 			}

--- a/internal/doctor/repair.go
+++ b/internal/doctor/repair.go
@@ -284,7 +284,6 @@ var pendingDescriptions = map[string]struct {
 	Description string
 	Default     string
 }{
-	"AGENT_USER":     {"GitHub username the agent commits as (e.g. goose-bot)", ""},
 	"RUNNER_LABEL":   {"GitHub Actions runner label", ""}, // resolved via select in cli layer
 	"AGENT_PROVIDER": {"The LLM provider the agent will use", "claude-code"},
 	"AGENT_MODEL":    {"Agent model override", "default"},

--- a/internal/doctor/repair_test.go
+++ b/internal/doctor/repair_test.go
@@ -152,7 +152,7 @@ func assertGHScope(t *testing.T, c *capturedGH, wantFlag, wantTarget string) {
 }
 
 func TestApplyPendingPrompt_Federated_SharedName_RoutesToOrg(t *testing.T) {
-	shared := []string{"AGENT_USER", "RUNNER_LABEL", "AGENT_PROVIDER", "AGENT_MODEL", "PROJECT_PAT", "CLAUDE_CREDENTIALS_JSON"}
+	shared := []string{"RUNNER_LABEL", "AGENT_PROVIDER", "AGENT_MODEL", "PROJECT_PAT", "CLAUDE_CREDENTIALS_JSON"}
 	for _, name := range shared {
 		t.Run(name, func(t *testing.T) {
 			c := &capturedGH{}
@@ -194,7 +194,7 @@ func TestApplyPendingPrompt_Federated_IdentityName_StaysAtRepo(t *testing.T) {
 
 func TestApplyPendingPrompt_Single_AllNames_StayAtRepo(t *testing.T) {
 	all := []string{
-		"AGENT_USER", "RUNNER_LABEL", "AGENT_PROVIDER", "AGENT_MODEL",
+		"RUNNER_LABEL", "AGENT_PROVIDER", "AGENT_MODEL",
 		"PROJECT_PAT", "CLAUDE_CREDENTIALS_JSON",
 		"AGENTIC_PROJECT_ID", "AGENTIC_TOPOLOGY", "AGENTIC_FRAMEWORK_VERSION",
 	}
@@ -291,7 +291,7 @@ func (c *recordedConfirm) run(title, body string) (bool, error) {
 
 func makeShadowItems() []ShadowValue {
 	return []ShadowValue{
-		{Name: "AGENT_USER", Kind: "variable", DeleteCommand: "gh variable delete --repo acme/cp AGENT_USER"},
+		{Name: "RUNNER_LABEL", Kind: "variable", DeleteCommand: "gh variable delete --repo acme/cp RUNNER_LABEL"},
 		{Name: "PROJECT_PAT", Kind: "secret", DeleteCommand: "gh secret delete --repo acme/cp PROJECT_PAT"},
 	}
 }
@@ -316,7 +316,7 @@ func TestRepairShadowValues_ConfirmYes_AllDeletesSucceed(t *testing.T) {
 		t.Fatalf("gh called %d times, want 2: %v", len(run.calls), run.calls)
 	}
 	// Delete commands use the injected runner with the right scope and name.
-	wantFirst := []string{"variable", "delete", "AGENT_USER", "--repo", "acme/cp"}
+	wantFirst := []string{"variable", "delete", "RUNNER_LABEL", "--repo", "acme/cp"}
 	wantSecond := []string{"secret", "delete", "PROJECT_PAT", "--repo", "acme/cp"}
 	if !reflectDeepEqualStrings(run.calls[0], wantFirst) {
 		t.Errorf("call 0: got %v, want %v", run.calls[0], wantFirst)
@@ -330,7 +330,7 @@ func TestRepairShadowValues_ConfirmYes_OneFailureDoesNotAbortBatch(t *testing.T)
 	items := makeShadowItems()
 	run := &shadowRunRecorder{
 		errs: map[string]error{
-			"variable|AGENT_USER": fmt.Errorf("boom"),
+			"variable|RUNNER_LABEL": fmt.Errorf("boom"),
 		},
 	}
 	confirm := &recordedConfirm{yes: true}

--- a/internal/project/scope_test.go
+++ b/internal/project/scope_test.go
@@ -13,14 +13,14 @@ func TestProjectScopeReExports_AreWiredCorrectly(t *testing.T) {
 		repo  = "acme-org/charging-cp"
 	)
 
-	if !IsSharedName("AGENT_USER") {
-		t.Error("IsSharedName(AGENT_USER) should be true")
+	if !IsSharedName("RUNNER_LABEL") {
+		t.Error("IsSharedName(RUNNER_LABEL) should be true")
 	}
 	if !IsIdentityName("AGENTIC_PROJECT_ID") {
 		t.Error("IsIdentityName(AGENTIC_PROJECT_ID) should be true")
 	}
 
-	flag, target := ScopeFor("AGENT_USER", "federated", owner, repo)
+	flag, target := ScopeFor("RUNNER_LABEL", "federated", owner, repo)
 	if flag != ScopeFlagOrg || target != owner {
 		t.Errorf("federated shared: got (%q, %q), want (%q, %q)", flag, target, ScopeFlagOrg, owner)
 	}

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -29,7 +29,6 @@ const (
 // live on the repo (there is no org above a single-repo deployment to pin
 // them to).
 var sharedNames = map[string]struct{}{
-	"AGENT_USER":              {},
 	"RUNNER_LABEL":            {},
 	"AGENT_PROVIDER":          {},
 	"AGENT_MODEL":             {},
@@ -81,7 +80,7 @@ func IsFederatedTopology(topology string) bool {
 // name under a given topology.
 //
 // Rules:
-//   - Shared names (AGENT_USER, RUNNER_LABEL, AGENT_PROVIDER, AGENT_MODEL,
+//   - Shared names (RUNNER_LABEL, AGENT_PROVIDER, AGENT_MODEL,
 //     PROJECT_PAT, CLAUDE_CREDENTIALS_JSON) route to --org under any
 //     federated topology variant and to --repo under single.
 //   - Per-repo identity names (AGENTIC_PROJECT_ID, AGENTIC_TOPOLOGY,

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -13,7 +13,6 @@ const (
 // Kept in a slice (not the set) so tests iterate deterministically and the
 // exhaustiveness assertion can compare lengths.
 var allSharedNames = []string{
-	"AGENT_USER",
 	"RUNNER_LABEL",
 	"AGENT_PROVIDER",
 	"AGENT_MODEL",


### PR DESCRIPTION
## Summary

- Removes `AGENT_USER` from the doctor variable check list — repair no longer prompts for it
- Removes `AGENT_USER` from `scope.sharedNames` — it is no longer routed to `--org` under federated topology
- Removes `AGENT_USER` from `repair.pendingDescriptions` — stops the repair wizard prompting the user to create a value that should be deleted
- Updates all affected tests to use `RUNNER_LABEL` as the representative shared variable

## Background

`AGENT_USER` was a PAT-era variable from when the pipeline ran as a named GitHub user (`goose-bot`). Since migrating to the agentic GitHub App identity (`concepts/migration-to-github-app.md`), the variable is obsolete — step 8 of the migration guide explicitly says to **delete** it.

Having it in doctor caused `gh agentic repair` to prompt for a value that no longer serves any purpose, and having it in `sharedNames` meant it would be written at org scope for federated topologies.

Closes the repair-prompts-for-AGENT_USER issue raised in the fix/init-scaffold-missing-files session.

## Test plan
- [x] `go test ./...` — all green

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)