### PR TITLE
fix(pipeline): expose GOOSE_VERSION repo variable to pin Goose version

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -143,6 +143,7 @@ jobs:
         uses: ./.agents/.github/actions/install-ai-tools
         with:
           agentic-version: ${{ steps.version.outputs.version }}
+          goose-version: ${{ vars.GOOSE_VERSION || 'latest' }}
           gh-token: ${{ github.token }}
 
       - name: Setup Agent Auth
@@ -426,6 +427,7 @@ jobs:
         uses: ./.agents/.github/actions/install-ai-tools
         with:
           agentic-version: ${{ steps.version.outputs.version }}
+          goose-version: ${{ vars.GOOSE_VERSION || 'latest' }}
           agent-provider: ${{ vars.AGENT_PROVIDER }}
           gh-token: ${{ github.token }}
 
@@ -621,6 +623,7 @@ jobs:
         with:
           agentic-version: ${{ steps.version.outputs.version }}
           gh-token: ${{ github.token }}
+          goose-version: ${{ vars.GOOSE_VERSION || 'latest' }}
 
       - name: Setup Agent Auth
         uses: ./.agents/.github/actions/setup-agent-auth
@@ -864,6 +867,7 @@ jobs:
         with:
           agentic-version: ${{ steps.version.outputs.version }}
           gh-token: ${{ github.token }}
+          goose-version: ${{ vars.GOOSE_VERSION || 'latest' }}
 
       - name: Setup Agent Auth
         uses: ./.agents/.github/actions/setup-agent-auth
@@ -973,6 +977,7 @@ jobs:
         uses: ./.agents/.github/actions/install-ai-tools
         with:
           agentic-version: ${{ steps.version.outputs.version }}
+          goose-version: ${{ vars.GOOSE_VERSION || 'latest' }}
           gh-token: ${{ github.token }}
 
       - name: Setup Agent Auth


### PR DESCRIPTION
## Summary

- Adds `goose-version: ${{ vars.GOOSE_VERSION || 'latest' }}` to all five `install-ai-tools` call sites in the pipeline
- Operators can now set `GOOSE_VERSION=1.34.1` as a repo variable to pin Goose without a framework update
- Defaults to `latest` so repos without the variable are unchanged in normal operation

## Why now

Goose 1.35.0 was released at 00:42 today and immediately broke the `claude-code` provider — every `goose run` starts, says "goose is ready," then silently exits in ~1.2 seconds with zero output and exit code 0. All agent pipeline stages (Feature Design, Dev Session, Compliance Verify, etc.) have been producing empty runs since then.

Fix confirmed: set `GOOSE_VERSION=1.34.1` in the affected repo until Goose ships a 1.35.x patch.

## Test plan
- [ ] All tests pass (`go test ./...`)
- [ ] Set `GOOSE_VERSION=1.34.1` in yapper and confirm the next pipeline run produces real agent output

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)