### PR TITLE
fix(pipeline): configure gh auth before Goose so go-gh can resolve token

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -156,12 +156,19 @@ jobs:
           gh-token: ${{ secrets.PIPELINE_PAT }}
 
       - name: Configure Goose
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p ~/.config/goose
           cat > ~/.config/goose/config.yaml <<GOOSEEOF
           GOOSE_PROVIDER: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
           GOOSE_MODEL: ${{ vars.AGENT_MODEL || 'default' }}
           GOOSEEOF
+          # Persist gh auth so that go-gh (used by `gh agentic` inside the Goose
+          # session) can resolve the token from gh's config file rather than relying
+          # on GH_TOKEN propagating through Goose's subprocess environment — which
+          # is not guaranteed for all Goose/Claude Code versions.
+          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run feature-design recipe
         run: |
@@ -456,12 +463,19 @@ jobs:
           git push origin HEAD:${{ steps.branch.outputs.name }} --force-with-lease
 
       - name: Configure Goose
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p ~/.config/goose
           cat > ~/.config/goose/config.yaml <<GOOSEEOF
           GOOSE_PROVIDER: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
           GOOSE_MODEL: ${{ vars.AGENT_MODEL || 'default' }}
           GOOSEEOF
+          # Persist gh auth so that go-gh (used by `gh agentic` inside the Goose
+          # session) can resolve the token from gh's config file rather than relying
+          # on GH_TOKEN propagating through Goose's subprocess environment — which
+          # is not guaranteed for all Goose/Claude Code versions.
+          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run dev-session recipe
         id: goose
@@ -636,12 +650,19 @@ jobs:
           gh-token: ${{ secrets.PIPELINE_PAT }}
 
       - name: Configure Goose
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p ~/.config/goose
           cat > ~/.config/goose/config.yaml <<GOOSEEOF
           GOOSE_PROVIDER: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
           GOOSE_MODEL: ${{ vars.AGENT_MODEL || 'default' }}
           GOOSEEOF
+          # Persist gh auth so that go-gh (used by `gh agentic` inside the Goose
+          # session) can resolve the token from gh's config file rather than relying
+          # on GH_TOKEN propagating through Goose's subprocess environment — which
+          # is not guaranteed for all Goose/Claude Code versions.
+          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run compliance-verify recipe
         run: |
@@ -881,12 +902,19 @@ jobs:
           gh-token: ${{ secrets.PIPELINE_PAT }}
 
       - name: Configure Goose
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p ~/.config/goose
           cat > ~/.config/goose/config.yaml <<GOOSEEOF
           GOOSE_PROVIDER: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
           GOOSE_MODEL: ${{ vars.AGENT_MODEL || 'default' }}
           GOOSEEOF
+          # Persist gh auth so that go-gh (used by `gh agentic` inside the Goose
+          # session) can resolve the token from gh's config file rather than relying
+          # on GH_TOKEN propagating through Goose's subprocess environment — which
+          # is not guaranteed for all Goose/Claude Code versions.
+          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run PR review recipe
         env:
@@ -993,12 +1021,19 @@ jobs:
           gh-token: ${{ secrets.PIPELINE_PAT }}
 
       - name: Configure Goose
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p ~/.config/goose
           cat > ~/.config/goose/config.yaml <<GOOSEEOF
           GOOSE_PROVIDER: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
           GOOSE_MODEL: ${{ vars.AGENT_MODEL || 'default' }}
           GOOSEEOF
+          # Persist gh auth so that go-gh (used by `gh agentic` inside the Goose
+          # session) can resolve the token from gh's config file rather than relying
+          # on GH_TOKEN propagating through Goose's subprocess environment — which
+          # is not guaranteed for all Goose/Claude Code versions.
+          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run issue session recipe
         run: |


### PR DESCRIPTION
## Root Cause

`gh agentic` uses `go-gh`'s `api.DefaultRESTClient()` to read `AGENTIC_PROJECT_ID` from the GitHub Variables API at runtime. The token is resolved via `auth.TokenForHost()`, which checks `GH_TOKEN` in the environment first, then falls back to gh's config file (`~/.config/gh/hosts.yml`).

On ephemeral runners (no persistent `HOME`), `GH_TOKEN` is set on the `goose run` step but **is not guaranteed to propagate** through Goose → Claude Code's subprocess environment. When the token isn't found, `resolveOptions` returns `"authentication token not found for host github.com"` — an error that is silently swallowed in `project.Resolve`, leaving `ProjectID` empty and every `gh agentic status feature N --raw` call failing with "AGENTIC_PROJECT_ID is not set."

The reference implementation (charging-domain) avoids this by running on a persistent runner home with `gh auth login` pre-configured. Ephemeral runners don't have that luxury.

## Fix

Add `echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com` to all five `Configure Goose` steps. This runs **before** `goose run` and writes the token to `~/.config/gh/hosts.yml`, where `go-gh`'s config resolver picks it up independently of whether `GH_TOKEN` propagates through Goose's subprocess tree.

The `GH_TOKEN: ${{ github.token }}` env is also explicitly set on each `Configure Goose` step (previously it was only on the `goose run` step).

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)