### PR TITLE
feat(setup-goose-env): conditional language toolchain installation (Go, Java)

### DIFF
--- a/.github/actions/setup-goose-env/action.yml
+++ b/.github/actions/setup-goose-env/action.yml
@@ -1,10 +1,18 @@
 name: Setup Goose Environment
 description: >
   Validates the framework version, installs Node.js, AI tools (Goose, Claude Code
-  CLI, gh-agentic extension), configures agent authentication, and writes the Goose
-  config file. Encapsulates the six setup steps that are identical across every
-  Goose-running pipeline job so the workflow stays thin and the logic stays in one
+  CLI, gh-agentic extension), conditionally installs project-specific language
+  toolchains (Go, Java) based on repo manifests, configures agent authentication,
+  and writes the Goose config file. Encapsulates every setup step the Goose-running
+  pipeline jobs need so the workflow stays thin and the logic stays in one
   authoritative place.
+
+  Conditional toolchain install: Go is installed when `go.mod` is present in the
+  repo root; Java is installed when `pom.xml` or `build.gradle[.kts]` is present.
+  Node.js is installed unconditionally because the Claude CLI itself is an npm
+  package. The agent uses these toolchains to verify its work as it writes —
+  without them the dev-session writes code blind, which is the root cause of
+  features that fail their PR-time CI gate.
 
   Auth note: pipeline-pat is used for both the gh-agentic extension install (reads
   the release) and for Claude credential rotation (requires secrets:write). The same
@@ -97,6 +105,62 @@ runs:
         claude-credentials-json: ${{ inputs.claude-credentials-json }}
         mistral-api-key: ${{ inputs.mistral-api-key }}
         gh-token: ${{ inputs.pipeline-pat }}
+
+    # Detect which language toolchains the *project* needs based on
+    # repo-root manifests. The agent uses these to verify its work as it
+    # writes — without them the dev-session writes code blind, which is
+    # the root cause of "code that fails the PR-time build" symptoms.
+    # Detection runs after checkout (which has already happened in the
+    # caller's job) and BEFORE the Goose recipe runs.
+    #
+    # Node.js is installed unconditionally above because the Claude CLI
+    # itself is an npm package; the agent needs it regardless of whether
+    # the project uses TypeScript.
+    #
+    # Adding a new language is a four-step add:
+    #   1. Add `standards/<lang>.md` with a `## Verification Gate` section
+    #   2. Add a `<lang>=true/false` line to "Detect project languages"
+    #   3. Add a `Setup <lang>` step gated on the corresponding output
+    #   4. (Optional) Add any apt deps to `install-ai-tools`
+    - name: Detect project languages
+      id: stacks
+      shell: bash
+      run: |
+        # go.mod at repo root → this is a Go module → install Go.
+        if [ -f go.mod ]; then
+          echo "go=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "go=false" >> "$GITHUB_OUTPUT"
+        fi
+        # Maven or Gradle build file → this is a Java project → install JDK.
+        if [ -f pom.xml ] || [ -f build.gradle ] || [ -f build.gradle.kts ]; then
+          echo "java=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "java=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Install Go only when the repo is actually a Go module. Pins to the
+    # Go version stated in go.mod so the agent verifies against the same
+    # toolchain the project targets. cache=false because dev-session
+    # runs are ephemeral; the cache hit rate would be low and not worth
+    # the network round-trip.
+    - name: Setup Go
+      if: steps.stacks.outputs.go == 'true'
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    # Install JDK only when the repo is actually a Java project. java-version
+    # is 21 (current LTS) as a pragmatic default; per-project version pinning
+    # can be added later via `java-version-file` (.java-version, etc.) if a
+    # project needs it.
+    - name: Setup Java
+      if: steps.stacks.outputs.java == 'true'
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+      with:
+        distribution: temurin
+        java-version: '21'
 
     # Write provider/model to the Goose config file so they are the defaults even
     # if the env vars are not inherited by a subprocess. The recipe run step also

--- a/skills/compliance-verify/SKILL.md
+++ b/skills/compliance-verify/SKILL.md
@@ -325,14 +325,34 @@ For each detected stack, load `standards/<stack>.md` →
 `## Verification Gate (build + test)`, execute the listed commands
 verbatim, in order, from the repo root.
 
