### PR TITLE
fix: add actions:read permission to all Goose-running pipeline jobs

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -98,6 +98,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      actions: read
 
     steps:
       - name: Checkout domain repo
@@ -363,6 +364,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      actions: read
 
     steps:
       - name: Resolve feature branch
@@ -818,6 +820,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: read
     concurrency:
       group: pr-review-${{ github.event.pull_request.number || inputs.pr_number || github.event.inputs.pr_number }}
       cancel-in-progress: false
@@ -929,6 +932,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      actions: read
     concurrency:
       group: issue-${{ github.event.issue.number }}
       cancel-in-progress: false
@@ -1071,6 +1075,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      actions: read
 
     steps:
       - name: Extract feature issue number


### PR DESCRIPTION
## Root Cause

The `gh agentic` CLI reads `AGENTIC_PROJECT_ID` via the GitHub REST API at runtime (`GET /repos/{owner}/{repo}/actions/variables/{name}`). All five pipeline jobs that invoke Goose recipes declared explicit `permissions:` blocks without `actions: read`, which scopes `github.token` down to only the listed permissions.

Result: the variable read returned 403/empty at runtime, the CLI silently left `ProjectID` blank, and every Goose session aborted immediately with:
```
AGENTIC_PROJECT_ID is not set for this repository.
```

This was the cause of the pipeline never doing real work in yapper — `AGENTIC_PROJECT_ID` was correctly set as a repo variable, but the token couldn't read it.

Note: `${{ vars.AGENTIC_PROJECT_ID }}` in workflow expressions works because GitHub resolves those at workflow-compile time, before job execution and token scoping. The CLI's runtime REST call is a different code path that needs the explicit permission.

## Fix

Add `actions: read` to the five jobs that run Goose recipes:
- Feature Design (Stage 3)
- Dev Session (Stage 4)
- PR Review Session (Stage 6)
- Issue Session (Stage 4c)
- Feature Complete (Stage 7)

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)