### PR TITLE
fix(pipeline): unset GH_TOKEN before gh auth login --with-token

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -168,7 +168,11 @@ jobs:
           # session) can resolve the token from gh's config file rather than relying
           # on GH_TOKEN propagating through Goose's subprocess environment — which
           # is not guaranteed for all Goose/Claude Code versions.
-          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
+          # gh auth login --with-token refuses to write to config when GH_TOKEN is
+          # set in the environment ("first clear the value"), so we save and unset it.
+          _TOKEN="${GH_TOKEN}"
+          unset GH_TOKEN
+          echo "${_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run feature-design recipe
         run: |
@@ -475,7 +479,11 @@ jobs:
           # session) can resolve the token from gh's config file rather than relying
           # on GH_TOKEN propagating through Goose's subprocess environment — which
           # is not guaranteed for all Goose/Claude Code versions.
-          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
+          # gh auth login --with-token refuses to write to config when GH_TOKEN is
+          # set in the environment ("first clear the value"), so we save and unset it.
+          _TOKEN="${GH_TOKEN}"
+          unset GH_TOKEN
+          echo "${_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run dev-session recipe
         id: goose
@@ -662,7 +670,11 @@ jobs:
           # session) can resolve the token from gh's config file rather than relying
           # on GH_TOKEN propagating through Goose's subprocess environment — which
           # is not guaranteed for all Goose/Claude Code versions.
-          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
+          # gh auth login --with-token refuses to write to config when GH_TOKEN is
+          # set in the environment ("first clear the value"), so we save and unset it.
+          _TOKEN="${GH_TOKEN}"
+          unset GH_TOKEN
+          echo "${_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run compliance-verify recipe
         run: |
@@ -914,7 +926,11 @@ jobs:
           # session) can resolve the token from gh's config file rather than relying
           # on GH_TOKEN propagating through Goose's subprocess environment — which
           # is not guaranteed for all Goose/Claude Code versions.
-          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
+          # gh auth login --with-token refuses to write to config when GH_TOKEN is
+          # set in the environment ("first clear the value"), so we save and unset it.
+          _TOKEN="${GH_TOKEN}"
+          unset GH_TOKEN
+          echo "${_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run PR review recipe
         env:
@@ -1033,7 +1049,11 @@ jobs:
           # session) can resolve the token from gh's config file rather than relying
           # on GH_TOKEN propagating through Goose's subprocess environment — which
           # is not guaranteed for all Goose/Claude Code versions.
-          echo "${GH_TOKEN}" | gh auth login --with-token --hostname github.com
+          # gh auth login --with-token refuses to write to config when GH_TOKEN is
+          # set in the environment ("first clear the value"), so we save and unset it.
+          _TOKEN="${GH_TOKEN}"
+          unset GH_TOKEN
+          echo "${_TOKEN}" | gh auth login --with-token --hostname github.com
 
       - name: Run issue session recipe
         run: |


### PR DESCRIPTION
## Problem

The v2.8.10 fix added `gh auth login --with-token` to persist auth to gh's config file before Goose runs. But `gh auth login --with-token` exits 1 when `GH_TOKEN` is already present in the environment:

```
The value of the GH_TOKEN environment variable is being used for authentication.
To have GitHub CLI store credentials instead, first clear the value from the environment.
Error: exit status 1
```

This caused the Configure Goose step to fail before Goose even started.

## Fix

Save the token to a local shell variable, unset `GH_TOKEN`, then pipe it to `gh auth login --with-token`. The token gets written to `~/.config/gh/hosts.yml` where `go-gh`'s `tokenForHost` can find it regardless of whether `GH_TOKEN` propagates through Goose's subprocess tree.

```bash
_TOKEN="${GH_TOKEN}"
unset GH_TOKEN
echo "${_TOKEN}" | gh auth login --with-token --hostname github.com
```

Applied to all five Configure Goose steps.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)