+**Per-stack pre-check — manifest eligibility.** Before attempting
+to run any gate commands, check whether the stack's **manifest
+file** is present in the repo:
+
+| Stack | Manifest probe |
+|---|---|
+| `go` | `test -f go.mod` |
+| `typescript` / `react` | `test -f package.json` (at repo root, or in the closest enclosing directory of every changed JS/TS file) |
+| `java` | `test -f pom.xml` OR `test -f build.gradle` OR `test -f build.gradle.kts` |
+
+If the manifest is **not present** for a detected stack, record
+`gate=SKIPPED-no-manifest` for that stack and continue without
+running the gate commands. This is **not a fail**. The compliance
+report's gate section lists the stack as `SKIPPED — manifest
+<name> not present` and proceeds to the next stack (or to Section
+B if every detected stack is SKIPPED).
+
 **Per-stack outcomes** (aggregate across all stacks):
 
-1. **All commands exit zero** → record `gate=PASS` plus the
-   captured command output summary into working memory. Continue
-   to Section B. The compliance report's first section reflects
-   the PASS.
+1. **Manifest absent** → `gate=SKIPPED-no-manifest`. Recorded in
+   the gate section of the report; not counted as a failure.
+   Continue to the next stack.
 
-2. **Any command exits non-zero** → record `gate=FAIL` plus the
+2. **All commands exit zero** → record `gate=PASS` plus the
+   captured command output summary. Continue to the next stack
+   (then to Section B).
+
+3. **Any command exits non-zero** → record `gate=FAIL` plus the
    captured failure output. Skip Section B (static analysis) and
    Section C (AC evaluation) entirely — ACs cannot be PASS while
    the build is broken. Jump directly to Section D with
@@ -340,18 +360,22 @@ verbatim, in order, from the repo root.
    failed". The overall verdict is FAIL with the gate-failure
    output as the structured violation list.
 
-3. **Toolchain unavailable** (e.g. `go` not on PATH, the standards
-   file lists tools the runner does not have) → record
-   `gate=BLOCKED`. Do NOT post a FAIL verdict — a BLOCKED verdict
-   is qualitatively different. Apply the `needs-human-review`
-   label (this is not part of the FAIL cycle; it is a runner
-   environment failure the human must resolve). Post a
-   `<!-- compliance-blocked:v1 -->` comment surfacing the missing
-   tool and the standards-file requirement. Exit with Output D.
-   Subsequent runs on the same Feature pick up only when the
-   human has installed the toolchain and re-toggled the label.
+4. **Toolchain unavailable** — manifest IS present but the
+   toolchain isn't on PATH (e.g. `go.mod` exists but `which go`
+   exits non-zero; `package.json` exists but `which node` exits
+   non-zero) → record `gate=SKIPPED-toolchain-absent`. Do NOT
+   post a FAIL verdict, do NOT post a BLOCKED verdict, do NOT
+   apply `needs-human-review`. Post a
+   `<!-- compliance-warn:v1 -->` comment surfacing the missing
+   tool, the manifest that triggered the eligibility check, and
+   the recommendation to install the toolchain on the runner
+   image (`actions/setup-go@v5`, `actions/setup-node@v4`, etc.).
+   Continue to Section B; the AC table proceeds based on what
+   CAN be verified. CI (`build-and-test.yml` or equivalent) is
+   the authoritative backstop for actually running the gate
+   commands once the PR is open.
 
-4. **No standards file** for the active stack (no
+5. **No standards file** for the active stack (no
    `standards/<stack>.md` exists, or the file has no
    `## Verification Gate` section) → raise
    `STACK_GATE_UNDEFINED` (`ERROR`). The compliance verifier
@@ -359,30 +383,30 @@ verbatim, in order, from the repo root.
    Surface the missing file to the human as a framework-level fix
    needed; exit with Output D.
 
-The gate's outcome is the first line of the compliance report
-(see step 14). When the report shows AC PASS but the gate ran
-and failed, that is a protocol violation — the gate gates
-everything.
+The gate's outcomes (one line per detected stack) form the first
+section of the compliance report. When any stack reports PASS or
+FAIL, those verdicts gate Section B / C as described. When every
+stack reports SKIPPED (either no-manifest or toolchain-absent),
+the report notes "no executable gate ran; CI is the backstop"
+and proceeds to Section B with that caveat recorded.
 
-#### The no-inspection rule (symmetric)
+#### The no-inspection rule (preserved)
 
