### PR TITLE
docs(skills): render-before-confirm gate rule

### DIFF
--- a/skills/definitions/render-before-confirm.md
+++ b/skills/definitions/render-before-confirm.md
@@ -1,0 +1,58 @@
+# Render-Before-Confirm Rule
+
+A reusable safeguard that any skill may load to guarantee the human
+can actually *see* the content they are being asked to approve. It
+governs every confirm-or-revise gate where the agent renders content
+(a plan, a draft artefact, an issue body, a task list) and then asks
+the human to Confirm / Revise / Cancel.
+
+## The problem it prevents
+
+When an agent renders content and invokes the approval prompt in the
+**same turn**, the prompt UI (the `prompt-user` / `AskUserQuestion`
+card) is what the human sees — and text emitted *before* a tool call
+in the same turn is not reliably displayed. The result is an approval
+gate for content the human never saw: "you are asking me to approve a
+plan but did not show it to me." Approval given blind is not approval.
+
+## The rule
+
+When a gate requires the human to approve rendered content, the agent
+MUST separate rendering from prompting across two turns:
+
+1. **Render and stop.** Emit the full content as the final output of a
+   turn — verbatim, in a fenced block where the content is structured —
+   and end the turn with NO tool call after it. The content is the last
+   thing in the response.
+2. **Prompt on the next turn.** Only after the content has been
+   displayed does the agent invoke the `prompt-user` gate
+   (Confirm / Revise / Cancel) in a subsequent turn.
+
+A gate that renders and prompts in one turn is malformed, regardless
+of how the rendering reads in the skill prose. Wording in a skill step
+such as "render the content … then `prompt-user(...)`" describes the
+logical order, NOT permission to do both in a single turn — the "then"
+is a turn boundary.
+
+The same rule applies to the per-revision re-render: when the human
+chooses Revise, the updated content (and any per-revision diff) is
+rendered as the final output of its turn, and the re-prompt comes
+on the following turn.
+
+## How a skill adopts this rule
+
+Add this file to the skill's `loads:` list and reference it in the
+`Definitions` section. The rule then applies to every confirm-or-revise
+gate in that skill — the individual gate steps do not need to restate
+it.
+
+## Why this works
+
+The failure is structural, not a matter of agent diligence: it stems
+from reading "render … then prompt" as a single atomic step. Naming
+the turn boundary explicitly removes the ambiguity — the agent treats
+the rendered content as a complete response and waits for it to land
+before gating on it. Observed in this framework when a Design Plan and
+its approval prompt were emitted together and the plan was hidden; the
+human could only see the card asking them to approve content they had
+never been shown.

--- a/skills/feature-design/SKILL.md
+++ b/skills/feature-design/SKILL.md
@@ -8,6 +8,7 @@ loads:
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
   - skills/definitions/state-model-pattern.md
+  - skills/definitions/render-before-confirm.md
   - skills/prompt-user/SKILL.md
   - skills/gh-agentic/SKILL.md
   - skills/apply-label/SKILL.md
@@ -125,6 +126,11 @@ the work.
 - `skills/definitions/step-skip-rule.md` — articulation-as-enforcement
   rule preventing silent skipping. Conditional-step carve-out applies
   to interactive-only steps in headless mode and vice versa.
+- `skills/definitions/render-before-confirm.md` — the turn-boundary
+  rule for the interactive confirm gates (rationale review, task-list
+  review): rendered content is the final output of its turn; the
+  `prompt-user` call comes on the next turn, so the human always sees
+  what they are approving.
 
 ## Dependencies
 
@@ -477,7 +483,12 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
    among the issue's comments. Always include it as the first line.
 
 10. **Confirm rationale. (interactive only)** Render the full
