### PR TITLE
fix(doctor): check and repair missing .github/workflows files

### DIFF
--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -392,7 +392,10 @@ func checkWorkflows(deps CheckDeps) Group {
 		path := filepath.Join(workflowsDir, wf)
 		if !fileExists(path) {
 			g.Results = append(g.Results, CheckResult{
-				Name: wf, Status: Warning, Message: wf + " not found",
+				Name:        wf,
+				Status:      Fail,
+				Message:     wf + " — not found",
+				Remediation: "Run 'gh agentic repair'",
 			})
 			continue
 		}

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -181,6 +181,38 @@ func TestCheckFramework_NotMounted(t *testing.T) {
 	}
 }
 
+func TestCheckWorkflows_MissingFile_Fail(t *testing.T) {
+	// No .github/workflows directory at all — both files missing.
+	root := t.TempDir()
+	setupAIGitRepo(t, filepath.Join(root, ".agents"), "v2.0.0")
+	deps := CheckDeps{Root: root}
+
+	g := checkWorkflows(deps)
+
+	// Both workflow files must produce a Fail (not Warning) with a non-empty
+	// Remediation so that RepairPipeline can pick them up.
+	for _, wf := range []string{"agentic-pipeline.yml", "release.yml"} {
+		found := false
+		for _, r := range g.Results {
+			if r.Name == wf {
+				found = true
+				if r.Status != Fail {
+					t.Errorf("%s: got status %d, want Fail", wf, r.Status)
+				}
+				if r.Remediation == "" {
+					t.Errorf("%s: missing remediation hint", wf)
+				}
+				if !strings.Contains(r.Message, "not found") {
+					t.Errorf("%s: message %q should contain 'not found'", wf, r.Message)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("no result for %s", wf)
+		}
+	}
+}
+
 func TestCheckWorkflows_VersionMismatch(t *testing.T) {
 	root := t.TempDir()
 	setupAIGitRepo(t, filepath.Join(root, ".agents"), "v2.0.0")

--- a/internal/doctor/repair.go
+++ b/internal/doctor/repair.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/eddiecarpenter/gh-agentic/internal/auth"
@@ -293,11 +294,18 @@ var pendingDescriptions = map[string]struct {
 }
 
 // workflowRepairNames is the set of CheckResult names produced by checkWorkflows
-// that map to a workflow-tag mismatch (auto-fixable via UpdateWorkflowVersions).
+// that are auto-fixable by repair — either a missing file (scaffold) or a
+// version-tag mismatch (UpdateWorkflowVersions).
 var workflowRepairNames = map[string]bool{
 	"agentic-pipeline.yml": true,
 	"release.yml":          true,
 }
+
+// workflowMissingRemediation is the exact Remediation string that
+// checkWorkflows writes when a workflow file does not exist. RepairPipeline
+// uses it to distinguish "file absent" from "version tag mismatch" so the
+// two cases can be routed to their respective repair paths.
+const workflowMissingRemediation = "Run 'gh agentic repair'"
 
 // RepairPipeline runs all pipeline checks and attempts to auto-repair the
 // failures that are mechanically fixable. Failures that require human input
@@ -312,6 +320,7 @@ func RepairPipeline(deps CheckDeps, setLabel func(string)) RepairResult {
 	report := RunAllChecksWithProgress(deps, setLabel)
 
 	workflowRepairAttempted := false
+	workflowScaffoldAttempted := false
 
 	for _, g := range report.Groups {
 		for _, r := range g.Results {
@@ -361,6 +370,37 @@ func RepairPipeline(deps CheckDeps, setLabel func(string)) RepairResult {
 					result.Lines = append(result.Lines,
 						fmt.Sprintf("  %s  Label %s created",
 							ui.StatusOK.Render("✓"), r.Name))
+					result.Repaired++
+				}
+
+			case workflowRepairNames[r.Name] && r.Remediation == workflowMissingRemediation:
+				// Workflow file is absent — scaffold it (and any other missing
+				// workflow) in a single pass. One call to GenerateWorkflows
+				// writes both agentic-pipeline.yml and release.yml, so dedupe.
+				if workflowScaffoldAttempted {
+					continue
+				}
+				workflowScaffoldAttempted = true
+				if setLabel != nil {
+					setLabel("Repairing: scaffolding missing workflow files...")
+				}
+				version, verr := mount.ReadAIVersionFromGit(deps.Root)
+				if verr != nil || version == "" {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Cannot scaffold workflows: framework version unknown — run 'gh agentic mount' first",
+							ui.StatusDanger.Render("✗")))
+					result.Unrepaired++
+					continue
+				}
+				if err := mount.GenerateWorkflows(io.Discard, deps.Root, version); err != nil {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Could not scaffold workflow files: %v",
+							ui.StatusDanger.Render("✗"), err))
+					result.Unrepaired++
+				} else {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Wrapper workflows created at .github/workflows/ (version %s)",
+							ui.StatusOK.Render("✓"), mount.TrimVPrefix(version)))
 					result.Repaired++
 				}
 

--- a/internal/doctor/repair_test.go
+++ b/internal/doctor/repair_test.go
@@ -117,6 +117,59 @@ func TestRepairPipeline_FixesGitignoreAndWorkflowTags(t *testing.T) {
 	}
 }
 