-Two failure modes both trace to the same root cause — the agent
-deciding it knows the gate result without having actually run it.
-Both are forbidden:
+The softening above relaxes the verdict on toolchain-absent — it
+does NOT relax the principle that drove v2.8.15. Both inspection
+traps remain forbidden:
 
 - **Compliance MUST NOT mark "build and tests pass" as PASS by
-  code inspection.** Inferring success from a clean-looking diff is
-  the trap that lets broken code reach a PR.
+  code inspection.** Inferring success from a clean-looking diff
+  is the trap that lets broken code reach a PR. SKIPPED is the
+  correct verdict, not PASS.
 
-- **Compliance MUST NOT mark "build and tests pass" as FAIL by code
-  inspection either.** This includes citing a CI run from another
-  branch, a closed PR, or any commit other than the current HEAD of
-  the feature branch as evidence. The reverse trap escalates
-  correct work to `needs-human-review` based on stale data.
+- **Compliance MUST NOT mark "build and tests pass" as FAIL by
+  code inspection either.** This includes citing a CI run from
+  another branch, a closed PR, or any commit other than the
+  current HEAD of the feature branch as evidence.
 
-If the gate could not run on the current branch HEAD, the verdict
-for AC-9 (build + test) is **BLOCKED**, recorded as such, and the
-cycle does not advance. Three valid evidence shapes for AC-9:
+The valid evidence shapes for the build+test AC are now:
 
 - **PASS** — every gate command exited zero; evidence cites the
   commands run plus the current commit SHA (e.g. `go build ./...
@@ -390,10 +414,13 @@ cycle does not advance. Three valid evidence shapes for AC-9:
 - **FAIL** — at least one gate command exited non-zero; evidence
   reproduces the failure output (test name, error line) plus the
   current commit SHA.
-- **BLOCKED** — the gate did not run (toolchain absent, standards
-  file missing); evidence reads `BLOCKED — <reason>` with a
-  remediation pointer. No fabricated CI run IDs, no synthetic
-  commit references.
+- **SKIPPED-no-manifest** — the stack's manifest isn't present;
+  this scope is not a project of that stack.
+- **SKIPPED-toolchain-absent** — manifest IS present but the
+  toolchain isn't on the runner; evidence reads `SKIPPED —
+  <toolchain> not installed on runner; install via
+  <remediation>; CI is the backstop`. No fabricated CI run IDs,
+  no synthetic commit references.
 
 #### No proxy evidence
 

--- a/skills/dev-session/SKILL.md
+++ b/skills/dev-session/SKILL.md
@@ -507,14 +507,30 @@ discipline at task granularity:
 
     **For each stack in `<stacks>`:**
 
-    1. Load `standards/<stack>.md` and find the
+    1. **Manifest pre-check** — confirm the stack's manifest is
+       present in the repo before attempting any gate commands:
+
+       | Stack | Probe |
+       |---|---|
+       | `go` | `test -f go.mod` |
+       | `typescript` / `react` | `test -f package.json` (root, or in the closest enclosing directory of every changed JS/TS file) |
+       | `java` | `test -f pom.xml` OR `test -f build.gradle` OR `test -f build.gradle.kts` |
+
+       If the manifest is absent, record `<stack>: SKIPPED — no
+       manifest` and move on to the next stack. This is not a
+       failure; the change is not within a project of that stack.
+
+    2. Load `standards/<stack>.md` and find the
        `## Verification Gate (build + test)` section.
-    2. Execute the listed commands verbatim, in order, from the
-       repo root.
-    3. Record the per-stack outcome.
+    3. Execute the listed commands verbatim, in order, from the
+       repo root (or the directory containing the manifest, for
+       monorepo-nested projects).
+    4. Record the per-stack outcome.
 
     **Per-stack outcomes:**
 
+    - **Manifest absent** → record `<stack>: SKIPPED — no manifest`
+      and continue. Not a failure.
     - **All commands exit zero** → record `<stack>: PASS` in
       working memory.
     - **Any command exits non-zero** → the dev session has produced
@@ -523,15 +539,18 @@ discipline at task granularity:
       recently committed), and fix it. Commit the fix with the
       task-N-of-M format (a fix commit counts as a continuation of
       the task whose work it corrects). Re-run the gate (all
-      stacks). Repeat until every stack reports PASS. The dev
-      session exits only on a clean gate across every detected
-      stack.
-    - **Toolchain unavailable** (e.g. `go` not on PATH for the `go`
-      stack, `node` not on PATH for the `typescript` stack) →
-      raise `VERIFICATION_TOOLCHAIN_MISSING` (`ERROR`) and exit
-      Output D. The dev session never claims completion without an
-      actual gate run; downstream compliance will surface the same
-      gap.
+      stacks). Repeat until every stack reports PASS or SKIPPED.
+      The dev session exits only on a clean gate across every
+      detected stack.
+    - **Toolchain unavailable** — manifest IS present but the
+      toolchain isn't on PATH (e.g. `go.mod` exists but `which go`
+      exits non-zero) → record `<stack>: SKIPPED —
+      <toolchain> not installed on runner; install via
+      <remediation>; CI is the backstop`. Continue to the next
+      stack. This is NOT a fail and the dev session is permitted
+      to exit (downstream compliance will run the same gate
+      against the same runner and emit a matching warning;
+      the PR-time CI is the authoritative backstop).
 
     **No standards file** for a detected stack (no
     `standards/<stack>.md` exists, or the file has no
@@ -542,7 +561,8 @@ discipline at task granularity:
 
     Record every per-stack outcome in working memory for inclusion
     in the exit block (step 18). The exit block lists each stack
-    + its commands + its result.
+    + its commands + its result (PASS / FAIL / SKIPPED with
+    reason).
 
 15a. **Acceptance-criteria coverage gate.** Before the closeout
     label flips, verify that every Feature acceptance criterion

--- a/standards/go.md
+++ b/standards/go.md
@@ -41,8 +41,8 @@ Never claim an implementation is complete without all four passing.
 
 ## Verification Gate (build + test)
 
-The build+test pass is a **mandatory gate** at two specific points in
-the pipeline. The same two commands run in both places:
+The build+test pass is the **mandatory gate** at two specific
+points in the pipeline. The same two commands run in both places:
 
 ```bash
 go build ./...
@@ -51,44 +51,95 @@ go test ./...
 
 Both must exit zero. Any non-zero exit — compilation failure,
 failing test, vet failure surfaced through `go test`, race-detector
-data race report under `go test -race`, etc. — fails the gate.
+data race report under `go test -race`, etc. — **fails** the gate.
+
+### Stack-eligibility pre-check (manifest presence)
+
+The Go gate only applies to a repository when its **manifest file
+is present**:
+
+```bash
+test -f go.mod
+```
+
+If `go.mod` is **not** present at the repo root (i.e. this isn't a
+Go module), the Go gate is **not eligible** for this repository.
+Compliance and the dev session SKIP the gate with a WARN ("Go
+manifest `go.mod` not present — Go gate not applicable to this
+repo"); the verdict is **not a fail**.
+
+This handles the legitimate case where a multi-stack repo (e.g.
+Go + TypeScript) gets a Feature whose diff touches only Go-extension
+files in a directory that is NOT a Go module — those files are not
+verifiable as a Go project and the gate should not pretend
+otherwise.
 
 ### Dev Session — last step before exit
 
 After the final task commit and before the workflow applies
-`in-verification`, the dev session **MUST** run the gate. On failure
-the dev session does NOT exit cleanly — it loops back to fix the
-breakage and re-runs the gate until it passes. Pushing a broken
-build or a failing test suite to the feature branch and signalling
-completion is forbidden.
+`in-verification`, the dev session **MUST** run the gate when
+eligible (manifest present). On gate failure the dev session does
+NOT exit cleanly — it loops back to fix the breakage and re-runs
+the gate until it passes. Pushing a broken build or a failing test
+suite and signalling completion is forbidden.
 
-The dev session's exit block must state whether the gate ran and
-what its result was. An exit block that omits the gate result is
-itself a protocol violation.
+The dev session's exit block must state, for each touched stack,
+whether the gate ran and what its result was (PASS / FAIL / SKIPPED).
+An exit block that omits the gate result is itself a protocol
+violation.
 
 ### Compliance Verify — first step before any other check
 
-The compliance verifier **MUST** run the gate before evaluating
-acceptance criteria, static analysis, or any other check. On
-failure the verifier emits an immediate FAIL verdict and
-short-circuits — ACs cannot be PASS while the build is broken or
-the tests fail, regardless of what code inspection suggests.
+The compliance verifier **MUST** run the gate (when eligible)
+before evaluating acceptance criteria, static analysis, or any
+other check. On gate failure the verifier emits an immediate FAIL
+verdict and short-circuits — ACs cannot be PASS while the build is
+broken or the tests fail, regardless of what code inspection
+suggests.
 
 The gate's run-and-result is the first item in the compliance
 report. Subsequent sections (static analysis, AC table) appear only
-when the gate passed.
+when the gate passed or was skipped per the rules below.
 
 ### When the toolchain is unavailable
 
-If `go` is not on the runner's PATH, the only correct verdict is
-**BLOCKED**, never PASS. Compliance MUST NOT infer build/test
-correctness from diff inspection alone. A BLOCKED verdict leaves
-the Feature at `in-verification` with a clear remediation ("install
-Go toolchain on the runner") — the human resolves before re-running.
+If `go.mod` IS present but `go` is **not** on the runner's PATH,
+the gate is treated as **SKIPPED with a WARN** — not as PASS, not
+as FAIL, not as BLOCKED. The recipe records:
 
-A PR opened against work whose AC9 was marked PASS by inspection
-rather than by an actual gate run is a verification-process bug —
-the rule above closes it.
+- a `compliance-warn:v1` comment noting that the Go gate was skipped
+  because the toolchain isn't installed on the runner, with the
+  exact `which go` / probe output
+- a recommendation to install the Go toolchain on the runner image
+  (via `actions/setup-go@v5` or an apt step) so the gate can actually
+  run on the next cycle
+- AC verdicts for build / test fields are marked **WARN — skipped**
+  rather than PASS or FAIL
+
+Compliance still produces an overall verdict, runs the static
+analysis section, and evaluates the AC table. The PR is permitted
+to open. CI ( `build-and-test.yml` or equivalent) is the
+authoritative backstop for actually running the tests once the PR
+is open.
+
+This is a deliberate softening of an earlier rule (v2.8.15) that
+required BLOCKED on toolchain absence. The softening is the right
+trade-off when the alternative is permanent stuck-state for a
+real Feature whose runner image cannot be changed in the moment.
+The intent is preserved by the "WARN, never PASS by inspection"
+rule below.
+
+### What is still forbidden
+
+- **PASS-by-inspection is still forbidden.** Compliance MUST NOT
+  emit a PASS verdict for the gate based on diff inspection alone.
+  The gate is either PASS (commands ran and exited zero), FAIL
+  (commands ran and exited non-zero), or SKIPPED-with-WARN
+  (commands could not run). No fourth state.
+- **FAIL-by-inspection is still forbidden.** Compliance MUST NOT
+  emit FAIL based on a CI run from a closed PR, sibling branch, or
+  any commit other than the current branch HEAD. Same trap, opposite
+  direction.
 
 ---
 

--- a/standards/react.md
+++ b/standards/react.md
@@ -27,17 +27,19 @@ for the full contract:
 
 - The same gate commands apply: `npx tsc --noEmit`, `npm test`,
   `npm run build`.
-- The dev-session runs the gate as its last step before exit; on
-  failure it loops back and never claims completion.
-- The compliance verifier runs the gate as its first step before any
-  AC evaluation; FAIL short-circuits, BLOCKED applies when the
-  toolchain is absent.
-- No FAIL-by-inspection, no PASS-by-inspection — BLOCKED is the only
-  correct verdict when the gate cannot actually run.
+- The same manifest-presence pre-check applies (`package.json`).
+- The dev-session runs the gate as its last step before exit when
+  the gate is eligible; on FAIL it loops back and never claims
+  completion.
+- The compliance verifier runs the gate as its first step before
+  any AC evaluation when the gate is eligible; FAIL short-circuits.
+- When the toolchain is absent on the runner, the gate is treated
+  as **SKIPPED with a WARN** — not PASS, not FAIL, not BLOCKED.
+  PASS-by-inspection and FAIL-by-inspection both remain forbidden.
 
 Skills loading the gate definition may load either `standards/react.md`
-or `standards/typescript.md` for a React project — the gate contract is
-the same.
+or `standards/typescript.md` for a React project — the gate contract
+is the same.
 
 ---
 

--- a/standards/typescript.md
+++ b/standards/typescript.md
@@ -51,8 +51,8 @@ npx prettier --write .
 
 ## Verification Gate (build + test)
 
-The build+test pass is a **mandatory gate** at two specific points in
-the pipeline. The same three commands run in both places:
+The build+test pass is the **mandatory gate** at two specific
+points in the pipeline. The same three commands run in both places:
 
 ```bash
 npx tsc --noEmit
@@ -68,7 +68,8 @@ actual production-build path (`vite build`, `tsc -b`, or whatever
 clean but fails to bundle is not shippable.
 
 All three must exit zero. Any non-zero exit — type error, failing
-test, bundler error, missing `build`/`test` script — fails the gate.
+test, bundler error, missing `build`/`test` script — **fails** the
+gate.
 
 If `package.json` has no `test` script (genuinely no tests in the
 project — rare, but possible for a CLI wrapper or a fresh scaffold),
@@ -79,46 +80,82 @@ project's testing strategy with the human. An empty
 no test specified\" && exit 1"`) is NOT acceptable — it must be a
 real command or removed.
 
+### Stack-eligibility pre-check (manifest presence)
+
+The TypeScript gate only applies to a directory that **contains a
+`package.json`**:
+
+```bash
+test -f package.json   # at the repo root, or in the closest
+                       # ancestor of every changed TS/JS file
+```
+
+If no `package.json` is present (the repo isn't an npm project, or
+the changed files live outside any npm-rooted subtree), the
+TypeScript gate is **not eligible**. Compliance and the dev session
+SKIP it with a WARN ("TypeScript manifest `package.json` not present
+— TypeScript gate not applicable to this scope"); the verdict is
+**not a fail**.
+
+For monorepos with multiple `package.json` files, each gate run is
+scoped to the directory containing the closest enclosing
+`package.json` of the changed files.
+
 ### Dev Session — last step before exit
 
 After the final task commit and before the workflow applies
-`in-verification`, the dev session **MUST** run the gate. On failure
-the dev session does NOT exit cleanly — it loops back to fix the
-breakage and re-runs the gate until it passes. Pushing broken
-TypeScript, type errors, failing tests, or a build that doesn't
-bundle to the feature branch and signalling completion is forbidden.
+`in-verification`, the dev session **MUST** run the gate when
+eligible. On failure the dev session does NOT exit cleanly — it
+loops back to fix the breakage and re-runs the gate until it
+passes. Pushing broken TypeScript, type errors, failing tests, or
+a build that doesn't bundle and signalling completion is forbidden.
 
-The dev session's exit block must state whether the gate ran and
-what its result was. An exit block that omits the gate result is
-itself a protocol violation.
+The dev session's exit block must state, for each touched stack,
+whether the gate ran and what its result was (PASS / FAIL / SKIPPED).
+An exit block that omits the gate result is itself a protocol
+violation.
 
 ### Compliance Verify — first step before any other check
 
-The compliance verifier **MUST** run the gate before evaluating
-acceptance criteria, static analysis, or any other check. On
-failure the verifier emits an immediate FAIL verdict and
-short-circuits — ACs cannot be PASS while `tsc` errors, tests fail,
-or the bundle is broken, regardless of what code inspection
-suggests.
+The compliance verifier **MUST** run the gate (when eligible)
+before evaluating acceptance criteria, static analysis, or any
+other check. On gate failure the verifier emits an immediate FAIL
+verdict and short-circuits.
 
 The gate's run-and-result is the first item in the compliance
 report. Subsequent sections (static analysis, AC table) appear only
-when the gate passed.
+when the gate passed or was skipped per the rules below.
 
 ### When the toolchain is unavailable
 
-If `node`/`npm` is not on the runner's PATH (or `node_modules/` is
-not installed and `npm ci` fails), the only correct verdict is
-**BLOCKED**, never PASS or FAIL. Compliance MUST NOT infer
-build/test correctness from diff inspection alone — that is the
-same overconfidence trap whether the inspection concludes pass or
-fail. A BLOCKED verdict leaves the Feature at `in-verification`
-with a clear remediation ("install Node.js and run `npm ci`") —
-the human resolves before re-running.
+If `package.json` IS present but `node` or `npm` is **not** on the
+runner's PATH (or `node_modules/` is missing and `npm ci` fails to
+install), the gate is treated as **SKIPPED with a WARN** — not as
+PASS, not as FAIL, not as BLOCKED. The recipe records:
 
-A PR opened against work whose build+test AC was marked PASS by
-inspection rather than by an actual gate run is a
-verification-process bug — the rule above closes it.
+- a `compliance-warn:v1` comment noting that the TypeScript gate
+  was skipped because the toolchain isn't installed on the runner,
+  with the exact `which node` / `which npm` probe output
+- a recommendation to install Node.js on the runner image (via
+  `actions/setup-node@v4` or an apt step) so the gate can actually
+  run on the next cycle
+- AC verdicts for build / test fields are marked **WARN — skipped**
+  rather than PASS or FAIL
+
+Compliance still produces an overall verdict, runs the static
+analysis section, and evaluates the AC table. The PR is permitted
+to open. CI is the authoritative backstop for actually running the
+tests once the PR is open.
+
+### What is still forbidden
+
+- **PASS-by-inspection is still forbidden.** The gate is either
+  PASS (commands ran and exited zero), FAIL (commands ran and
+  exited non-zero), or SKIPPED-with-WARN (commands could not run).
+  No fourth state.
+- **FAIL-by-inspection is still forbidden.** Compliance MUST NOT
+  emit FAIL based on a CI run from a closed PR, sibling branch, or
+  any commit other than the current branch HEAD.
 
 ---
 


### PR DESCRIPTION
## Background

You spotted the root cause: yapper #15 committed 17 Go files / +3,167 LOC across 4 task commits without the agent ever running `go build` or `go test`, because the yapper runner has no Go installed. The agent followed `standards/go.md`'s instructions, got `go: command not found`, and committed blind. **That** is why "code doesn't work out of the box" and why PRs fail their build-and-test CI gate.

Companion PR #819 softens the gate's verdict when the toolchain is missing (WARN, not BLOCKED). This PR fixes the underlying issue: ensures the toolchain IS available when the project needs it, so the agent can actually verify its work as it writes.

## Design — manifest-conditional install

After `actions/checkout` populates the workspace, `setup-goose-env` runs a new "Detect project languages" step that probes the repo root for stack manifest files. For each detected stack, the matching `actions/setup-<lang>` step runs (pinned to the latest release SHA).

| Stack | Detection marker | Install step |
|---|---|---|
| Go | `go.mod` at repo root | `actions/setup-go@v6.4.0` with `go-version-file: go.mod` |
| Java | `pom.xml`, `build.gradle`, or `build.gradle.kts` | `actions/setup-java@v5.2.0` with Temurin 21 |
| Node (unchanged) | unconditional | `actions/setup-node@v6.3.0` — Claude CLI needs npm regardless |

## Cost / payoff

| Repo type | Time added |
|---|---|
| Pure TypeScript (current setup) | 0s |
| Pure Go (gh-agentic, ocs-testbench) | ~10s |
| Multi-stack (yapper: Go + TS) | ~10s |
| Pure Java | ~30s |

Payoff: dev-session can run `go test ./...` / `mvn verify` / `npm test` as it writes, fail fast, fix in the same task, and arrive at PR time with code the CI gate confirms rather than discovers.

## Extensibility — one language = four small changes

| Step | What |
|---|---|
| 1 | Add `standards/<lang>.md` with a `## Verification Gate` section (already required since v2.8.14) |
| 2 | Add a `<lang>=true|false` line to the Detect step |
| 3 | Add a `Setup <lang>` step with the corresponding `if:` gate |
| 4 | (Optional) Any language-specific apt deps in `install-ai-tools` |

The pattern scales without forcing every consumer to pay the install time of languages they don't use.

## How this pairs with #819

| PR | Layer | Without it |
|---|---|---|
| #819 (gate softening) | The verdict — when no toolchain, SKIP-with-WARN | Permanent BLOCKED loops |
| This PR (conditional install) | The toolchain itself — present when needed | Agent writes blind, PRs fail CI |

Both are needed for the intent: *"the gate should be a mere formality at PR time."* The gate runs during dev-session AND compliance against a runner that has the toolchain, **OR** softly skips if the runner genuinely can't be fixed (the v2.8.19 safety net).

## Test plan
- [x] `go test ./internal/mount/...` — pipeline structure tests pass
- [x] shellcheck on the new Detect block — clean
- [x] SHA pins verified against `gh api repos/actions/setup-go/git/refs/tags/v6.4.0` and same for `setup-java/v5.2.0`
- [ ] After merge: yapper's next dev-session for #15 sees `go.mod` present → installs Go → agent's `go build` and `go test` actually run as it writes

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)