### PR TITLE
feat(doctor): detect and repair issues missing from agentic project

### DIFF
--- a/internal/project/check.go
+++ b/internal/project/check.go
@@ -69,6 +69,7 @@ func allCheckSteps() []checkStep {
 		{"Checking project status options...", checkStatusFieldOptions},
 		{"Checking framework version sync...", checkFrameworkVersionSync},
 		{"Checking topology variables...", checkTopologyVars},
+		{"Checking issue membership in project...", checkOrphanProjectIssues},
 	}
 }
 
@@ -562,5 +563,75 @@ func checkFrameworkVersionSync(deps Deps) CheckResult {
 		Name:    "framework-version-sync",
 		Status:  CheckPass,
 		Message: fmt.Sprintf("framework version in sync (%s)", localVersion),
+	}
+}
+
+// checkOrphanProjectIssues detects open issues carrying a type
+// label (feature / requirement / task) that are NOT members of the
+// agentic ProjectV2. The pipeline cannot resolve such issues via
+// `gh agentic status …` — `gh agentic` only reports project members
+// — so a feature-design / dev-session triggered on an orphan halts
+// at "issue not found in project" without producing any artefacts.
+//
+// The gap surfaced on yapper: features #13–#19 were created with
+// the `feature` + `in-design` labels but never added to the
+// project. The feature-design recipe aborted on every one with the
+// same error. This check catches the condition at `gh agentic check`
+// time; `gh agentic repair` then adds the orphans to the project
+// via `addProjectV2ItemById`.
+func checkOrphanProjectIssues(deps Deps) CheckResult {
+	projectID, err := deps.GetRepoVariable(deps.Owner, deps.RepoName, ProjectVarName)
+	if err != nil || projectID == "" {
+		// No project set — earlier checks already report this; no
+		// orphan check is meaningful here.
+		return CheckResult{
+			Name:    "orphan-issues",
+			Status:  CheckWarn,
+			Message: "orphan-issue check skipped — " + ProjectVarName + " not set",
+		}
+	}
+
+	if deps.FetchOrphanIssues == nil {
+		return CheckResult{
+			Name:    "orphan-issues",
+			Status:  CheckWarn,
+			Message: "orphan-issue check skipped — no fetcher configured",
+		}
+	}
+
+	orphans, err := deps.FetchOrphanIssues(deps.Owner, deps.RepoName, projectID)
+	if err != nil {
+		return CheckResult{
+			Name:    "orphan-issues",
+			Status:  CheckWarn,
+			Message: fmt.Sprintf("orphan-issue check failed — %v", err),
+		}
+	}
+
+	if len(orphans) == 0 {
+		return CheckResult{
+			Name:    "orphan-issues",
+			Status:  CheckPass,
+			Message: "all type-labelled open issues are project members",
+		}
+	}
+
+	// Build a compact summary: "#13, #14, #15 (3 orphan issue(s))"
+	parts := make([]string, 0, len(orphans))
+	for _, o := range orphans {
+		parts = append(parts, fmt.Sprintf("#%d", o.Number))
+	}
+	noun := "issue"
+	if len(orphans) > 1 {
+		noun = "issues"
+	}
+	return CheckResult{
+		Name:   "orphan-issues",
+		Status: CheckFail,
+		Message: fmt.Sprintf(
+			"%d open %s carrying a type label but missing from the project: %s",
+			len(orphans), noun, strings.Join(parts, ", "),
+		),
+		Remediation: "run 'gh agentic repair' to add each orphan to the agentic project",
 	}
 }

--- a/internal/project/deps.go
+++ b/internal/project/deps.go
@@ -41,6 +41,8 @@ type Deps struct {
 	FetchProjectsForOwner    FetchProjectsForOwnerFunc
 	FetchProjectTitle        FetchProjectTitleFunc
 	FetchProjectOwner        FetchProjectOwnerFunc
+	FetchOrphanIssues        FetchOrphanIssuesFunc
+	AddIssueToProject        AddIssueToProjectFunc
 	Run                      auth.RunCommandFunc
 }
 
