### PR TITLE
feat(standards,skills): multi-stack verification gate (TS, React, diff-based detection)

### DIFF
--- a/skills/compliance-verify/SKILL.md
+++ b/skills/compliance-verify/SKILL.md
@@ -289,13 +289,43 @@ first action after Section A setup completes and the diff +
 acceptance-criteria list have been loaded.
 
 The rule lives in `standards/<stack-lowercase>.md` →
-`## Verification Gate (build + test)`. Load that section, execute
-the listed commands verbatim, in order, from the repo root. The
-same commands will have been run by the dev session as its
-last step before exit; this is a fresh re-run that re-validates the
-pushed branch is consistent with the build and test contract.
+`## Verification Gate (build + test)`. Multi-stack Features run the
+gate for **every stack the Feature touched**, not a project-wide
+single stack — see Stack Detection below. The same commands will
+have been run by the dev session as its last step before exit;
+this is a fresh re-run that re-validates the pushed branch is
+consistent with the build and test contract.
 
-**Possible outcomes:**
+**Stack detection.** The skill enumerates which language standards
+apply by looking at the diff against `origin/main`:
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+Classify each changed path against the stack markers below. The
+set of distinct matches is `<stacks>`:
+
+| Stack | Marker (any of these matches) |
+|---|---|
+| `go` | path ends in `.go`, OR `go.mod`/`go.sum` touched |
+| `typescript` | path under a directory containing `package.json`, AND ends in `.ts`, `.tsx`, `.mts`, `.cts`, `.js`, `.jsx`, `.mjs`, `.cjs`, OR `package.json`/`package-lock.json`/`tsconfig*.json` touched |
+| `react` | as `typescript` PLUS a JSX file under a project that imports React. Gate is identical to `typescript` — see `standards/react.md` |
+| `java` | path ends in `.java`, OR `pom.xml`/`build.gradle*` touched |
+
+Documentation-only changes (`.md`, `docs/**`) and workflow files
+(`.github/workflows/**`) do not select any gate. A pure-docs
+Feature falls through to "gate not applicable — continue to
+Section B" (the AC table in Section C still applies).
+
+If `vars.PROJECT_STACK` is set, it overrides detection — use only
+that stack. Useful for single-stack repos.
+
+For each detected stack, load `standards/<stack>.md` →
+`## Verification Gate (build + test)`, execute the listed commands
+verbatim, in order, from the repo root.
+
+**Per-stack outcomes** (aggregate across all stacks):
 
 1. **All commands exit zero** → record `gate=PASS` plus the
    captured command output summary into working memory. Continue

--- a/skills/dev-session/SKILL.md
+++ b/skills/dev-session/SKILL.md
@@ -472,38 +472,77 @@ discipline at task granularity:
 
 ### Section C — Closeout
 
-15pre. **Build + test gate.** Before any closeout work, load
-    `standards/<stack-lowercase>.md` (where `<stack>` is the
-    project's primary language — `go`, `java`, `typescript`, etc.,
-    matching `vars.PROJECT_STACK` or the value in the project
-    config). Read the `## Verification Gate (build + test)` section
-    and execute the listed commands verbatim, in order, from the
-    repo root.
+15pre. **Build + test gate.** Before any closeout work, run the
+    verification gate for every stack the feature touched.
 
-    Outcomes:
+    **Stack detection (multi-stack aware).** The skill enumerates
+    which language standards apply to *this Feature's* changes —
+    not a project-wide setting — by looking at the diff against
+    `origin/main`:
 
