### PR TITLE
fix(install-ai-tools): use authenticated gh api to resolve Goose version

### DIFF
--- a/.github/actions/install-ai-tools/action.yml
+++ b/.github/actions/install-ai-tools/action.yml
@@ -74,9 +74,12 @@ runs:
       shell: bash
       env:
         INPUT_GOOSE_VERSION: ${{ inputs.goose-version }}
+        GH_TOKEN: ${{ inputs.gh-token }}
       run: |
         if [ "${INPUT_GOOSE_VERSION}" = "latest" ]; then
-          GOOSE_VERSION=$(curl --proto '=https' --tlsv1.2 -fsSL https://api.github.com/repos/block/goose/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
+          # Use gh api (authenticated via GH_TOKEN) to avoid the 60 req/hour
+          # unauthenticated rate limit that causes 403s on shared runner IPs.
+          GOOSE_VERSION=$(gh api repos/block/goose/releases/latest --jq '.tag_name' | sed 's/^v//')
         else
           GOOSE_VERSION="${INPUT_GOOSE_VERSION}"
         fi


### PR DESCRIPTION
## Summary

- Replaces the unauthenticated `curl https://api.github.com/repos/block/goose/releases/latest` in the "Resolve Goose version" step with `gh api repos/block/goose/releases/latest --jq '.tag_name'`
- Passes `GH_TOKEN: ${{ inputs.gh-token }}` to the step env so `gh api` is authenticated
- Unauthenticated GitHub API requests are rate-limited to 60/hour per IP — self-hosted runners sharing an IP exhaust this quickly, producing `curl: (22) The requested URL returned error: 403` and failing the Install tools step

Root cause confirmed in yapper run `26257014687` (Compliance Verify / Feature #12) — the log shows the exact error immediately after the `Install system packages` step completes successfully.

## Test plan
- [ ] All existing tests pass (`go test ./...`)
- [ ] Trigger a pipeline run on a self-hosted runner and confirm the "Resolve Goose version" step no longer 403s

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)