@@ -73,6 +75,8 @@ func DefaultDeps(owner, repoName, root string) Deps {
 		FetchProjectsForOwner:    DefaultFetchProjectsForOwner,
 		FetchProjectTitle:        DefaultFetchProjectTitle,
 		FetchProjectOwner:        DefaultFetchProjectOwner,
+		FetchOrphanIssues:        DefaultFetchOrphanIssues,
+		AddIssueToProject:        DefaultAddIssueToProject,
 		Run:                      auth.DefaultRunCommand,
 	}
 }

--- a/internal/project/info_test.go
+++ b/internal/project/info_test.go
@@ -85,6 +85,14 @@ func testDeps(owner, repo string) Deps {
 			}
 			return "", nil
 		},
+		// Orphan-issue check defaults: empty list (no orphans). Tests that
+		// want to exercise the orphan-detection path override these locally.
+		FetchOrphanIssues: func(owner, repo, projectID string) ([]OrphanIssue, error) {
+			return nil, nil
+		},
+		AddIssueToProject: func(projectID, issueNodeID string) error {
+			return nil
+		},
 	}
 }
 

--- a/internal/project/orphan_issues.go
+++ b/internal/project/orphan_issues.go
@@ -1,0 +1,194 @@
+package project
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+)
+
+// OrphanIssue describes an issue carrying a type label
+// (feature / requirement / task) but missing from the agentic
+// ProjectV2 board. The pipeline cannot resolve these issues via
+// `gh agentic status …`, so the agent halts during design at
+// "issue not found in project" — the symptom that surfaced this
+// gap on yapper.
+type OrphanIssue struct {
+	Number int
+	NodeID string
+	Title  string
+	Labels []string // the type label(s) the issue carries
+}
+
+// FetchOrphanIssuesFunc returns the list of open issues carrying a
+// type label that are NOT members of the named project.
+type FetchOrphanIssuesFunc func(owner, repo, projectID string) ([]OrphanIssue, error)
+
+// AddIssueToProjectFunc adds a single issue to a ProjectV2 board via
+// the `addProjectV2ItemById` GraphQL mutation. Idempotent — adding
+// an issue that is already a member returns the existing item ID.
+type AddIssueToProjectFunc func(projectID, issueNodeID string) error
+
+// graphqlOrphanIssuesResponse is the response shape of the
+// triple-aliased query that fetches all type-labelled open issues.
+type graphqlOrphanIssuesResponse struct {
+	Repository struct {
+		Features     issueWithProjectsConnection `json:"features"`
+		Requirements issueWithProjectsConnection `json:"requirements"`
+		Tasks        issueWithProjectsConnection `json:"tasks"`
+	} `json:"repository"`
+}
+
+type issueWithProjectsConnection struct {
+	Nodes []issueWithProjectsNode `json:"nodes"`
+}
+
+type issueWithProjectsNode struct {
+	Number       int            `json:"number"`
+	ID           string         `json:"id"`
+	Title        string         `json:"title"`
+	Labels       labelsNode     `json:"labels"`
+	ProjectItems projectsResult `json:"projectItems"`
+}
+
+type labelsNode struct {
+	Nodes []struct {
+		Name string `json:"name"`
+	} `json:"nodes"`
+}
+
+type projectsResult struct {
+	Nodes []struct {
+		Project struct {
+			ID string `json:"id"`
+		} `json:"project"`
+	} `json:"nodes"`
+}
+
+// DefaultFetchOrphanIssues runs one aliased GraphQL query that
+// fetches every open issue carrying a `feature`, `requirement`, or
+// `task` label, with each issue's `projectItems` so we can detect
+// project-membership locally without N+1 round trips.
+//
+// Issues that ARE members of `projectID` are filtered out; the
+// returned slice contains only orphans, sorted by issue number.
+func DefaultFetchOrphanIssues(owner, repo, projectID string) ([]OrphanIssue, error) {
+	if projectID == "" {
+		return nil, fmt.Errorf("project ID is empty")
+	}
+	client, err := api.DefaultGraphQLClient()
+	if err != nil {
+		return nil, fmt.Errorf("creating GraphQL client: %w", err)
+	}
+
+	// Triple-aliased query: GitHub's `labels:` arg on issues is an
+	// AND filter, so we cannot ask for "any of [feature, requirement,
+	// task]" in one call. Three aliased connections in one query is
+	// still one HTTP round trip.
+	const query = `
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    features: issues(states: OPEN, labels: ["feature"], first: 100) {
+      nodes { ...IssueWithProjects }
+    }
+    requirements: issues(states: OPEN, labels: ["requirement"], first: 100) {
+      nodes { ...IssueWithProjects }
+    }
+    tasks: issues(states: OPEN, labels: ["task"], first: 100) {
+      nodes { ...IssueWithProjects }
+    }
+  }
+}
+fragment IssueWithProjects on Issue {
+  number
+  id
+  title
+  labels(first: 20) { nodes { name } }
+  projectItems(first: 10) { nodes { project { id } } }
+}`
+
+	var resp graphqlOrphanIssuesResponse
+	if err := client.Do(query, map[string]interface{}{
+		"owner": owner,
+		"repo":  repo,
+	}, &resp); err != nil {
+		return nil, fmt.Errorf("querying orphan issues for %s/%s: %w", owner, repo, err)
+	}
+
+	// Merge the three connections by node ID — an issue can appear
+	// in two (e.g. a `task` that's also somehow labelled `feature`,
+	// rare but possible). De-dupe to avoid double-counting orphans.
+	merged := map[string]issueWithProjectsNode{}
+	for _, n := range resp.Repository.Features.Nodes {
+		merged[n.ID] = n
+	}
+	for _, n := range resp.Repository.Requirements.Nodes {
+		merged[n.ID] = n
+	}
+	for _, n := range resp.Repository.Tasks.Nodes {
+		merged[n.ID] = n
+	}
+
+	var orphans []OrphanIssue
+	for _, n := range merged {
+		if isMemberOfProject(n.ProjectItems, projectID) {
+			continue
+		}
+		labels := make([]string, 0, len(n.Labels.Nodes))
+		for _, lbl := range n.Labels.Nodes {
+			labels = append(labels, lbl.Name)
+		}
+		orphans = append(orphans, OrphanIssue{
+			Number: n.Number,
+			NodeID: n.ID,
+			Title:  n.Title,
+			Labels: labels,
+		})
+	}
+	sort.Slice(orphans, func(i, j int) bool {
+		return orphans[i].Number < orphans[j].Number
+	})
+	return orphans, nil
+}
+
+// isMemberOfProject returns true if any of the issue's projectItems
+// belongs to the named project.
+func isMemberOfProject(items projectsResult, projectID string) bool {
+	for _, item := range items.Nodes {
+		if item.Project.ID == projectID {
+			return true
+		}
+	}
+	return false
+}
+
+// DefaultAddIssueToProject adds an issue to a ProjectV2 via the
+// `addProjectV2ItemById` mutation. The mutation is idempotent at the
+// GraphQL layer — adding an already-present issue returns its
+// existing item ID without error.
+func DefaultAddIssueToProject(projectID, issueNodeID string) error {
+	client, err := api.DefaultGraphQLClient()
+	if err != nil {
+		return fmt.Errorf("creating GraphQL client: %w", err)
+	}
+	const mutation = `
+mutation($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+    item { id }
+  }
+}`
+	var resp struct {
+		AddProjectV2ItemById struct {
+			Item struct {
+				ID string `json:"id"`
+			} `json:"item"`
+		} `json:"addProjectV2ItemById"`
+	}
+	if err := client.Do(mutation, map[string]interface{}{
+		"projectId": projectID,
+		"contentId": issueNodeID,
+	}, &resp); err != nil {
+		return fmt.Errorf("adding issue %s to project %s: %w", issueNodeID, projectID, err)
+	}
+	return nil
+}