-    - **All commands exit zero** → record `gate=PASS` in working
-      memory; continue to step 15a.
+    ```bash
+    git diff --name-only origin/main...HEAD
+    ```
+
+    Classify each changed path against the stack markers below.
+    The set of distinct matches is `<stacks>`:
+
+    | Stack | Marker (any of these matches) |
+    |---|---|
+    | `go` | path ends in `.go`, OR any `go.mod`/`go.sum` touched |
+    | `typescript` | path under a directory containing `package.json`, AND ends in `.ts`, `.tsx`, `.mts`, `.cts`, `.js`, `.jsx`, `.mjs`, `.cjs`, OR `package.json`/`package-lock.json`/`tsconfig*.json` touched |
+    | `react` | as `typescript` PLUS file contains JSX (`.tsx`/`.jsx`) under a project that imports React. The `typescript` gate covers React too — see `standards/react.md`; the gate is identical. |
+    | `java` | path ends in `.java`, OR any `pom.xml`/`build.gradle*` touched |
+
+    Documentation-only changes (`.md`, `docs/**`) and workflow
+    files (`.github/workflows/**`) do not select any gate — they
+    are not testable by the language toolchain. A diff that is
+    pure docs falls through to "no gate applies for this feature
+    — continue to step 15a" (still requires the AC coverage gate;
+    docs Features must still satisfy their ACs).
+
+    If `vars.PROJECT_STACK` is set, it overrides the detection —
+    use only that stack. Useful for single-stack repos where
+    detection adds no value, or for testing.
+
+    **For each stack in `<stacks>`:**
+
+    1. Load `standards/<stack>.md` and find the
+       `## Verification Gate (build + test)` section.
+    2. Execute the listed commands verbatim, in order, from the
+       repo root.
+    3. Record the per-stack outcome.
+
+    **Per-stack outcomes:**
+
+    - **All commands exit zero** → record `<stack>: PASS` in
+      working memory.
     - **Any command exits non-zero** → the dev session has produced
       broken code. Do NOT exit. Loop back: read the failure output,
       identify the offending change (most often the task most
       recently committed), and fix it. Commit the fix with the
       task-N-of-M format (a fix commit counts as a continuation of
-      the task whose work it corrects). Re-run the gate. Repeat
-      until `gate=PASS`. The dev session exits only on a clean gate.
-    - **Toolchain unavailable** (e.g. `go` not on PATH) → raise
-      `VERIFICATION_TOOLCHAIN_MISSING` (`ERROR`) and exit Output D.
-      The dev session never claims completion without an actual
-      gate run; downstream compliance will surface the same gap.
+      the task whose work it corrects). Re-run the gate (all
+      stacks). Repeat until every stack reports PASS. The dev
+      session exits only on a clean gate across every detected
+      stack.
+    - **Toolchain unavailable** (e.g. `go` not on PATH for the `go`
+      stack, `node` not on PATH for the `typescript` stack) →
+      raise `VERIFICATION_TOOLCHAIN_MISSING` (`ERROR`) and exit
+      Output D. The dev session never claims completion without an
+      actual gate run; downstream compliance will surface the same
+      gap.
 
-    No standards file exists for the active stack → raise
+    **No standards file** for a detected stack (no
+    `standards/<stack>.md` exists, or the file has no
+    `## Verification Gate` section) → raise
     `VERIFICATION_GATE_UNDEFINED` (`ERROR`) and exit Output D.
     Adding the language to `standards/` is a framework-level fix,
     not work the dev session can route around.
 
-    Record the gate's final outcome (`gate=PASS` plus the command
-    output line summary) in working memory for inclusion in the
-    exit block (step 18).
+    Record every per-stack outcome in working memory for inclusion
+    in the exit block (step 18). The exit block lists each stack
+    + its commands + its result.
 
 15a. **Acceptance-criteria coverage gate.** Before the closeout
     label flips, verify that every Feature acceptance criterion
@@ -591,9 +630,9 @@ discipline at task granularity:
       - <K> task issue(s) closed: #<T_a>, #<T_b>, ...
       - All <M> tasks for #<N> are closed
 
-    Verification gate: PASS
-      - go build ./... ✓
-      - go test ./... ✓ (or the stack-equivalent commands)
+    Verification gate: PASS (stacks: <stack-1>[, <stack-2>...])
+      - <stack-1>: <command-1> ✓ ; <command-2> ✓ ; ...
+      - <stack-2>: <command-1> ✓ ; <command-2> ✓ ; ...
 
     Blocked: none
 
