### PR TITLE
fix: doctor variable checks false-fail on runners with outdated gh CLI

### DIFF
--- a/.github/actions/install-ai-tools/action.yml
+++ b/.github/actions/install-ai-tools/action.yml
@@ -37,9 +37,23 @@ runs:
       id: sys-check
       shell: bash
       run: |
-        dpkg -s gh bzip2 libgomp1 libvulkan1 >/dev/null 2>&1 \
-          && echo "installed=true" >> $GITHUB_OUTPUT \
-          || echo "installed=false" >> $GITHUB_OUTPUT
+        # gh must be modern enough for the `gh variable` command group
+        # (shipped in gh 2.31) — distro-packaged gh can predate it (#844).
+        # An old gh therefore counts as "not installed" so the install step
+        # runs and upgrades it from the official GitHub CLI apt repo.
+        MIN_GH=2.31.0
+        gh_ok=false
+        if command -v gh >/dev/null 2>&1; then
+          GH_VER=$(gh --version | head -1 | awk '{print $3}')
+          if [ "$(printf '%s\n' "$MIN_GH" "$GH_VER" | sort -V | head -1)" = "$MIN_GH" ]; then
+            gh_ok=true
+          fi
+        fi
+        if dpkg -s bzip2 libgomp1 libvulkan1 >/dev/null 2>&1 && [ "$gh_ok" = "true" ]; then
+          echo "installed=true" >> $GITHUB_OUTPUT
+        else
+          echo "installed=false" >> $GITHUB_OUTPUT
+        fi
 
     - name: Resolve package versions for cache key
       id: sys-pkg-versions
@@ -65,6 +79,16 @@ runs:
       if: steps.sys-check.outputs.installed != 'true'
       shell: bash
       run: |
