### PR TITLE
standard(go): mandate build+test verification gate at dev/compliance boundaries

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -271,7 +271,9 @@ jobs:
       # Resolve the branch name before checkout so the checkout ref is known.
       # Inline (not a composite action) because the workspace has no checkout yet —
       # local composite actions require the submodule tree to be on disk first.
-      # github.token is sufficient — read-only branches list query.
+      # Uses curl+jq (not gh) because gh is installed by setup-goose-env which
+      # runs after checkout — self-hosted runners do not have gh pre-installed.
+      # Paginated: fetches up to 100 branches per page until branch found or exhausted.
       - name: Resolve feature branch
         id: branch
         env:
@@ -279,10 +281,18 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: |
-          BRANCH=$(gh api "repos/${REPO}/branches" --paginate \
-            --jq '.[].name' \
-            | grep "^feature/${ISSUE}-" \
-            | head -1)
+          PAGE=1
+          BRANCH=""
+          while [ -z "${BRANCH}" ]; do
+            RESPONSE=$(curl --proto '=https' --tlsv1.2 -fsSL \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/branches?per_page=100&page=${PAGE}")
+            BRANCH=$(echo "${RESPONSE}" | jq -r '.[].name' | grep "^feature/${ISSUE}-" | head -1 || true)
+            COUNT=$(echo "${RESPONSE}" | jq '. | length')
+            [ "${COUNT}" -lt 100 ] && break
+            PAGE=$((PAGE + 1))
+          done
           if [ -z "${BRANCH}" ]; then
             echo "::error::No branch matching feature/${ISSUE}-* found in ${REPO}."
             exit 1
@@ -416,7 +426,8 @@ jobs:
       actions: read
 
     steps:
-      # Inline (not composite action) — workspace not yet checked out here.
+      # Inline curl+jq (not gh) — workspace not yet checked out here and
+      # gh is not pre-installed on self-hosted runners.
       - name: Resolve feature branch
         id: branch
         env:
@@ -424,10 +435,18 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: |
-          BRANCH=$(gh api "repos/${REPO}/branches" --paginate \
-            --jq '.[].name' \
-            | grep "^feature/${ISSUE}-" \
-            | head -1)
+          PAGE=1
+          BRANCH=""
+          while [ -z "${BRANCH}" ]; do
+            RESPONSE=$(curl --proto '=https' --tlsv1.2 -fsSL \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/branches?per_page=100&page=${PAGE}")
+            BRANCH=$(echo "${RESPONSE}" | jq -r '.[].name' | grep "^feature/${ISSUE}-" | head -1 || true)
+            COUNT=$(echo "${RESPONSE}" | jq '. | length')
+            [ "${COUNT}" -lt 100 ] && break
+            PAGE=$((PAGE + 1))
+          done
           if [ -z "${BRANCH}" ]; then
             echo "::error::No branch matching feature/${ISSUE}-* found in ${REPO}."
             exit 1

--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -823,6 +823,30 @@ jobs:
       actions: read
 
     steps:
+      # Checkout + setup-goose-env: required because (a) gh is invoked below
+      # and is not pre-installed on self-hosted runners, and (b) set-project-status
+      # is a local composite action that requires the .agents/ submodule on disk.
+      # Stage 7 does not run Goose itself but reuses the same setup primitive
+      # for consistency with every other stage.
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 1
+          submodules: recursive
+          token: ${{ github.token }}
+
+      - name: Setup Goose environment
+        uses: ./.agents/.github/actions/setup-goose-env
+        with:
+          agentic-framework-version: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+          goose-version: ${{ vars.GOOSE_VERSION || 'latest' }}
+          agent-provider: ${{ vars.AGENT_PROVIDER || 'claude-code' }}
+          agent-model: ${{ vars.AGENT_MODEL || 'default' }}
+          pipeline-pat: ${{ secrets.PIPELINE_PAT }}
+          claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
+          mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
+
       - name: Extract feature issue number
         id: feature
         env:

--- a/internal/mount/pipeline_scripts_exec_test.go
+++ b/internal/mount/pipeline_scripts_exec_test.go
@@ -1,0 +1,506 @@
+package mount
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Layer 3 — execute the deterministic run: blocks against stubbed
+// external binaries (gh, curl) and assert their behaviour.
+//
+// We cannot exercise the Goose-running steps (they shell out to
+// `goose run` which calls Claude) nor the steps that depend on a
+// real GitHub API surface for non-deterministic data. But the glue
+// around them — branch-name parsing, label-decision logic, paginated
+// curl branch lookup, parent-requirement extraction — is pure logic
+// and deserves execution coverage so a typo doesn't survive to a
+// live pipeline failure.
+
+// scriptByName extracts a single run: block matching the given
+// job-id and step-name from agentic-pipeline.yml. Fails the test if
+// no match.
+func scriptByName(t *testing.T, jobID, stepName string) string {
+	t.Helper()
+	path := reusableWorkflowPath(t)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	jobs := doc["jobs"].(map[string]any)
+	job, ok := jobs[jobID].(map[string]any)
+	if !ok {
+		t.Fatalf("no job %q in workflow", jobID)
+	}
+	steps := job["steps"].([]any)
+	for _, s := range steps {
+		m := s.(map[string]any)
+		name, _ := m["name"].(string)
+		if name == stepName {
+			run, _ := m["run"].(string)
+			if run == "" {
+				t.Fatalf("step %q has no run: block", stepName)
+			}
+			return run
+		}
+	}
+	t.Fatalf("no step named %q in job %q", stepName, jobID)
+	return ""
+}
+
+// substituteExpr replaces every ${{ key }} occurrence with the value
+// from subs. Keys must match the inner trimmed text of the expression
+// (e.g. "github.event.issue.number"). Unmatched expressions are left
+// in place — the caller should provide every value the script reads
+// or the script will crash.
+func substituteExpr(script string, subs map[string]string) string {
+	for key, val := range subs {
+		marker := "${{ " + key + " }}"
+		script = strings.ReplaceAll(script, marker, val)
+	}
+	return script
+}
+
+// runScript executes a bash script with the given env and a PATH
+// rooted at stubDir. Returns stdout, stderr, exit code.
+//
+// The PATH includes stubDir first (so stubs win), then /usr/bin and /bin
+// for universal POSIX tools, then any extra directories needed for tools
+// whose feature set diverges across platforms (e.g. grep -P needs GNU
+// grep, which is at /opt/homebrew/bin on macOS).
+func runScript(t *testing.T, script, stubDir string, env map[string]string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command("bash", "-c", script)
+	// Empty environment + curated stubs only — no pollution from the
+	// developer's shell.
+	// On macOS, homebrew GNU tool variants (notably GNU grep with -P
+	// support) live at /opt/homebrew/bin. We put them BEFORE /usr/bin so
+	// our test environment behaves like a Linux runner — the workflow
+	// targets Linux, so testing against Linux-compatible tools is the
+	// honest test. On Linux these directories are usually absent;
+	// including them is harmless.
+	pathDirs := []string{stubDir, "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"}
+	cmd.Env = []string{
+		"PATH=" + strings.Join(pathDirs, ":"),
+		"HOME=" + t.TempDir(),
+	}
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	stdout := &strings.Builder{}
+	stderr := &strings.Builder{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		} else {
+			t.Fatalf("script execution error: %v", err)
+		}
+	}
+	return stdout.String(), stderr.String(), code
+}
+
+// writeStub creates an executable shell script at stubDir/name with
+// the given body.
+func writeStub(t *testing.T, stubDir, name, body string) {
+	t.Helper()
+	path := filepath.Join(stubDir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/bash\n"+body), 0o755); err != nil {
+		t.Fatalf("write stub %s: %v", path, err)
+	}
+}
+
+// stubDir creates a temp dir for stubs and a GITHUB_OUTPUT file.
+func makeStubDir(t *testing.T) (string, string) {
+	t.Helper()
+	stubDir := t.TempDir()
+	githubOutput := filepath.Join(t.TempDir(), "github_output")
+	if err := os.WriteFile(githubOutput, nil, 0o644); err != nil {
+		t.Fatalf("create GITHUB_OUTPUT: %v", err)
+	}
+	return stubDir, githubOutput
+}
+
+// readOutput reads the GITHUB_OUTPUT file into a map.
+func readOutput(t *testing.T, path string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read GITHUB_OUTPUT: %v", err)
+	}
+	out := map[string]string{}
+	for _, line := range strings.Split(string(data), "\n") {
+		if i := strings.Index(line, "="); i > 0 {
+			out[line[:i]] = line[i+1:]
+		}
+	}
+	return out
+}
+
+// -------------------------------------------------------------------
+// Test: feature-complete "Extract feature issue number"
+//
+// Pure sed parsing — no external dependencies. The only thing that
+// can go wrong is a regex typo.
+// -------------------------------------------------------------------
+
+func TestExtractFeatureIssueNumber(t *testing.T) {
+	script := scriptByName(t, "feature-complete", "Extract feature issue number")
+
+	cases := []struct {
+		name    string
+		branch  string
+		want    string
+	}{
+		{"simple", "feature/42-add-login", "42"},
+		{"multi-word", "feature/123-some-complex-description", "123"},
+		{"single-digit", "feature/7-x", "7"},
+		{"large-number", "feature/99999-x", "99999"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubDir, ghOut := makeStubDir(t)
+			env := map[string]string{
+				"PR_HEAD_REF":   tc.branch,
+				"GITHUB_OUTPUT": ghOut,
+			}
+			_, stderr, code := runScript(t, script, stubDir, env)
+			if code != 0 {
+				t.Fatalf("script exited %d: %s", code, stderr)
+			}
+			out := readOutput(t, ghOut)
+			if got := out["issue_number"]; got != tc.want {
+				t.Errorf("issue_number = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// -------------------------------------------------------------------
+// Test: dev-session "Resolve feature branch"
+//
+// Calls curl against the GitHub API and parses the JSON branch list
+// with jq. Mock curl to return a fixed JSON payload; verify the script
+// extracts the right branch name.
+// -------------------------------------------------------------------
+
+func TestResolveFeatureBranch_HappyPath(t *testing.T) {
+	script := scriptByName(t, "dev-session", "Resolve feature branch")
+
+	stubDir, ghOut := makeStubDir(t)
+	// curl stub returns a JSON branch list when page=1; empty page=2.
+	writeStub(t, stubDir, "curl", `
+# Last arg is the URL. Extract the page query parameter.
+URL="${@: -1}"
+case "$URL" in
+  *\&page=1)
+    cat <<'JSON'
+[
+  {"name": "main"},
+  {"name": "feature/41-other-thing"},
+  {"name": "feature/42-add-login"},
+  {"name": "develop"}
+]
+JSON
+    ;;
+  *\&page=2)
+    echo '[]'
+    ;;
+esac
+`)
+	// jq is real (universal command).
+
+	env := map[string]string{
+		"GH_TOKEN":      "stub-token",
+		"REPO":          "owner/repo",
+		"ISSUE":         "42",
+		"GITHUB_OUTPUT": ghOut,
+	}
+	stdout, stderr, code := runScript(t, script, stubDir, env)
+	if code != 0 {
+		t.Fatalf("script exited %d: stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	out := readOutput(t, ghOut)
+	if got, want := out["name"], "feature/42-add-login"; got != want {
+		t.Errorf("name = %q, want %q (stdout=%q)", got, want, stdout)
+	}
+}
+
+func TestResolveFeatureBranch_NoMatch(t *testing.T) {
+	script := scriptByName(t, "dev-session", "Resolve feature branch")
+
+	stubDir, ghOut := makeStubDir(t)
+	writeStub(t, stubDir, "curl", `
+URL="${@: -1}"
+case "$URL" in
+  *\&page=1)
+    cat <<'JSON'
+[
+  {"name": "main"},
+  {"name": "feature/41-other-thing"},
+  {"name": "develop"}
+]
+JSON
+    ;;
+  *\&page=2)
+    echo '[]'
+    ;;
+esac
+`)
+
+	env := map[string]string{
+		"GH_TOKEN":      "stub-token",
+		"REPO":          "owner/repo",
+		"ISSUE":         "999", // no branch matches
+		"GITHUB_OUTPUT": ghOut,
+	}
+	stdout, stderr, code := runScript(t, script, stubDir, env)
+	if code == 0 {
+		t.Errorf("expected non-zero exit when no branch found, got 0")
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "No branch matching feature/999-* found") {
+		t.Errorf("expected ::error:: message about missing branch, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+// Verifies the paginated loop: branch found on page 2 of 2.
+func TestResolveFeatureBranch_PaginatedHit(t *testing.T) {
+	script := scriptByName(t, "dev-session", "Resolve feature branch")
+
+	stubDir, ghOut := makeStubDir(t)
+	writeStub(t, stubDir, "curl", `
+URL="${@: -1}"
+case "$URL" in
+  *\&page=1)
+    # 100 branches, none matching → triggers pagination.
+    echo -n '['
+    for i in $(seq 1 99); do
+      printf '{"name":"feat-%s"},' "$i"
+    done
+    printf '{"name":"feat-100"}'
+    echo ']'
+    ;;
+  *\&page=2)
+    echo '[{"name":"feature/77-found-it"}]'
+    ;;
+esac
+`)
+
+	env := map[string]string{
+		"GH_TOKEN":      "stub-token",
+		"REPO":          "owner/repo",
+		"ISSUE":         "77",
+		"GITHUB_OUTPUT": ghOut,
+	}
+	stdout, stderr, code := runScript(t, script, stubDir, env)
+	if code != 0 {
+		t.Fatalf("script exited %d: stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	out := readOutput(t, ghOut)
+	if got, want := out["name"], "feature/77-found-it"; got != want {
+		t.Errorf("name = %q, want %q", got, want)
+	}
+}
+
+// -------------------------------------------------------------------
+// Test: feature-complete "Parse parent requirement"
+//
+// Grep -P parses "Closes #N" / "Closes owner/repo#N" /
+// "Closes part of owner/repo#N" from the issue body. The regex is
+// non-trivial; this test pins the supported syntaxes.
+// -------------------------------------------------------------------
+
+// hostHasGNUGrep returns true if `grep -P` is supported on the host —
+// production runners (Linux) always have it; macOS without homebrew GNU
+// grep does not.
+func hostHasGNUGrep() bool {
+	cmd := exec.Command("grep", "-oP", `\d+`)
+	cmd.Stdin = strings.NewReader("x 1")
+	return cmd.Run() == nil
+}
+
+func TestParseParentRequirement(t *testing.T) {
+	if !hostHasGNUGrep() {
+		t.Skip("grep -P (PCRE) not supported on host — install GNU grep " +
+			"to exercise this test locally. The workflow targets Linux runners " +
+			"which always have GNU grep; this is purely a developer-machine skip.")
+	}
+	script := scriptByName(t, "feature-complete", "Parse parent requirement")
+
+	cases := []struct {
+		name        string
+		issueBody   string
+		ghLabels    string // label list returned by `gh issue view PARENT --json labels`
+		wantParent  string
+	}{
+		{
+			name:       "closes-N",
+			issueBody:  "Closes #42\n\nSome other text",
+			ghLabels:   "requirement\nbacklog",
+			wantParent: "42",
+		},
+		{
+			name:       "closes-cross-repo",
+			issueBody:  "Closes eddiecarpenter/gh-agentic#123",
+			ghLabels:   "requirement",
+			wantParent: "123",
+		},
+		{
+			name:       "closes-part-of",
+			issueBody:  "Closes part of eddiecarpenter/gh-agentic#777",
+			ghLabels:   "requirement",
+			wantParent: "777",
+		},
+		{
+			name:       "no-closes",
+			issueBody:  "This issue is unrelated to any requirement.",
+			ghLabels:   "",
+			wantParent: "", // step exits cleanly without writing requirement_number
+		},
+		{
+			name:       "not-a-requirement-label",
+			issueBody:  "Closes #42",
+			ghLabels:   "bug\nfeature", // no "requirement" label on parent
+			wantParent: "",              // step exits cleanly without writing requirement_number
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubDir, ghOut := makeStubDir(t)
+			// gh stub: handles both `gh issue view N --json body` and
+			// `gh issue view N --json labels`.
+			writeStub(t, stubDir, "gh", `
+# Look for --json body or --json labels.
+ARGS="$@"
+if echo "$ARGS" | grep -q -- '--json body'; then
+  cat <<'BODY'
+`+tc.issueBody+`
+BODY
+elif echo "$ARGS" | grep -q -- '--json labels'; then
+  printf '%s\n' '`+tc.ghLabels+`'
+else
+  echo "stub gh: unhandled args: $ARGS" >&2
+  exit 1
+fi
+`)
+
+			env := map[string]string{
+				"GH_TOKEN":      "stub-token",
+				"REPO":          "owner/repo",
+				"AGENTIC_REPO":  "owner/repo",
+				"GITHUB_OUTPUT": ghOut,
+			}
+			// The step references ${{ steps.feature.outputs.issue_number }}.
+			// Substitute that with "1" (the feature issue number, doesn't matter
+			// for this test).
+			sub := substituteExpr(script, map[string]string{
+				"steps.feature.outputs.issue_number": "1",
+			})
+			stdout, stderr, code := runScript(t, sub, stubDir, env)
+			if code != 0 {
+				t.Fatalf("script exited %d: stdout=%s stderr=%s", code, stdout, stderr)
+			}
+			out := readOutput(t, ghOut)
+			if got := out["requirement_number"]; got != tc.wantParent {
+				t.Errorf("requirement_number = %q, want %q", got, tc.wantParent)
+			}
+		})
+	}
+}
+
+// -------------------------------------------------------------------
+// Test: dev-session "Apply in-verification label" — skip path
+//
+// When the dev session produced no commits (git rev-list --count = 0),
+// the step must NOT apply the label and must write skipped=true.
+// -------------------------------------------------------------------
+
+func TestApplyInVerification_SkipWhenNoCommits(t *testing.T) {
+	script := scriptByName(t, "dev-session", "Apply in-verification label")
+
+	stubDir, ghOut := makeStubDir(t)
+	// git rev-list returns 0
+	writeStub(t, stubDir, "git", `
+if [ "$1" = "rev-list" ]; then echo 0; fi
+`)
+	// gh should NEVER be called in skip path
+	writeStub(t, stubDir, "gh", `
+echo "ERROR: gh was called in skip path with: $@" >&2
+exit 99
+`)
+
+	env := map[string]string{
+		"GH_TOKEN":      "stub-token",
+		"GITHUB_OUTPUT": ghOut,
+	}
+	// substitute ${{ github.event.issue.number }} → 42
+	sub := substituteExpr(script, map[string]string{
+		"github.event.issue.number": "42",
+	})
+	stdout, stderr, code := runScript(t, sub, stubDir, env)
+	if code != 0 {
+		t.Fatalf("script exited %d: stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	out := readOutput(t, ghOut)
+	if got, want := out["skipped"], "true"; got != want {
+		t.Errorf("skipped = %q, want %q", got, want)
+	}
+	if !strings.Contains(stdout, "No commits") {
+		t.Errorf("expected 'No commits' message, got stdout=%q", stdout)
+	}
+}
+
+// Happy path: commits exist, gh is invoked with the expected args, skipped=false.
+func TestApplyInVerification_HappyPath(t *testing.T) {
+	script := scriptByName(t, "dev-session", "Apply in-verification label")
+
+	stubDir, ghOut := makeStubDir(t)
+	writeStub(t, stubDir, "git", `
+if [ "$1" = "rev-list" ]; then echo 3; fi
+`)
+	// Capture gh args to a file for assertion.
+	ghLog := filepath.Join(t.TempDir(), "gh.log")
+	writeStub(t, stubDir, "gh", `echo "$@" >> `+ghLog+`
+`)
+
+	env := map[string]string{
+		"GH_TOKEN":      "stub-token",
+		"GITHUB_OUTPUT": ghOut,
+	}
+	sub := substituteExpr(script, map[string]string{
+		"github.event.issue.number": "42",
+	})
+	stdout, stderr, code := runScript(t, sub, stubDir, env)
+	if code != 0 {
+		t.Fatalf("script exited %d: stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	out := readOutput(t, ghOut)
+	if got, want := out["skipped"], "false"; got != want {
+		t.Errorf("skipped = %q, want %q", got, want)
+	}
+	logData, _ := os.ReadFile(ghLog)
+	logStr := string(logData)
+	if !strings.Contains(logStr, "issue edit 42") {
+		t.Errorf("gh log did not include 'issue edit 42': %s", logStr)
+	}
+	if !strings.Contains(logStr, "--remove-label in-development") {
+		t.Errorf("gh log did not include '--remove-label in-development': %s", logStr)
+	}
+	if !strings.Contains(logStr, "--add-label in-verification") {
+		t.Errorf("gh log did not include '--add-label in-verification': %s", logStr)
+	}
+}

--- a/internal/mount/pipeline_scripts_test.go
+++ b/internal/mount/pipeline_scripts_test.go
@@ -1,0 +1,240 @@
+package mount
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Pipeline run-block execution tests.
+//
+// Extracts every `run:` block from the reusable workflow + every
+// composite action, and exercises them in three layers:
+//
+//   Layer 1 — bash -n: every script parses as valid bash.
+//   Layer 2 — shellcheck: deeper static analysis of every script.
+//             Errors fail the test; informational warnings (SC2086 etc.)
+//             are surfaced but do not fail.
+//   Layer 3 — execution: a subset of deterministic scripts (branch
+//             extraction, label-decision, etc.) are run against stubbed
+//             gh / curl / git binaries to assert their behaviour.
+//
+// Layer 3 cannot cover the Goose-running steps (they invoke `goose run`
+// against Claude) or the steps that depend on a real GitHub API surface.
+// Those are exercised by the live pipeline; the unit-level coverage
+// here is for the deterministic glue around them.
+
+// extractRunBlocks walks the workflow YAML and returns every `run:`
+// block with a context label (job-or-action / step-name).
+func extractRunBlocks(t *testing.T, path string) []runBlock {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	// Generic YAML decoding — we use map[string]any so the function works
+	// for both reusable workflows (jobs.X.steps) and composite actions
+	// (runs.steps).
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var out []runBlock
+
+	// Reusable-workflow shape: jobs.<id>.steps[]
+	if jobs, ok := doc["jobs"].(map[string]any); ok {
+		for jobID, job := range jobs {
+			steps := stepsOf(job)
+			for i, step := range steps {
+				if s := runOf(step); s != "" {
+					out = append(out, runBlock{
+						Context: "jobs/" + jobID + "/" + stepName(step, i),
+						Script:  s,
+					})
+				}
+			}
+		}
+	}
+
+	// Composite-action shape: runs.steps[]
+	if runs, ok := doc["runs"].(map[string]any); ok {
+		if steps, ok := runs["steps"].([]any); ok {
+			for i, step := range steps {
+				if s := runOf(step); s != "" {
+					out = append(out, runBlock{
+						Context: filepath.Base(filepath.Dir(path)) + "/" + stepName(step, i),
+						Script:  s,
+					})
+				}
+			}
+		}
+	}
+
+	return out
+}
+
+type runBlock struct {
+	Context string
+	Script  string
+}
+
+func stepsOf(job any) []any {
+	m, ok := job.(map[string]any)
+	if !ok {
+		return nil
+	}
+	steps, _ := m["steps"].([]any)
+	return steps
+}
+
+func runOf(step any) string {
+	m, ok := step.(map[string]any)
+	if !ok {
+		return ""
+	}
+	r, _ := m["run"].(string)
+	return r
+}
+
+func stepName(step any, idx int) string {
+	m, ok := step.(map[string]any)
+	if !ok {
+		return "step-" + itoa(idx)
+	}
+	if n, _ := m["name"].(string); n != "" {
+		return sanitize(n)
+	}
+	return "step-" + itoa(idx)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	digits := ""
+	for i > 0 {
+		digits = string(rune('0'+i%10)) + digits
+		i /= 10
+	}
+	return digits
+}
+
+func sanitize(s string) string {
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.ReplaceAll(s, "/", "-")
+	return s
+}
+
+// stripGitHubExpressions replaces every ${{ … }} with a shell-safe
+// literal so the script becomes valid bash. GitHub Actions evaluates
+// these substitutions before the script runs; for syntax checking
+// they need to be neutralised first.
+func stripGitHubExpressions(script string) string {
+	out := strings.Builder{}
+	i := 0
+	for i < len(script) {
+		if i+2 < len(script) && script[i] == '$' && script[i+1] == '{' && script[i+2] == '{' {
+			// Find the closing }}
+			end := strings.Index(script[i:], "}}")
+			if end < 0 {
+				// Unclosed — copy the rest verbatim.
+				out.WriteString(script[i:])
+				break
+			}
+			// Replace with a placeholder that is bash-safe in expansion
+			// and assignment contexts.
+			out.WriteString("__GHA_EXPR__")
+			i += end + 2
+			continue
+		}
+		out.WriteByte(script[i])
+		i++
+	}
+	return out.String()
+}
+
+// TestEveryRunBlockSyntax — Layer 1: every run: block parses as valid bash.
+func TestEveryRunBlockSyntax(t *testing.T) {
+	paths := allWorkflowAndActionPaths(t)
+	totalBlocks := 0
+	for _, path := range paths {
+		blocks := extractRunBlocks(t, path)
+		for _, b := range blocks {
+			totalBlocks++
+			t.Run(filepath.Base(path)+"/"+b.Context, func(t *testing.T) {
+				cleaned := stripGitHubExpressions(b.Script)
+				cmd := exec.Command("bash", "-n")
+				cmd.Stdin = strings.NewReader(cleaned)
+				out, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Errorf("bash -n rejected script in %s:\n%s\n--- script ---\n%s",
+						b.Context, string(out), cleaned)
+				}
+			})
+		}
+	}
+	if totalBlocks == 0 {
+		t.Fatalf("no run: blocks discovered — extraction is broken")
+	}
+	t.Logf("checked %d run: blocks across %d files", totalBlocks, len(paths))
+}
+
+// TestEveryRunBlockShellcheck — Layer 2: shellcheck errors fail the
+// test. Lower-severity warnings (info/style) are accepted because the
+// workflow includes many SC2086 informationals that we accept as
+// intentional (heredoc interpolation, label name args, etc.).
+func TestEveryRunBlockShellcheck(t *testing.T) {
+	if _, err := exec.LookPath("shellcheck"); err != nil {
+		t.Skip("shellcheck not installed — Layer 2 test skipped")
+	}
+	paths := allWorkflowAndActionPaths(t)
+	for _, path := range paths {
+		blocks := extractRunBlocks(t, path)
+		for _, b := range blocks {
+			t.Run(filepath.Base(path)+"/"+b.Context, func(t *testing.T) {
+				cleaned := stripGitHubExpressions(b.Script)
+				// --severity=error → only errors are surfaced.
+				// --shell=bash → matches the workflow's `shell: bash`.
+				cmd := exec.Command("shellcheck",
+					"--severity=error",
+					"--shell=bash",
+					"--external-sources",
+					"-")
+				cmd.Stdin = strings.NewReader(cleaned)
+				out, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Errorf("shellcheck found errors in %s:\n%s\n--- script ---\n%s",
+						b.Context, string(out), cleaned)
+				}
+			})
+		}
+	}
+}
+
+// allWorkflowAndActionPaths returns the reusable workflow path plus
+// every composite action.yml under .github/actions/.
+func allWorkflowAndActionPaths(t *testing.T) []string {
+	t.Helper()
+	out := []string{reusableWorkflowPath(t)}
+	actionsDir := compositeActionsDir(t)
+	entries, err := os.ReadDir(actionsDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", actionsDir, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		ap := filepath.Join(actionsDir, e.Name(), "action.yml")
+		if _, err := os.Stat(ap); err == nil {
+			out = append(out, ap)
+		}
+	}
+	return out
+}

--- a/internal/mount/pipeline_steps_test.go
+++ b/internal/mount/pipeline_steps_test.go
@@ -1,0 +1,264 @@
+package mount
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Pipeline step-ordering invariants.
+//
+// This test parses .github/workflows/agentic-pipeline.yml and walks each
+// job's steps in order, modelling which tools and resources are available
+// after each step. It then asserts that every step's preconditions are
+// satisfied — catching the class of bug that v2.8.11 → v2.8.13 kept
+// re-introducing:
+//
+//   - A composite action referenced before the .agents/ submodule was
+//     checked out (`Can't find action.yml`).
+//   - `gh` invoked before install-ai-tools installed it (self-hosted
+//     runners don't have gh pre-installed) (`gh: command not found`).
+//   - `goose` invoked before install-ai-tools installed it.
+//
+// The model deliberately assumes the WORST baseline: a bare self-hosted
+// runner with only the universal POSIX toolchain (bash, curl, jq, git,
+// sed, grep). Anything else must be explicitly installed by a step
+// before it can be invoked. This keeps the workflow portable across
+// GitHub-hosted ubuntu-latest (which has more pre-installed) and
+// minimal self-hosted runners (which have less).
+
+type workflowState struct {
+	// True once a composite action under .agents/.github/actions/... can
+	// be safely referenced.
+	agentsSubmoduleOnDisk bool
+	// True once install-ai-tools (or any step that installs it) has run.
+	ghInstalled    bool
+	gooseInstalled bool
+}
+
+type pipelineJob struct {
+	Name  string         `yaml:"name"`
+	Steps []pipelineStep `yaml:"steps"`
+}
+
+type pipelineStep struct {
+	Name string         `yaml:"name"`
+	Uses string         `yaml:"uses"`
+	Run  string         `yaml:"run"`
+	With map[string]any `yaml:"with"`
+}
+
+type pipelineWorkflow struct {
+	Jobs map[string]pipelineJob `yaml:"jobs"`
+}
+
+// universal commands present on every Linux runner — bare-image baseline.
+// Anything not in this set must be installed by a prior step.
+var universalCommands = map[string]bool{
+	"bash":  true,
+	"sh":    true,
+	"curl":  true,
+	"wget":  true,
+	"jq":    true,
+	"git":   true,
+	"sed":   true,
+	"grep":  true,
+	"awk":   true,
+	"tr":    true,
+	"cat":   true,
+	"echo":  true,
+	"head":  true,
+	"tail":  true,
+	"cut":   true,
+	"sort":  true,
+	"uniq":  true,
+	"mkdir": true,
+	"rm":    true,
+	"cp":    true,
+	"mv":    true,
+	"chmod": true,
+	"base64": true,
+	"date":  true,
+	"sleep": true,
+	"exit":  true,
+	"set":   true,
+	"printf": true,
+}
+
+// Commands installed by install-ai-tools (which setup-goose-env wraps).
+var installedByAITools = map[string]bool{
+	"gh":      true, // installed via apt-get gh
+	"goose":   true, // installed via curl + tar to ~/.local/bin
+	"node":    true, // setup-node action
+	"npm":     true, // comes with node
+	"claude":  true, // npm install -g @anthropic-ai/claude-code
+}
+
+// Detects shell command invocations in a `run:` block. We deliberately
+// only look at the first token of each (logical) line — finding every
+// invocation in arbitrary shell is impossible, but the leading-token
+// heuristic catches every real usage in this workflow.
+var commandInvocationRe = regexp.MustCompile(`(?m)^[ \t]*(?:[A-Z_][A-Z0-9_]*=\S+[ \t]+)*([a-zA-Z][a-zA-Z0-9_-]*)\b`)
+
+// TestPipelineStepOrdering walks every job's steps in order and asserts
+// that each step's tool/resource preconditions hold at the moment it
+// runs. This is the regression gate for the v2.8.11 → v2.8.13 incidents.
+func TestPipelineStepOrdering(t *testing.T) {
+	path := reusableWorkflowPath(t)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var wf pipelineWorkflow
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	if len(wf.Jobs) == 0 {
+		t.Fatalf("no jobs parsed from %s — schema drift?", path)
+	}
+
+	// Track which jobs we expect — surface drift if a job appears or disappears.
+	expectedJobs := []string{
+		"feature-design",
+		"dev-session",
+		"compliance-verify",
+		"pr-review-session",
+		"issue-session",
+		"feature-complete",
+	}
+	seen := map[string]bool{}
+	for jobID := range wf.Jobs {
+		seen[jobID] = true
+	}
+	for _, want := range expectedJobs {
+		if !seen[want] {
+			t.Errorf("missing expected job %q — pipeline structure changed", want)
+		}
+	}
+
+	for jobID, job := range wf.Jobs {
+		t.Run(jobID, func(t *testing.T) {
+			state := workflowState{}
+			for i, step := range job.Steps {
+				checkStep(t, jobID, i, step, &state)
+				updateState(step, &state)
+			}
+		})
+	}
+}
+
+// checkStep verifies the step's preconditions against the current state.
+func checkStep(t *testing.T, jobID string, idx int, step pipelineStep, state *workflowState) {
+	t.Helper()
+
+	// `uses: ./.agents/.github/actions/...` requires the .agents/
+	// submodule to be on disk.
+	if strings.HasPrefix(strings.TrimSpace(step.Uses), "./.agents/.github/actions/") {
+		if !state.agentsSubmoduleOnDisk {
+			t.Errorf(
+				"job %s, step %d (%q): uses local composite %q but no prior step "+
+					"checked out the repo with submodules: recursive. The .agents/ "+
+					"directory will be empty and the runner will fail with "+
+					"\"Can't find action.yml\". Either move this step after the checkout, "+
+					"or inline its logic.",
+				jobID, idx, step.Name, step.Uses,
+			)
+		}
+	}
+
+	// `run:` blocks: scan for commands that need to be installed first.
+	if step.Run != "" {
+		for _, cmd := range commandsUsedIn(step.Run) {
+			if universalCommands[cmd] {
+				continue
+			}
+			if !installedByAITools[cmd] {
+				continue // unknown command — not our concern
+			}
+			if cmd == "gh" && !state.ghInstalled {
+				t.Errorf(
+					"job %s, step %d (%q): invokes %q but install-ai-tools has not "+
+						"run yet in this job. Self-hosted runners do not have gh "+
+						"pre-installed (it is installed via apt-get by install-ai-tools "+
+						"inside setup-goose-env). Move this step after setup-goose-env, "+
+						"or replace %q with curl+jq against the REST API.",
+					jobID, idx, step.Name, cmd, cmd,
+				)
+			}
+			if cmd == "goose" && !state.gooseInstalled {
+				t.Errorf(
+					"job %s, step %d (%q): invokes %q but install-ai-tools has not "+
+						"run yet in this job. Move this step after setup-goose-env.",
+					jobID, idx, step.Name, cmd,
+				)
+			}
+		}
+	}
+}
+
+// updateState updates the state model based on what the step did.
+func updateState(step pipelineStep, state *workflowState) {
+	uses := strings.TrimSpace(step.Uses)
+
+	// Any actions/checkout step with submodules: recursive populates
+	// .agents/.
+	if strings.HasPrefix(uses, "actions/checkout@") {
+		if sub, ok := step.With["submodules"]; ok {
+			if s, ok := sub.(string); ok && s == "recursive" {
+				state.agentsSubmoduleOnDisk = true
+			}
+		}
+	}
+
+	// setup-goose-env wraps install-ai-tools which installs gh and goose
+	// (and Node, but we don't track Node usage).
+	if strings.HasPrefix(uses, "./.agents/.github/actions/setup-goose-env") {
+		state.ghInstalled = true
+		state.gooseInstalled = true
+	}
+
+	// install-ai-tools called directly installs the same.
+	if strings.HasPrefix(uses, "./.agents/.github/actions/install-ai-tools") {
+		state.ghInstalled = true
+		state.gooseInstalled = true
+	}
+}
+
+// commandsUsedIn returns the set of leading-token commands seen in a
+// shell script. Heuristic — see commandInvocationRe.
+func commandsUsedIn(script string) []string {
+	matches := commandInvocationRe.FindAllStringSubmatch(script, -1)
+	seen := map[string]bool{}
+	out := []string{}
+	// Common bash keywords / built-ins / control flow we should skip
+	// when they appear as a line's leading token.
+	skip := map[string]bool{
+		"if": true, "elif": true, "else": true, "fi": true,
+		"for": true, "while": true, "do": true, "done": true,
+		"case": true, "esac": true, "in": true, "then": true,
+		"return": true, "break": true, "continue": true,
+		"local": true, "declare": true, "readonly": true,
+		"function": true, "true": true, "false": true,
+		"export": true,
+	}
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		cmd := m[1]
+		if skip[cmd] {
+			continue
+		}
+		if seen[cmd] {
+			continue
+		}
+		seen[cmd] = true
+		out = append(out, cmd)
+	}
+	return out
+}

--- a/internal/mount/pipeline_structure_test.go
+++ b/internal/mount/pipeline_structure_test.go
@@ -1,0 +1,237 @@
+package mount
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Layer 4 — structural and contract tests for composite actions and
+// for each job's `if:` trigger expression.
+//
+// These tests do not execute scripts. They verify shape:
+//   - Each composite action has a name, description, runs.using:
+//     composite, and at least one step.
+//   - Every input the workflow passes to a composite action is
+//     declared in that action's inputs:.
+//   - Every job's `if:` trigger expression contains the substrings
+//     we expect for the event it claims to handle, so a typo in
+//     the gate is caught at test time.
+
+type compositeAction struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Inputs      map[string]any `yaml:"inputs"`
+	Runs        struct {
+		Using string `yaml:"using"`
+		Steps []any  `yaml:"steps"`
+	} `yaml:"runs"`
+}
+
+// TestCompositeActionsAreWellFormed — every composite has a name,
+// description, runs.using == composite, and at least one step.
+func TestCompositeActionsAreWellFormed(t *testing.T) {
+	actionsDir := compositeActionsDir(t)
+	entries, err := os.ReadDir(actionsDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", actionsDir, err)
+	}
+	found := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		actionYAML := filepath.Join(actionsDir, e.Name(), "action.yml")
+		data, err := os.ReadFile(actionYAML)
+		if err != nil {
+			continue
+		}
+		found++
+		var ca compositeAction
+		if err := yaml.Unmarshal(data, &ca); err != nil {
+			t.Errorf("%s parse error: %v", e.Name(), err)
+			continue
+		}
+		t.Run(e.Name(), func(t *testing.T) {
+			if strings.TrimSpace(ca.Name) == "" {
+				t.Errorf("composite %s has empty name:", e.Name())
+			}
+			if strings.TrimSpace(ca.Description) == "" {
+				t.Errorf("composite %s has empty description:", e.Name())
+			}
+			if ca.Runs.Using != "composite" {
+				t.Errorf("composite %s: runs.using = %q, want \"composite\"", e.Name(), ca.Runs.Using)
+			}
+			if len(ca.Runs.Steps) == 0 {
+				t.Errorf("composite %s: no steps declared", e.Name())
+			}
+		})
+	}
+	if found == 0 {
+		t.Fatalf("no composite actions discovered under %s", actionsDir)
+	}
+}
+
+// TestCompositeActionInputsMatchCallSites — for every `uses:
+// ./.agents/.github/actions/<name>` call site in the reusable
+// workflow, verify every key under `with:` is declared in that
+// composite's `inputs:`. Catches typos like passing `agentic-version`
+// when the composite expects `agentic-framework-version`.
+func TestCompositeActionInputsMatchCallSites(t *testing.T) {
+	wfPath := reusableWorkflowPath(t)
+	data, err := os.ReadFile(wfPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", wfPath, err)
+	}
+	var wf map[string]any
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("parse workflow: %v", err)
+	}
+
+	// Load every composite's input list.
+	actionInputs := map[string]map[string]bool{}
+	actionsDir := compositeActionsDir(t)
+	entries, _ := os.ReadDir(actionsDir)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		ap := filepath.Join(actionsDir, e.Name(), "action.yml")
+		ad, err := os.ReadFile(ap)
+		if err != nil {
+			continue
+		}
+		var ca compositeAction
+		if err := yaml.Unmarshal(ad, &ca); err != nil {
+			continue
+		}
+		ins := map[string]bool{}
+		for k := range ca.Inputs {
+			ins[k] = true
+		}
+		actionInputs[e.Name()] = ins
+	}
+
+	// Walk every job's steps and check each uses: call site.
+	jobs := wf["jobs"].(map[string]any)
+	for jobID, j := range jobs {
+		job := j.(map[string]any)
+		steps, _ := job["steps"].([]any)
+		for i, s := range steps {
+			step := s.(map[string]any)
+			uses, _ := step["uses"].(string)
+			uses = strings.TrimSpace(uses)
+			const prefix = "./.agents/.github/actions/"
+			if !strings.HasPrefix(uses, prefix) {
+				continue
+			}
+			actionName := strings.TrimPrefix(uses, prefix)
+			declared, ok := actionInputs[actionName]
+			if !ok {
+				t.Errorf("job %s step %d uses unknown composite %q", jobID, i, actionName)
+				continue
+			}
+			with, _ := step["with"].(map[string]any)
+			for k := range with {
+				if !declared[k] {
+					t.Errorf(
+						"job %s step %d (uses: %s): passes input %q that the composite "+
+							"does not declare. Declared inputs: %v",
+						jobID, i, uses, k, sortedKeys(declared),
+					)
+				}
+			}
+		}
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// simple insertion sort; the lists are short
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// TestJobTriggersMatchEvents — assert that every job's `if:`
+// expression contains the GitHub event name and condition it claims
+// to handle. This is a smoke test against typos like
+// `github.event.action == 'labelled'`.
+func TestJobTriggersMatchEvents(t *testing.T) {
+	wfPath := reusableWorkflowPath(t)
+	data, err := os.ReadFile(wfPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", wfPath, err)
+	}
+	var wf map[string]any
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("parse workflow: %v", err)
+	}
+	jobs := wf["jobs"].(map[string]any)
+
+	expected := map[string][]string{
+		// jobID → substrings every `if:` must contain
+		"feature-design": {
+			"github.event_name == 'issues'",
+			"github.event.action == 'labeled'",
+			"'in-design'",
+		},
+		"dev-session": {
+			"github.event_name == 'issues'",
+			"github.event.action == 'labeled'",
+			"'in-development'",
+		},
+		"compliance-verify": {
+			"'in-verification'",
+			"github.event.action == 'labeled'",
+		},
+		"pr-review-session": {
+			"pull_request_review",
+			"changes_requested",
+			"feature/", // head ref filter
+		},
+		"issue-session": {
+			"github.event_name == 'issues'",
+			"github.event.action == 'labeled'",
+			"'assigned-to-agent'",
+		},
+		"feature-complete": {
+			"github.event_name == 'pull_request'",
+			"github.event.pull_request.merged == true",
+			"feature/", // head ref filter
+		},
+	}
+
+	for jobID, mustContain := range expected {
+		t.Run(jobID, func(t *testing.T) {
+			job, ok := jobs[jobID].(map[string]any)
+			if !ok {
+				t.Fatalf("job %s missing", jobID)
+			}
+			ifExpr, _ := job["if"].(string)
+			if ifExpr == "" {
+				t.Fatalf("job %s has no `if:` — would run on every event", jobID)
+			}
+			// Normalise whitespace for substring matching.
+			normalised := strings.Join(strings.Fields(ifExpr), " ")
+			for _, sub := range mustContain {
+				normSub := strings.Join(strings.Fields(sub), " ")
+				if !strings.Contains(normalised, normSub) {
+					t.Errorf(
+						"job %s `if:` expression is missing required substring %q.\nFull if: %q",
+						jobID, sub, ifExpr,
+					)
+				}
+			}
+		})
+	}
+}

--- a/skills/compliance-verify/SKILL.md
+++ b/skills/compliance-verify/SKILL.md
@@ -248,12 +248,73 @@ and reuse as `<active-repo>`.
 
 ---
 
+### Section A.0 — Build & Test Gate
+
+The gate runs **before** any other compliance check. It is the
+first action after Section A setup completes and the diff +
+acceptance-criteria list have been loaded.
+
+The rule lives in `standards/<stack-lowercase>.md` →
+`## Verification Gate (build + test)`. Load that section, execute
+the listed commands verbatim, in order, from the repo root. The
+same commands will have been run by the dev session as its
+last step before exit; this is a fresh re-run that re-validates the
+pushed branch is consistent with the build and test contract.
+
+**Possible outcomes:**
+
+1. **All commands exit zero** → record `gate=PASS` plus the
+   captured command output summary into working memory. Continue
+   to Section B. The compliance report's first section reflects
+   the PASS.
+
+2. **Any command exits non-zero** → record `gate=FAIL` plus the
+   captured failure output. Skip Section B (static analysis) and
+   Section C (AC evaluation) entirely — ACs cannot be PASS while
+   the build is broken. Jump directly to Section D with
+   `<sa-verdict>` and `<ac-verdict>` both set to "skipped — gate
+   failed". The overall verdict is FAIL with the gate-failure
+   output as the structured violation list.
+
+3. **Toolchain unavailable** (e.g. `go` not on PATH, the standards
+   file lists tools the runner does not have) → record
+   `gate=BLOCKED`. Do NOT post a FAIL verdict — a BLOCKED verdict
+   is qualitatively different. Apply the `needs-human-review`
+   label (this is not part of the FAIL cycle; it is a runner
+   environment failure the human must resolve). Post a
+   `<!-- compliance-blocked:v1 -->` comment surfacing the missing
+   tool and the standards-file requirement. Exit with Output D.
+   Subsequent runs on the same Feature pick up only when the
+   human has installed the toolchain and re-toggled the label.
+
+4. **No standards file** for the active stack (no
+   `standards/<stack>.md` exists, or the file has no
+   `## Verification Gate` section) → raise
+   `STACK_GATE_UNDEFINED` (`ERROR`). The compliance verifier
+   cannot enforce a contract the framework has not defined.
+   Surface the missing file to the human as a framework-level fix
+   needed; exit with Output D.
+
+The gate's outcome is the first line of the compliance report
+(see step 14). When the report shows AC PASS but the gate ran
+and failed, that is a protocol violation — the gate gates
+everything.
+
+**Compliance MUST NOT mark "build and tests pass" as PASS by code
+inspection.** If the gate could not run, the verdict for that AC
+is BLOCKED, recorded as such, and the cycle does not advance.
+
+---
+
 ### Section B — Static Analysis
 
 Perform a code-quality and security gate before AC evaluation. This
 section runs entirely against the checked-out feature branch. All
 findings are recorded for inclusion in the compliance report (step 14)
 and, if the overall verdict is FAIL, the feedback comment (step 16).
+
+**Pre-requisite:** Section A.0 has executed and `gate=PASS`. If
+`gate=FAIL`, Section B is skipped — see Section A.0 outcome #2.
 
 **Severity levels used throughout this section:**
 

--- a/skills/dev-session/SKILL.md
+++ b/skills/dev-session/SKILL.md
@@ -472,6 +472,39 @@ discipline at task granularity:
 
 ### Section C — Closeout
 
+15pre. **Build + test gate.** Before any closeout work, load
+    `standards/<stack-lowercase>.md` (where `<stack>` is the
+    project's primary language — `go`, `java`, `typescript`, etc.,
+    matching `vars.PROJECT_STACK` or the value in the project
+    config). Read the `## Verification Gate (build + test)` section
+    and execute the listed commands verbatim, in order, from the
+    repo root.
+
+    Outcomes:
+
+    - **All commands exit zero** → record `gate=PASS` in working
+      memory; continue to step 15a.
+    - **Any command exits non-zero** → the dev session has produced
+      broken code. Do NOT exit. Loop back: read the failure output,
+      identify the offending change (most often the task most
+      recently committed), and fix it. Commit the fix with the
+      task-N-of-M format (a fix commit counts as a continuation of
+      the task whose work it corrects). Re-run the gate. Repeat
+      until `gate=PASS`. The dev session exits only on a clean gate.
+    - **Toolchain unavailable** (e.g. `go` not on PATH) → raise
+      `VERIFICATION_TOOLCHAIN_MISSING` (`ERROR`) and exit Output D.
+      The dev session never claims completion without an actual
+      gate run; downstream compliance will surface the same gap.
+
+    No standards file exists for the active stack → raise
+    `VERIFICATION_GATE_UNDEFINED` (`ERROR`) and exit Output D.
+    Adding the language to `standards/` is a framework-level fix,
+    not work the dev session can route around.
+
+    Record the gate's final outcome (`gate=PASS` plus the command
+    output line summary) in working memory for inclusion in the
+    exit block (step 18).
+
 15a. **Acceptance-criteria coverage gate.** Before the closeout
     label flips, verify that every Feature acceptance criterion
     is satisfied by the work that just landed.
@@ -558,10 +591,19 @@ discipline at task granularity:
       - <K> task issue(s) closed: #<T_a>, #<T_b>, ...
       - All <M> tasks for #<N> are closed
 
+    Verification gate: PASS
+      - go build ./... ✓
+      - go test ./... ✓ (or the stack-equivalent commands)
+
     Blocked: none
 
     Next: workflow applies in-verification, triggering compliance-verify
     ```
+
+    The "Verification gate" line is mandatory in Output A and
+    Output B. Omitting it is a protocol violation per
+    `standards/<stack>.md` → Verification Gate. The exact commands
+    shown match what was actually run in step 15pre.
 
     **Output B — Resumed and completed:**
     ```

--- a/standards/go.md
+++ b/standards/go.md
@@ -39,6 +39,59 @@ Never claim an implementation is complete without all four passing.
 
 ---
 
+## Verification Gate (build + test)
+
+The build+test pass is a **mandatory gate** at two specific points in
+the pipeline. The same two commands run in both places:
+
+```bash
+go build ./...
+go test ./...
+```
+
+Both must exit zero. Any non-zero exit — compilation failure,
+failing test, vet failure surfaced through `go test`, race-detector
+data race report under `go test -race`, etc. — fails the gate.
+
+### Dev Session — last step before exit
+
+After the final task commit and before the workflow applies
+`in-verification`, the dev session **MUST** run the gate. On failure
+the dev session does NOT exit cleanly — it loops back to fix the
+breakage and re-runs the gate until it passes. Pushing a broken
+build or a failing test suite to the feature branch and signalling
+completion is forbidden.
+
+The dev session's exit block must state whether the gate ran and
+what its result was. An exit block that omits the gate result is
+itself a protocol violation.
+
+### Compliance Verify — first step before any other check
+
+The compliance verifier **MUST** run the gate before evaluating
+acceptance criteria, static analysis, or any other check. On
+failure the verifier emits an immediate FAIL verdict and
+short-circuits — ACs cannot be PASS while the build is broken or
+the tests fail, regardless of what code inspection suggests.
+
+The gate's run-and-result is the first item in the compliance
+report. Subsequent sections (static analysis, AC table) appear only
+when the gate passed.
+
+### When the toolchain is unavailable
+
+If `go` is not on the runner's PATH, the only correct verdict is
+**BLOCKED**, never PASS. Compliance MUST NOT infer build/test
+correctness from diff inspection alone. A BLOCKED verdict leaves
+the Feature at `in-verification` with a clear remediation ("install
+Go toolchain on the runner") — the human resolves before re-running.
+
+A PR opened against work whose AC9 was marked PASS by inspection
+rather than by an actual gate run is a verification-process bug —
+the rule above closes it.
+
+---
+
 ## Coding Standards
 
 - **Context propagation**: Every I/O function (DB, HTTP, Kafka) accepts `context.Context` as first parameter and propagates it. Never use `context.Background()` inside business logic — only at entry points.


### PR DESCRIPTION
## Background

PR #810 surfaced a real verification gap. Compliance marked AC9 (\`go build ./... && go test ./...\` pass) as PASS by code inspection because the runner lacked the Go toolchain — and the CI then caught a real test regression (`TestRepairPipeline_FixesGitignoreAndWorkflowTags`) that compliance had missed. The verdict was structurally incorrect: "PASS by inspection" is not a valid path when the gate can't actually run.

This PR closes that gap in three coordinated places.

## Changes

**1. `standards/go.md` — new "Verification Gate (build + test)" section.** Defines the canonical contract:
- Same two commands (`go build ./...`, `go test ./...`) run at two specific gate points
- Dev session runs them as the **last** step before exit
- Compliance runs them as the **first** step before any other check
- When the toolchain is unavailable, the verdict is **BLOCKED**, never PASS

**2. `skills/dev-session/SKILL.md` — new step 15pre (Build + test gate).** Loads `standards/<stack>.md` → Verification Gate, runs the commands, loops on failure (never exits dirty), surfaces missing toolchain as ERROR. Mandates the gate-result line in the exit block (Output A / Output B).

**3. `skills/compliance-verify/SKILL.md` — new Section A.0 (Build & Test Gate).** Runs before Section B (static analysis) and Section C (AC evaluation). On failure, short-circuits — ACs cannot be PASS while the build is broken. On toolchain absent, posts a BLOCKED verdict (not FAIL), applies `needs-human-review`, exits without advancing the cycle counter. Hard rule embedded in the section text:

> **Compliance MUST NOT mark "build and tests pass" as PASS by code inspection.**

## Follow-ups

Same gate principle applies to `java.md`, `typescript.md`, `react.md` — those standards files need the same section. Filing as a follow-up so we can verify the Go path first.

The Goose runner image should also have `go` installed so the BLOCKED path is the exception, not the norm. Separate issue.

## Test plan
- [x] `go test ./internal/mount/...` — full project tests still pass
- [x] Section A.0 placement verified — sits between Section A (Setup) and Section B (Static Analysis) per skill structure

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)