-    rationale verbatim in a fenced markdown block, then:
+    rationale verbatim in a fenced markdown block as the final output
+    of the turn, and stop. Per
+    `skills/definitions/render-before-confirm.md`, the `prompt-user`
+    gate below is invoked on the *next* turn — never render the
+    rationale and prompt for its approval in the same turn, or the
+    human is asked to confirm a Design Plan they cannot see. Then:
 
     ```
     prompt-user(
@@ -630,8 +641,11 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
     traceable to tasks is malformed.
 
 16. **Confirm task list. (interactive only)** Render each task as
-    a fenced markdown block prefaced by `Task K of M (title):`,
-    then:
+    a fenced markdown block prefaced by `Task K of M (title):` as the
+    final output of the turn, and stop. Per
+    `skills/definitions/render-before-confirm.md`, the `prompt-user`
+    gate below is invoked on the *next* turn — never render the task
+    list and prompt for its approval in the same turn. Then:
 
     ```
     prompt-user(

--- a/skills/requirement-scoping/SKILL.md
+++ b/skills/requirement-scoping/SKILL.md
@@ -7,6 +7,7 @@ loads:
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
   - skills/definitions/state-model-pattern.md
+  - skills/definitions/render-before-confirm.md
   - skills/prompt-user/SKILL.md
   - skills/gh-agentic/SKILL.md
   - skills/apply-label/SKILL.md
@@ -93,6 +94,10 @@ body as a `## Parking Lot` section, not as separate artefacts.
 - `skills/definitions/step-skip-rule.md` — articulation-as-enforcement
   rule preventing silent skipping. Conditional-step carve-out
   applies to artefacts 7 (UX triage downstream) and revision loops.
+- `skills/definitions/render-before-confirm.md` — the turn-boundary
+  rule for every artefact gate: rendered content is the final output
+  of its turn; the `prompt-user` Confirm/Revise/Cancel call comes on
+  the next turn, so the human always sees what they are approving.
 
 ## Dependencies
 
@@ -170,7 +175,12 @@ artefact walk (steps in section C):
 - **Confirm-or-revise gate per artefact.** Each of the 9 artefacts
   has an explicit `prompt-user` gate before the skill moves to the
   next artefact. Options: Confirm / Revise / Cancel. No artefact
-  is silently accepted.
+  is silently accepted. Per
+  `skills/definitions/render-before-confirm.md`, the artefact is
+  rendered as the final output of its turn and the `prompt-user`
+  gate is invoked on the *next* turn — never render the artefact and
+  prompt for its approval in the same turn, or the human is asked to
+  confirm content they cannot see.
 - **Per-revision diff (mandatory).** When an artefact is revised,
   before re-rendering it for confirmation the agent must emit — in
   its response stream — a per-field diff showing only the changed


### PR DESCRIPTION
## What

Adds a shared framework rule — `skills/definitions/render-before-confirm.md` — that fixes a structural defect in confirm-or-revise gates: when an agent renders content (a Design Plan, a task list, an artefact draft) and invokes the approval prompt in the **same turn**, the prompt card is all the human sees, and the content emitted before the tool call is hidden. The human is then asked to approve something they were never shown.

## Where it bit us

During the interactive feature-design session for #825, the agent rendered the Design Plan and called the approval prompt together; the human saw only the prompt card: *"You are prompting me to approve a plan but do not display the plan!"* The same render-then-prompt pattern exists across every gate in `requirement-scoping` and the rationale/task-list gates in `feature-design`, so this is fixed once as a shared definition rather than patched per skill.

## The rule

Rendered content that requires approval must be the **final output of its turn** (no tool call after it); the `prompt-user` Confirm/Revise/Cancel gate is invoked on the **next** turn, after the content has displayed. Wording like "render … then prompt" describes logical order — the "then" is a turn boundary, not permission to do both at once.

## Changes

- **New:** `skills/definitions/render-before-confirm.md` (mirrors `step-skip-rule.md` style — problem, rule, adoption, why-it-works).
- **`requirement-scoping`:** added to `loads:` + Definitions; the per-artefact gate discipline now cites the turn-boundary rule.
- **`feature-design`:** added to `loads:` + Definitions; steps 10 (rationale review) and 16 (task-list review) updated to render-and-stop before prompting.

## Verification

`go build ./...` clean; `go test ./internal/doctor/` passes (skill frontmatter validation unaffected — `loads` remains a list of strings).

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)