@@ -603,7 +642,12 @@ discipline at task granularity:
     The "Verification gate" line is mandatory in Output A and
     Output B. Omitting it is a protocol violation per
     `standards/<stack>.md` → Verification Gate. The exact commands
-    shown match what was actually run in step 15pre.
+    shown match what was actually run in step 15pre, per stack.
+    For multi-stack Features (e.g. a feature touching both Go and
+    TypeScript), one line per stack appears. A Features that
+    touches only docs / workflow files may show "Verification
+    gate: NOT APPLICABLE (no stacks touched)" — but step 15pre's
+    AC coverage gate still ran.
 
     **Output B — Resumed and completed:**
     ```

--- a/standards/react.md
+++ b/standards/react.md
@@ -18,6 +18,29 @@ Never claim an implementation is complete without all three passing.
 
 ---
 
+## Verification Gate (build + test)
+
+The Verification Gate for React projects is identical to TypeScript —
+React is a TypeScript-superset standard. See
+[`standards/typescript.md` → Verification Gate](typescript.md#verification-gate-build--test)
+for the full contract:
+
+- The same gate commands apply: `npx tsc --noEmit`, `npm test`,
+  `npm run build`.
+- The dev-session runs the gate as its last step before exit; on
+  failure it loops back and never claims completion.
+- The compliance verifier runs the gate as its first step before any
+  AC evaluation; FAIL short-circuits, BLOCKED applies when the
+  toolchain is absent.
+- No FAIL-by-inspection, no PASS-by-inspection — BLOCKED is the only
+  correct verdict when the gate cannot actually run.
+
+Skills loading the gate definition may load either `standards/react.md`
+or `standards/typescript.md` for a React project — the gate contract is
+the same.
+
+---
+
 ## Component Rules
 
 - **Functional components only** — class components are prohibited

--- a/standards/typescript.md
+++ b/standards/typescript.md
@@ -49,6 +49,79 @@ npx prettier --write .
 
 ---
 
+## Verification Gate (build + test)
+
+The build+test pass is a **mandatory gate** at two specific points in
+the pipeline. The same three commands run in both places:
+
+```bash
+npx tsc --noEmit
+npm test
+npm run build
+```
+
+`tsc --noEmit` catches type errors without producing emitted files;
+`npm test` runs the project's test command (project must define a
+`test` script in `package.json`); `npm run build` exercises the
+actual production-build path (`vite build`, `tsc -b`, or whatever
+`scripts.build` resolves to) — a project that type-checks and tests
+clean but fails to bundle is not shippable.
+
+All three must exit zero. Any non-zero exit — type error, failing
+test, bundler error, missing `build`/`test` script — fails the gate.
+
+If `package.json` has no `test` script (genuinely no tests in the
+project — rare, but possible for a CLI wrapper or a fresh scaffold),
+the gate is satisfied when `tsc --noEmit` and `npm run build` exit
+zero AND the standards file's "Testing" section has confirmed the
+project's testing strategy with the human. An empty
+`scripts.test` left at the npm-init default (`"test": "echo \"Error:
+no test specified\" && exit 1"`) is NOT acceptable — it must be a
+real command or removed.
+
+### Dev Session — last step before exit
+
+After the final task commit and before the workflow applies
+`in-verification`, the dev session **MUST** run the gate. On failure
+the dev session does NOT exit cleanly — it loops back to fix the
+breakage and re-runs the gate until it passes. Pushing broken
+TypeScript, type errors, failing tests, or a build that doesn't
+bundle to the feature branch and signalling completion is forbidden.
+
+The dev session's exit block must state whether the gate ran and
+what its result was. An exit block that omits the gate result is
+itself a protocol violation.
+
+### Compliance Verify — first step before any other check
+
+The compliance verifier **MUST** run the gate before evaluating
+acceptance criteria, static analysis, or any other check. On
+failure the verifier emits an immediate FAIL verdict and
+short-circuits — ACs cannot be PASS while `tsc` errors, tests fail,
+or the bundle is broken, regardless of what code inspection
+suggests.
+
+The gate's run-and-result is the first item in the compliance
+report. Subsequent sections (static analysis, AC table) appear only
+when the gate passed.
+
+### When the toolchain is unavailable
+
+If `node`/`npm` is not on the runner's PATH (or `node_modules/` is
+not installed and `npm ci` fails), the only correct verdict is
+**BLOCKED**, never PASS or FAIL. Compliance MUST NOT infer
+build/test correctness from diff inspection alone — that is the
+same overconfidence trap whether the inspection concludes pass or
+fail. A BLOCKED verdict leaves the Feature at `in-verification`
+with a clear remediation ("install Node.js and run `npm ci`") —
+the human resolves before re-running.
+
+A PR opened against work whose build+test AC was marked PASS by
+inspection rather than by an actual gate run is a
+verification-process bug — the rule above closes it.
+
+---
+
 ## Dependency Management
 
 ```bash