+func TestRepairPipeline_ScaffoldsMissingWorkflows(t *testing.T) {
+	// Build a repo that has the framework mounted but no .github/workflows/
+	// directory at all — simulating a repo where init ran but the workflow
+	// scaffolding was skipped (the exact scenario the user reported).
+	root := t.TempDir()
+	setupAIGitRepo(t, filepath.Join(root, ".agents"), "v2.0.0")
+
+	// Framework files — enough to pass non-workflow checks.
+	_ = os.MkdirAll(filepath.Join(root, ".agents", "skills"), 0o755)
+	_ = os.WriteFile(filepath.Join(root, ".agents", "RULEBOOK.md"), []byte("# Rules"), 0o644)
+	_ = os.WriteFile(filepath.Join(root, ".gitignore"), []byte("node_modules/\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(root, "CLAUDE.md"), []byte("# CLAUDE.md\n@AGENTS.md"), 0o644)
+	_ = os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("# AGENTS.md\n@.agents/RULEBOOK.md"), 0o644)
+
+	deps := CheckDeps{
+		Root:         root,
+		RepoFullName: "owner/repo",
+		Owner:        "owner",
+		RepoName:     "repo",
+		OwnerType:    "User",
+		Topology:     "single",
+		Run:          fakeRunMissingVarsAndSecret,
+		ReadCreds:    func(run auth.RunCommandFunc) ([]byte, error) { return []byte(`{"token":"abc"}`), nil },
+	}
+
+	result := RepairPipeline(deps, nil)
+
+	// Both workflow files should now exist on disk.
+	for _, wf := range []string{"agentic-pipeline.yml", "release.yml"} {
+		path := filepath.Join(root, ".github", "workflows", wf)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("%s was not created by repair", wf)
+		}
+	}
+
+	// There should be exactly one scaffold success line (GenerateWorkflows
+	// writes both files in one call, so the repair loop dedupes).
+	scaffoldLines := 0
+	for _, l := range result.Lines {
+		if strings.Contains(l, "Wrapper workflows created") {
+			scaffoldLines++
+		}
+	}
+	if scaffoldLines != 1 {
+		t.Errorf("expected 1 scaffold success line, got %d (lines: %v)", scaffoldLines, result.Lines)
+	}
+
+	// The scaffold should count as one repair.
+	if result.Repaired < 1 {
+		t.Errorf("expected at least 1 repaired, got %d", result.Repaired)
+	}
+}
+
 // capturedGH holds every gh invocation a fake run function received, so
 // routing tests can assert exactly which scope flag/target was used.
 type capturedGH struct {

--- a/internal/mount/firsttime.go
+++ b/internal/mount/firsttime.go
@@ -49,7 +49,7 @@ func RunFirstTime(w io.Writer, root, version string, fetch CloneFunc) error {
 
 	// Step 4: Generate wrapper workflows.
 	fmt.Fprintln(w, "  ✓ Wrapper workflows created")
-	if err := generateWorkflows(w, root, version); err != nil {
+	if err := GenerateWorkflows(w, root, version); err != nil {
 		return fmt.Errorf("creating workflows: %w", err)
 	}
 
@@ -64,8 +64,10 @@ func RunFirstTime(w io.Writer, root, version string, fetch CloneFunc) error {
 	return nil
 }
 
-// generateWorkflows creates the wrapper workflow files in .github/workflows/.
-func generateWorkflows(w io.Writer, root, version string) error {
+// GenerateWorkflows creates the wrapper workflow files in .github/workflows/.
+// It is exported so that repair tooling can scaffold missing workflow files
+// without going through the full first-time mount flow.
+func GenerateWorkflows(w io.Writer, root, version string) error {
 	workflowsDir := filepath.Join(root, ".github", "workflows")
 	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
 		return fmt.Errorf("creating workflows directory: %w", err)

--- a/internal/mount/firsttime_test.go
+++ b/internal/mount/firsttime_test.go
@@ -177,7 +177,7 @@ func TestGenerateWorkflows_CreatesDirectory(t *testing.T) {
 	root := t.TempDir()
 	var buf bytes.Buffer
 
-	err := generateWorkflows(&buf, root, "v2.0.0")
+	err := GenerateWorkflows(&buf, root, "v2.0.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Missing `agentic-pipeline.yml` / `release.yml` previously reported as **Warning** with no remediation — both `gh agentic check` and `gh agentic repair` silently ignored them
- Now reported as **Fail** with `Remediation: "Run 'gh agentic repair'"` so the condition is visible in check output
- `gh agentic repair` now auto-scaffolds both workflow files when they are absent (calls `mount.GenerateWorkflows` in a single deduplicated pass)
- `mount.generateWorkflows` → `mount.GenerateWorkflows` (exported so repair can call it directly)

## Root cause

The repair loop skips `Warning` results unless they carry a variable/secret `gh variable set ...` or `gh secret set ...` remediation hint. Missing workflows had neither — so they were never acted on. The fix promotes missing-workflow results to `Fail` and adds a dedicated scaffold handler in `RepairPipeline`.

## Test plan
- [x] `TestCheckWorkflows_MissingFile_Fail` — both missing workflows produce `Fail` with `not found` message and non-empty remediation
- [x] `TestRepairPipeline_ScaffoldsMissingWorkflows` — repair creates both files on disk and counts as one `Repaired`
- [x] `go test ./...` — all green

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)