--- a/internal/project/orphan_issues_test.go
+++ b/internal/project/orphan_issues_test.go
@@ -1,0 +1,155 @@
+package project
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestCheckOrphanProjectIssues_NoOrphans confirms the check passes
+// when no type-labelled issues are missing from the project.
+func TestCheckOrphanProjectIssues_NoOrphans(t *testing.T) {
+	deps := testDeps("owner", "myrepo")
+	result := checkOrphanProjectIssues(deps)
+	if result.Status != CheckPass {
+		t.Errorf("expected CheckPass, got %v — message: %s", result.Status, result.Message)
+	}
+}
+
+// TestCheckOrphanProjectIssues_FailsWhenOrphansExist confirms the
+// check returns a Fail result listing every orphan issue.
+func TestCheckOrphanProjectIssues_FailsWhenOrphansExist(t *testing.T) {
+	deps := testDeps("owner", "myrepo")
+	deps.FetchOrphanIssues = func(owner, repo, projectID string) ([]OrphanIssue, error) {
+		return []OrphanIssue{
+			{Number: 13, NodeID: "I_13", Title: "Whisper STT", Labels: []string{"feature"}},
+			{Number: 14, NodeID: "I_14", Title: "Foo", Labels: []string{"feature"}},
+			{Number: 15, NodeID: "I_15", Title: "Bar", Labels: []string{"feature"}},
+		}, nil
+	}
+	result := checkOrphanProjectIssues(deps)
+	if result.Status != CheckFail {
+		t.Errorf("expected CheckFail, got %v", result.Status)
+	}
+	for _, want := range []string{"#13", "#14", "#15", "3 open issues"} {
+		if !strings.Contains(result.Message, want) {
+			t.Errorf("expected message to contain %q — got %q", want, result.Message)
+		}
+	}
+	if result.Remediation == "" {
+		t.Error("expected a remediation string")
+	}
+}
+
+// TestCheckOrphanProjectIssues_SkipsWhenNoProjectID confirms the
+// check returns a Warn (not Fail) when the project variable is
+// unset — earlier checks already report that, no need to compound.
+func TestCheckOrphanProjectIssues_SkipsWhenNoProjectID(t *testing.T) {
+	deps := testDeps("owner", "myrepo")
+	deps.GetRepoVariable = func(o, r, n string) (string, error) {
+		return "", errors.New("not set")
+	}
+	result := checkOrphanProjectIssues(deps)
+	if result.Status != CheckWarn {
+		t.Errorf("expected CheckWarn, got %v", result.Status)
+	}
+}
+
+// TestCheckOrphanProjectIssues_WarnsOnFetchError confirms the check
+// degrades gracefully when the API call fails. A transient GitHub
+// error should not block the whole check report.
+func TestCheckOrphanProjectIssues_WarnsOnFetchError(t *testing.T) {
+	deps := testDeps("owner", "myrepo")
+	deps.FetchOrphanIssues = func(owner, repo, projectID string) ([]OrphanIssue, error) {
+		return nil, errors.New("transient API failure")
+	}
+	result := checkOrphanProjectIssues(deps)
+	if result.Status != CheckWarn {
+		t.Errorf("expected CheckWarn on fetch error, got %v", result.Status)
+	}
+	if !strings.Contains(result.Message, "transient API failure") {
+		t.Errorf("expected message to surface the underlying error — got %q", result.Message)
+	}
+}
+
+// TestRepairOrphanIssues_AddsEachOrphan confirms the repair iterates
+// the orphan list and calls AddIssueToProject for each one.
+func TestRepairOrphanIssues_AddsEachOrphan(t *testing.T) {
+	deps := testDeps("owner", "myrepo")
+	deps.FetchOrphanIssues = func(owner, repo, projectID string) ([]OrphanIssue, error) {
+		return []OrphanIssue{
+			{Number: 13, NodeID: "I_13", Title: "Whisper STT"},
+			{Number: 14, NodeID: "I_14", Title: "Foo"},
+		}, nil
+	}
+	calledWith := []string{}
+	deps.AddIssueToProject = func(projectID, issueNodeID string) error {
+		calledWith = append(calledWith, projectID+":"+issueNodeID)
+		return nil
+	}
+	var buf bytes.Buffer
+	if err := repairOrphanIssues(&buf, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calledWith) != 2 {
+		t.Errorf("expected 2 calls to AddIssueToProject, got %d (%v)", len(calledWith), calledWith)
+	}
+	for _, want := range []string{"PVT_test123:I_13", "PVT_test123:I_14"} {
+		found := false
+		for _, got := range calledWith {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected AddIssueToProject called with %q — got %v", want, calledWith)
+		}
+	}
+	if !strings.Contains(buf.String(), "Added #13") || !strings.Contains(buf.String(), "Added #14") {
+		t.Errorf("expected per-issue ✓ lines in output — got:\n%s", buf.String())
+	}
+}
+
+// TestRepairOrphanIssues_PartialFailureReportsAggregateError
+// confirms that when one issue add fails, the repair surfaces what
+// succeeded vs failed rather than silently swallowing the error.
+func TestRepairOrphanIssues_PartialFailureReportsAggregateError(t *testing.T) {
+	deps := testDeps("owner", "myrepo")
+	deps.FetchOrphanIssues = func(owner, repo, projectID string) ([]OrphanIssue, error) {
+		return []OrphanIssue{
+			{Number: 13, NodeID: "I_13", Title: "ok"},
+			{Number: 14, NodeID: "I_14", Title: "fails"},
+		}, nil
+	}
+	deps.AddIssueToProject = func(projectID, issueNodeID string) error {
+		if issueNodeID == "I_14" {
+			return errors.New("API rejected")
+		}
+		return nil
+	}
+	var buf bytes.Buffer
+	err := repairOrphanIssues(&buf, deps)
+	if err == nil {
+		t.Fatal("expected an aggregate error reporting the failed add")
+	}
+	if !strings.Contains(err.Error(), "#14") || !strings.Contains(err.Error(), "API rejected") {
+		t.Errorf("expected error to surface #14 and underlying cause — got %q", err)
+	}
+	if !strings.Contains(err.Error(), "added 1") {
+		t.Errorf("expected error to report the successful adds — got %q", err)
+	}
+}
+
+// TestRepairOrphanIssues_EmptyList exits cleanly and reports no work.
+func TestRepairOrphanIssues_EmptyList(t *testing.T) {
+	deps := testDeps("owner", "myrepo") // default fake returns nil
+	var buf bytes.Buffer
+	if err := repairOrphanIssues(&buf, deps); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No orphan issues") {
+		t.Errorf("expected 'No orphan issues' message — got:\n%s", buf.String())
+	}
+}

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -111,6 +111,18 @@ func RepairWithProgress(deps Deps, setLabel func(string)) RepairResult {
 				result.Lines = append(result.Lines, strings.TrimRight(buf.String(), "\n"))
 				result.Repaired++
 			}