### PR DESCRIPTION
## Background

v2.8.14 introduced the build+test verification gate, encoded in `standards/go.md` and consulted by `skills/dev-session/SKILL.md` step 15pre and `skills/compliance-verify/SKILL.md` Section A.0. Both skills looked for a single \`vars.PROJECT_STACK\` and assumed one language per repo. Yapper — Go relay + React/TypeScript SPA — was blocked by that assumption.

This PR makes the gate multi-stack aware and adds the gate definition to TypeScript and React standards so non-Go work can pass the gate too.

## Changes

### Standards
- **`standards/typescript.md`** — new `## Verification Gate (build + test)` section. Gate commands: \`npx tsc --noEmit && npm test && npm run build\` — adds the bundler step because a project that type-checks and tests clean but fails to bundle is not shippable. Mirrors `standards/go.md`'s dev-session-last / compliance-first contract; BLOCKED (never PASS or FAIL by inspection) when node/npm unavailable.
- **`standards/react.md`** — gate is identical to TypeScript (React is a TypeScript superset standard); section delegates to `standards/typescript.md` with a clear pointer. No duplication.

### Skills
- **`skills/dev-session/SKILL.md` step 15pre** — replaces single \`PROJECT_STACK\` lookup with **diff-based stack detection**: \`git diff --name-only origin/main...HEAD\` → classify each path against a stack-markers table → run the gate for each detected stack. Documentation/workflow-only changes fall through with "no gate applies" (AC coverage still enforced). Exit block emits one line per stack.
- **`skills/compliance-verify/SKILL.md` Section A.0** — same diff-based detection logic; aggregates per-stack outcomes; FAIL on any stack short-circuits Sections B and C. \`PROJECT_STACK\` still works as an override for single-stack repos.

### Stack markers (canonical)
| Stack | Marker |
|---|---|
| `go` | path ends in `.go`, OR `go.mod`/`go.sum` touched |
| `typescript` | path under a directory containing `package.json` AND ends in `.ts`/`.tsx`/`.mts`/`.cts`/`.js`/`.jsx`/`.mjs`/`.cjs`, OR `package.json`/`package-lock.json`/`tsconfig*.json` touched |
| `react` | as `typescript` PLUS JSX file under a React-importing project; gate is identical to `typescript` |
| `java` | path ends in `.java`, OR `pom.xml`/`build.gradle*` touched |

## Test plan
- [x] \`go test ./internal/mount/...\` — pipeline structure tests still pass
- [ ] After merge: tag v2.8.16, update yapper's `AGENTIC_FRAMEWORK_VERSION` + workflow caller, retrigger Feature #12 (TypeScript only — gate should detect TS stack and run only the TS gate)

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)