+        # Configure the official GitHub CLI apt repository before installing
+        # gh — the distro archive can ship a gh too old for the `gh variable`
+        # command group (#844).
+        type -p wget >/dev/null || (sudo apt-get update -qq && sudo apt-get install -y wget)
+        sudo mkdir -p -m 755 /etc/apt/keyrings
+        wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+          | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+        sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+          | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
         sudo rm -rf /var/lib/apt/lists/*
         sudo apt-get update -qq
         sudo apt-get install -y --no-install-recommends --fix-missing gh bzip2 libgomp1 libvulkan1

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -894,8 +894,7 @@ func checkLegacyFederationConfig(deps CheckDeps) Group {
 	// AGENTIC_TOPOLOGY variable — was the old topology marker; replaced by
 	// FEDERATION.md presence detection in Feature #824.
 	if deps.Run != nil {
-		out, err := deps.Run("gh", "variable", "get", "AGENTIC_TOPOLOGY", "--repo", deps.RepoFullName)
-		if err == nil && strings.TrimSpace(out) != "" {
+		if hit, _, _ := getRepoVariable(deps, "AGENTIC_TOPOLOGY"); hit {
 			g.Results = append(g.Results, CheckResult{
 				Name:        "legacy-topology",
 				Status:      Warning,
@@ -909,8 +908,7 @@ func checkLegacyFederationConfig(deps CheckDeps) Group {
 	// AGENTIC_CONTROL_PLANE variable — was written by the old federated init
 	// flow; the FEDERATION.md manifest supersedes it.
 	if deps.Run != nil {
-		out, err := deps.Run("gh", "variable", "get", "AGENTIC_CONTROL_PLANE", "--repo", deps.RepoFullName)
-		if err == nil && strings.TrimSpace(out) != "" {
+		if hit, _, _ := getRepoVariable(deps, "AGENTIC_CONTROL_PLANE"); hit {
 			g.Results = append(g.Results, CheckResult{
 				Name:        "legacy-control-plane",
 				Status:      Warning,
@@ -944,17 +942,35 @@ func checkLegacyFederationConfig(deps CheckDeps) Group {
 	return g
 }
 
+// getRepoVariable reads a repo-scoped Actions variable via `gh api`. It
+// returns found=true when the variable exists, along with the raw gh output
+// and error for the caller's failure-mode analysis.
+//
+// `gh api` is used instead of `gh variable get` deliberately (#844): the
+// `gh variable` command group only shipped in gh 2.31, and distro-packaged
+// gh on self-hosted runners can predate it. On such versions `gh variable
+// get` fails with "unknown command" — an error that must not be mistaken
+// for "variable missing". The api command exists in every gh version.
+func getRepoVariable(deps CheckDeps, name string) (bool, string, error) {
+	out, err := deps.Run("gh", "api", "repos/"+deps.RepoFullName+"/actions/variables/"+name)
+	return err == nil && strings.TrimSpace(out) != "", out, err
+}
+
 // checkVariable checks if a GitHub variable exists at --repo scope.
 //
 // Feature #824: all variables are --repo scoped. The old org-scope fallback
 // for shared names under federated topology has been removed.
+//
+// Failure-mode discipline (#844): only a clean HTTP 404 proves the variable
+// is missing. A permission error or any other failure (network, unexpected
+// gh error) is inconclusive and reported as "unable to check" — never as
+// "not configured".
 func checkVariable(deps CheckDeps, name string) CheckResult {
 	if deps.Run == nil {
 		return CheckResult{Name: name, Status: Warning, Message: name + " — unable to check (no run func)"}
 	}
 
-	out, err := deps.Run("gh", "variable", "get", name, "--repo", deps.RepoFullName)
-	hit := err == nil && strings.TrimSpace(out) != ""
+	hit, out, err := getRepoVariable(deps, name)
 
 	// Distinguish an auth/permission failure from a genuine missing variable.
 	// GitHub App tokens used in CI often lack the Actions:Read permission
@@ -965,6 +981,14 @@ func checkVariable(deps CheckDeps, name string) CheckResult {
 		return CheckResult{
 			Name: name, Status: Warning,
 			Message: name + " — unable to check (token lacks variable-read permission)",
+		}
+	}
+
+	// Any other non-404 failure is equally inconclusive.
+	if !hit && err != nil && !isNotFoundError(out) {
+		return CheckResult{
+			Name: name, Status: Warning,
+			Message: name + " — unable to check (gh api call failed)",
 		}
 	}
 
@@ -1034,6 +1058,13 @@ func isPermissionError(out string) bool {
 		strings.Contains(lower, "insufficient scopes") ||
 		strings.Contains(lower, "must have admin rights") ||
 		strings.Contains(lower, "forbidden")
+}
+
+// isNotFoundError returns true when gh CLI output indicates HTTP 404 — the
+// only failure mode that proves a queried resource genuinely does not exist.
+func isNotFoundError(out string) bool {
+	lower := strings.ToLower(out)
+	return strings.Contains(lower, "404") || strings.Contains(lower, "not found")
 }
 
 // containsVariableName returns true if the gh output from

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -92,8 +92,11 @@ func TestRunAllChecks_HealthyRepo(t *testing.T) {
 		Run: func(name string, args ...string) (string, error) {
 			// Fake variable/secret/label checks.
 			if name == "gh" && len(args) > 0 {
-				if args[0] == "variable" && args[1] == "get" {
-					return "some-value", nil
+				if isVarAPICall(args) {
+					if strings.Contains(args[1], "AGENTIC_TOPOLOGY") || strings.Contains(args[1], "AGENTIC_CONTROL_PLANE") {
+						return "", fmt.Errorf("HTTP 404: Not Found") // no legacy config
+					}
+					return `{"name":"X","value":"some-value"}`, nil
 				}
 				if args[0] == "secret" && args[1] == "list" {
 					return "PROJECT_PAT\tUpdated 2026-04-01\nPIPELINE_PAT\tUpdated 2026-04-01\nCLAUDE_CREDENTIALS_JSON\tUpdated 2026-04-01", nil
@@ -746,8 +749,8 @@ func TestCheckLabels_VerificationLabels_PresentInRequiredSet(t *testing.T) {
 		wantDescSub string
 	}{
 		{
-			labelName:   "in-verification",
-			wantColor:   "d93f0b",
+			labelName: "in-verification",
+			wantColor: "d93f0b",
 			// Substring chosen to survive description-wording refinements;
 			// the protective intent is "the description mentions Compliance
 			// Verify" — not a specific phrasing.
@@ -855,6 +858,13 @@ func TestContainsLabelName(t *testing.T) {
 }
 
 // --- checkVariable / checkSecret scope-fallback tests (task #531) ---
+
+// isVarAPICall returns true when the faked gh invocation is the
+// `gh api repos/<owner>/<repo>/actions/variables/<name>` read that
+// getRepoVariable issues (#844 — replaced `gh variable get`).
+func isVarAPICall(args []string) bool {
+	return len(args) >= 2 && args[0] == "api" && strings.Contains(args[1], "/actions/variables/")
+}
 
 // ghRun is a minimal fake for deps.Run used in scope-fallback tests. It
 // takes a routing table keyed by the scope flag ("--org" or "--repo") and
@@ -1093,6 +1103,71 @@ func TestCheckVariable_PermissionError_Warns(t *testing.T) {
 	}
 }
 
+// TestCheckVariable_NotFound_Fails verifies a clean HTTP 404 — the one
+// failure mode that proves the variable is missing — still hard-fails.
+func TestCheckVariable_NotFound_Fails(t *testing.T) {
+	deps := CheckDeps{
+		RepoFullName: "acme/repo", Owner: "acme", Topology: "single",
+		Run: func(name string, args ...string) (string, error) {
+			return "gh: Not Found (HTTP 404)", fmt.Errorf("gh: exit status 1")
+		},
+	}
+	res := checkVariable(deps, "RUNNER_LABEL")
+	if res.Status != Fail {
+		t.Fatalf("status: got %d (%s), want Fail", res.Status, res.Message)
+	}
+}
+
+// TestCheckVariable_InconclusiveError_Warns covers #844: gh failures that are
+// neither a 403 nor a 404 — e.g. an outdated gh CLI rejecting the command, or
+// a network failure — must report "unable to check", never "not configured".
+func TestCheckVariable_InconclusiveError_Warns(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		output string
+	}{
+		{"old gh unknown command", `unknown command "get" for "gh variable"`},
+		{"network failure", "error connecting to api.github.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := CheckDeps{
+				RepoFullName: "acme/repo", Owner: "acme", Topology: "single",
+				Run: func(name string, args ...string) (string, error) {
+					return tc.output, fmt.Errorf("gh: exit status 1")
+				},
+			}
+			res := checkVariable(deps, "RUNNER_LABEL")
+			if res.Status != Warning {
+				t.Fatalf("status: got %d (%s), want Warning", res.Status, res.Message)
+			}
+			if !strings.Contains(res.Message, "unable to check") {
+				t.Errorf("message: got %q, want 'unable to check'", res.Message)
+			}
+		})
+	}
+}
+
+// TestCheckVariable_ReadsViaAPI pins the #844 fix: the variable read must go
+// through `gh api` (available in every gh version), not `gh variable get`
+// (gh ≥ 2.31 only — absent from distro-packaged gh on self-hosted runners).
+func TestCheckVariable_ReadsViaAPI(t *testing.T) {
+	var got [][]string
+	deps := CheckDeps{
+		RepoFullName: "acme/repo", Owner: "acme", Topology: "single",
+		Run: func(name string, args ...string) (string, error) {
+			got = append(got, append([]string{name}, args...))
+			return `{"name":"RUNNER_LABEL","value":"x"}`, nil
+		},
+	}
+	res := checkVariable(deps, "RUNNER_LABEL")
+	if res.Status != Pass {
+		t.Fatalf("status: got %d (%s), want Pass", res.Status, res.Message)
+	}
+	if len(got) != 1 || got[0][1] != "api" || got[0][2] != "repos/acme/repo/actions/variables/RUNNER_LABEL" {
+		t.Errorf("expected single gh api call, got %v", got)
+	}
+}
+
 // --- checkFederationManifest tests ---
 
 func TestCheckFederationManifest_NoFile_Pass(t *testing.T) {
@@ -1217,10 +1292,10 @@ func TestCheckLegacyFederationConfig_AgenticTopologySet_Warns(t *testing.T) {
 		RepoFullName: "acme/repo",
 		Run: func(name string, args ...string) (string, error) {
 			// AGENTIC_TOPOLOGY is set; AGENTIC_CONTROL_PLANE is not.
-			if len(args) >= 3 && args[0] == "variable" && args[2] == "AGENTIC_TOPOLOGY" {
-				return "federation", nil
+			if isVarAPICall(args) && strings.Contains(args[1], "AGENTIC_TOPOLOGY") {
+				return `{"name":"AGENTIC_TOPOLOGY","value":"federation"}`, nil
 			}
-			return "", fmt.Errorf("not set")
+			return "", fmt.Errorf("HTTP 404: Not Found")
 		},
 	}
 
@@ -1252,10 +1327,10 @@ func TestCheckLegacyFederationConfig_AgenticControlPlaneSet_Warns(t *testing.T) 
 		RepoFullName: "acme/repo",
 		Run: func(name string, args ...string) (string, error) {
 			// AGENTIC_CONTROL_PLANE is set; AGENTIC_TOPOLOGY is not.
-			if len(args) >= 3 && args[0] == "variable" && args[2] == "AGENTIC_CONTROL_PLANE" {
-				return "acme/cp", nil
+			if isVarAPICall(args) && strings.Contains(args[1], "AGENTIC_CONTROL_PLANE") {
+				return `{"name":"AGENTIC_CONTROL_PLANE","value":"acme/cp"}`, nil
 			}
-			return "", fmt.Errorf("not set")
+			return "", fmt.Errorf("HTTP 404: Not Found")
 		},
 	}
 
@@ -1312,11 +1387,11 @@ func TestCheckLegacyFederationConfig_MultipleItems_MultipleWarnings(t *testing.T
 		RepoFullName: "acme/repo",
 		Run: func(name string, args ...string) (string, error) {
 			// Both legacy variables are set.
-			if len(args) >= 3 && args[0] == "variable" &&
-				(args[2] == "AGENTIC_TOPOLOGY" || args[2] == "AGENTIC_CONTROL_PLANE") {
-				return "some-value", nil
+			if isVarAPICall(args) &&
+				(strings.Contains(args[1], "AGENTIC_TOPOLOGY") || strings.Contains(args[1], "AGENTIC_CONTROL_PLANE")) {
+				return `{"name":"X","value":"some-value"}`, nil
 			}
-			return "", fmt.Errorf("not set")
+			return "", fmt.Errorf("HTTP 404: Not Found")
 		},
 	}
 
@@ -1628,4 +1703,3 @@ func TestCheckFederationProjectSync_NotWiredForFrameworkSource(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/doctor/repair_test.go
+++ b/internal/doctor/repair_test.go
@@ -18,8 +18,8 @@ import (
 // label repair, and the label-create calls would otherwise inflate the repair
 // count and break assertions.
 func fakeRunMissingVarsAndSecret(name string, args ...string) (string, error) {
-	if name == "gh" && len(args) > 1 && args[0] == "variable" && args[1] == "get" {
-		return "", nil
+	if name == "gh" && isVarAPICall(args) {
+		return "", fmt.Errorf("HTTP 404: Not Found")
 	}
 	if name == "gh" && len(args) > 1 && args[0] == "secret" && args[1] == "list" {
 		return "", nil
@@ -253,8 +253,8 @@ func TestRepairPipeline_CreatesLabels(t *testing.T) {
 		Run: func(name string, args ...string) (string, error) {
 			if name == "gh" && len(args) > 1 {
 				switch {
-				case args[0] == "variable" && args[1] == "get":
-					return "configured", nil
+				case isVarAPICall(args):
+					return `{"name":"X","value":"configured"}`, nil
 				case args[0] == "secret" && args[1] == "list":
 					return "PROJECT_PAT\tUpdated 2026-04-01", nil
 				case args[0] == "label" && args[1] == "list":
@@ -298,8 +298,8 @@ func TestRepairPipeline_LabelCreateFails_CountsUnrepaired(t *testing.T) {
 		Run: func(name string, args ...string) (string, error) {
 			if name == "gh" && len(args) > 1 {
 				switch {
-				case args[0] == "variable" && args[1] == "get":
-					return "configured", nil
+				case isVarAPICall(args):
+					return `{"name":"X","value":"configured"}`, nil
 				case args[0] == "secret" && args[1] == "list":
 					return "PROJECT_PAT\tUpdated 2026-04-01", nil
 				case args[0] == "label" && args[1] == "list":
@@ -377,8 +377,8 @@ func TestRepairPipeline_NoFailures(t *testing.T) {
 		ProjectID:         "PVT_configured",
 		FetchProjectTitle: func(id string) (string, error) { return "Healthy", nil },
 		Run: func(name string, args ...string) (string, error) {
-			if name == "gh" && len(args) > 1 && args[0] == "variable" && args[1] == "get" {
-				return "configured", nil
+			if name == "gh" && isVarAPICall(args) {
+				return `{"name":"X","value":"configured"}`, nil
 			}
 			if name == "gh" && len(args) > 1 && args[0] == "secret" && args[1] == "list" {
 				return "PROJECT_PAT\tUpdated 2026-04-01", nil


### PR DESCRIPTION
Closes #844

## What

Headless pipeline sessions were reporting `RUNNER_LABEL not configured` (and silently falling back to defaults for `AGENT_PROVIDER` / `AGENT_MODEL`) even though all variables are set on the repo.

## Root cause

`internal/doctor` read variables via `gh variable get`, a command that only exists from gh 2.31 — and `install-ai-tools` installs gh from the distro apt archive, which can ship a far older gh on self-hosted runners. The "unknown command" error was indistinguishable from "variable missing" in `checkVariable`, so every variable read failed: defaulted variables degraded to quiet warnings, and `RUNNER_LABEL` (no default) hard-failed. Secrets passed because `gh secret list` is an old command — making the failure look RUNNER_LABEL-specific.

## Fix

**Doctor (`internal/doctor/checks.go`):**
- New `getRepoVariable` helper reads via `gh api repos/<repo>/actions/variables/<name>` — available in every gh version. Used by `checkVariable` and both legacy-config checks.
- Failure-mode discipline: only a clean HTTP 404 reports "not configured". Permission errors (403) and any other failure (old gh, network) report "unable to check" — never a false Fail.

**Runner provisioning (`.github/actions/install-ai-tools/action.yml`):**
- Configures the official GitHub CLI apt repository (cli.github.com keyring + source) before `apt-get install gh`.
- The already-installed short-circuit now also requires gh ≥ 2.31, so previously-provisioned runners with an old distro gh get upgraded on their next run instead of being skipped forever.

## Tests

- `TestCheckVariable_ReadsViaAPI` pins the `gh api` call shape.
- `TestCheckVariable_InconclusiveError_Warns` covers the old-gh "unknown command" and network-failure cases.
- `TestCheckVariable_NotFound_Fails` pins that a genuine 404 still hard-fails.
- Existing fakes updated from `gh variable get` to the api shape.
- `go test ./...` passes; `go build ./...` clean.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)