+		case "orphan-issues":
+			if setLabel != nil {
+				setLabel("Repairing: adding orphan issues to project...")
+			}
+			var buf bytes.Buffer
+			if err := repairOrphanIssues(&buf, deps); err != nil {
+				result.Lines = append(result.Lines, fmt.Sprintf("  %s  Could not add orphan issues to project: %v", ui.StatusDanger.Render("✗"), err))
+				result.Unrepaired++
+			} else {
+				result.Lines = append(result.Lines, strings.TrimRight(buf.String(), "\n"))
+				result.Repaired++
+			}
 		default:
 			result.Lines = append(result.Lines, fmt.Sprintf("  %s  %s — %s",
 				ui.StatusDanger.Render("✗"),
@@ -324,5 +336,50 @@ func repairFramework(w io.Writer, deps Deps) error {
 		return fmt.Errorf("mounting framework: %w", err)
 	}
 	fmt.Fprintf(w, "  %s  Framework mounted at %s\n", ui.StatusOK.Render("✓"), latest)
+	return nil
+}
+
+// repairOrphanIssues adds every open issue carrying a type label
+// (feature / requirement / task) that is missing from the agentic
+// project. Idempotent — the `addProjectV2ItemById` mutation returns
+// the existing item ID for an already-member issue.
+func repairOrphanIssues(w io.Writer, deps Deps) error {
+	projectID, err := deps.GetRepoVariable(deps.Owner, deps.RepoName, ProjectVarName)
+	if err != nil || projectID == "" {
+		return fmt.Errorf("AGENTIC_PROJECT_ID not set")
+	}
+	if deps.FetchOrphanIssues == nil {
+		return fmt.Errorf("no FetchOrphanIssues function configured")
+	}
+	if deps.AddIssueToProject == nil {
+		return fmt.Errorf("no AddIssueToProject function configured")
+	}
+
+	orphans, err := deps.FetchOrphanIssues(deps.Owner, deps.RepoName, projectID)
+	if err != nil {
+		return fmt.Errorf("fetching orphan issues: %w", err)
+	}
+	if len(orphans) == 0 {
+		fmt.Fprintf(w, "  %s  No orphan issues to add\n", ui.StatusOK.Render("✓"))
+		return nil
+	}
+
+	var failures []string
+	added := 0
+	for _, o := range orphans {
+		if err := deps.AddIssueToProject(projectID, o.NodeID); err != nil {
+			failures = append(failures, fmt.Sprintf("#%d (%v)", o.Number, err))
+			continue
+		}
+		fmt.Fprintf(w, "  %s  Added #%d to project: %s\n",
+			ui.StatusOK.Render("✓"), o.Number, o.Title)
+		added++
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("added %d, failed %d: %s",
+			added, len(failures), strings.Join(failures, "; "))
+	}
+	fmt.Fprintf(w, "  %s  %d orphan issue(s) added to project\n",
+		ui.StatusOK.Render("✓"), added)
 	return nil
 }


### PR DESCRIPTION
## Background

Yapper Feature #13 (Whisper STT via Transformers.js + ONNX Web) failed Stage 3 (feature-design) on its first trigger. The Goose recipe correctly diagnosed the root cause and halted cleanly:

> Issue #13 carries the \`feature\` + \`in-design\` labels but is NOT a member of the Agentic ProjectV2 (\`yapper\` / \`PVT_kwHOBODmNc4BYUnq\`). Its \`projectItems\` array is empty. \`gh agentic\` only resolves issues that are project members, so the skill cannot capture the required feature state at step 2.

The agent's own spot check found that **9 of yapper's 12 type-labelled issues were orphans** — Features #8–#11 (closed) and #13–#19 (open) all carry lifecycle labels but were never added to the project.

\`gh agentic check\`/\`repair\` didn't catch this because the existing checks audit the **repo's** project affiliation, not each issue's project membership.

## Changes

### Detection — \`checkOrphanProjectIssues\`

New check (wired in as "Checking issue membership in project...") that:
- Runs **one** triple-aliased GraphQL query for every open \`feature\` / \`requirement\` / \`task\` issue with each issue's \`projectItems\` inline — no N+1 round trips
- Returns CheckFail with a compact \`#13, #14, #15 (N orphan issue(s))\` message
- Degrades to CheckWarn (not Fail) when \`AGENTIC_PROJECT_ID\` is unset or the API call fails

### Repair — \`repairOrphanIssues\`

New repair branch (\`case "orphan-issues"\`) that:
- Iterates the orphan list and calls \`addProjectV2ItemById\` for each one
- The mutation is idempotent — adding an already-member issue is a no-op
- Reports per-issue ✓ lines + aggregate count
- On partial failure (e.g. permission error on one issue), returns an aggregate error reporting which ones succeeded and which failed

### Infrastructure

| File | Change |
|---|---|
| \`internal/project/orphan_issues.go\` (new) | \`OrphanIssue\` type, function types, \`DefaultFetchOrphanIssues\` (triple-aliased query), \`DefaultAddIssueToProject\` (mutation) |
| \`internal/project/check.go\` | New \`checkOrphanProjectIssues\` function; wired into \`allCheckSteps()\` |
| \`internal/project/repair.go\` | New \`repairOrphanIssues\` function; new \`case "orphan-issues"\` in repair switch |
| \`internal/project/deps.go\` | New \`FetchOrphanIssues\` + \`AddIssueToProject\` fields on \`Deps\`, wired through \`DefaultDeps\` |
| \`internal/project/info_test.go\` | \`testDeps\` fake gets default stubs so existing tests stay green |
| \`internal/project/orphan_issues_test.go\` (new) | 7 focused tests: pass / fail / fetch-error / no-project-ID paths on check, plus add-each / partial-failure / empty-list on repair |

## Test plan

- [x] \`go test ./...\` — all packages green
- [x] New \`TestCheckOrphanProjectIssues_*\` + \`TestRepairOrphanIssues_*\` (7 tests) cover happy path, no-orphans, fetch-error, missing-config, multi-orphan add, partial-failure aggregate error, and empty-list
- [ ] After merge: tag v2.8.18, bump yapper, run \`gh agentic check\` against yapper → expect \`✗ 7 open issues carrying a type label but missing from the project: #13, #14, #15, #16, #17, #18, #19\`. Then \`gh agentic repair\` → expect 7 \`Added #X to project: …\` lines. Retrigger feature-design on #13 → expect clean run

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)