### PR TITLE
feat: Read-only control-plane checkout with nested target-repo clone

### DIFF
--- a/.github/actions/cp-rooted-checkout/action.yml
+++ b/.github/actions/cp-rooted-checkout/action.yml
@@ -111,10 +111,11 @@ runs:
         gh repo clone "${CP_REPO}" "${cp_dir}" -- --branch main --recurse-submodules "${depth_args[@]}"
 
         # Ensure the nested work dir can never be committed into the control plane.
+        # Use the repo-local exclude file, NOT the tracked .gitignore — validated
+        # on a real runner (#866): editing .gitignore dirties `git status`, whereas
+        # .git/info/exclude keeps the CP working tree pristine.
         mkdir -p "${cp_dir}/.work"
-        if ! grep -qxF '.work/' "${cp_dir}/.gitignore" 2>/dev/null; then
-          echo '.work/' >> "${cp_dir}/.gitignore"
-        fi
+        echo '/.work/' >> "${cp_dir}/.git/info/exclude"
 
         # Target repo @ target-ref into the gitignored work dir (writable surface).
         mkdir -p "$(dirname "${work_dir}")"

--- a/.github/actions/cp-rooted-checkout/action.yml
+++ b/.github/actions/cp-rooted-checkout/action.yml
@@ -1,0 +1,141 @@
+name: CP-rooted checkout
+description: >
+  Construct the federated CP-rooted execution layout for a pipeline execution
+  phase: check out the control plane at main (read-only knowledge root) and
+  clone the feature's target repo into a gitignored work directory inside it.
+  For single-topology projects it falls back to a plain single-repo checkout.
+
+  ⚠️ UNVALIDATED FIRST CUT (#858 / #866). This action has NOT been run against a
+  real federated pipeline. It needs end-to-end validation on a federation
+  testbed (the OpenBSS org, per #823) before any of the execution jobs are
+  wired to it (#867). Do not rely on it until that validation is done.
+
+  Layout produced for a FEDERATED feature:
+    <cp-path>/                      ← control plane @ main (read-only; docs live here)
+    <cp-path>/.work/<repo>/         ← target repo @ target-ref (writable; code work here)
+  Layout produced for a SINGLE-topology feature:
+    <work-path>                     ← the target repo, checked out normally; cp-path empty
+
+inputs:
+  target-ref:
+    description: 'Ref to check out in the target repo (e.g. main, the feature branch, the PR head).'
+    required: true
+  gh-token:
+    description: 'Token with read access to the control plane and target repos (PIPELINE_PAT).'
+    required: true
+  agentic-version:
+    description: 'gh-agentic extension version to install (must match AGENTIC_FRAMEWORK_VERSION).'
+    required: true
+  fetch-depth:
+    description: 'Fetch depth for the target clone (0 = full history).'
+    required: false
+    default: '0'
+
+outputs:
+  topology:
+    description: '"federated" or "single".'
+    value: ${{ steps.resolve.outputs.topology }}
+  cp-path:
+    description: 'Absolute path to the control-plane checkout (empty for single topology).'
+    value: ${{ steps.layout.outputs.cp-path }}
+  work-path:
+    description: 'Absolute path to the writable target working directory (where code work happens).'
+    value: ${{ steps.layout.outputs.work-path }}
+
+runs:
+  using: composite
+  steps:
+    # 1. Install the gh-agentic extension so we can resolve the control plane.
+    #    Done before any checkout because resolution does not need a working
+    #    tree — it reads the Project + remote FEDERATION.md presence over the API.
+    - name: Install gh-agentic extension
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        AGENTIC_VERSION: ${{ inputs.agentic-version }}
+      run: |
+        gh extension install eddiecarpenter/gh-agentic --pin "${AGENTIC_VERSION}" --force
+
+    # 2. Resolve the control plane. GH_REPO makes repository.Current() resolve
+    #    from the env (no checkout needed). Empty stdout ⇒ single topology.
+    - name: Resolve control plane
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        cp="$(gh agentic project control-plane --raw || true)"
+        if [ -z "${cp}" ]; then
+          echo "topology=single" >> "$GITHUB_OUTPUT"
+          echo "Single topology — no separate control plane."
+        else
+          echo "topology=federated" >> "$GITHUB_OUTPUT"
+          echo "cp-repo=${cp}" >> "$GITHUB_OUTPUT"
+          echo "Control plane resolved: ${cp}"
+        fi
+
+    # 3a. SINGLE topology — plain checkout of the target repo (unchanged behaviour).
+    - name: Checkout (single topology)
+      if: steps.resolve.outputs.topology == 'single'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.target-ref }}
+        fetch-depth: ${{ inputs.fetch-depth }}
+        submodules: recursive
+        token: ${{ inputs.gh-token }}
+
+    # 3b. FEDERATED — build the CP-rooted layout: CP@main + target cloned into
+    #     a gitignored work dir inside it. Both are fresh clones so the layout
+    #     is constructed deterministically regardless of the runner's default
+    #     workspace.
+    - name: Build CP-rooted layout (federated)
+      if: steps.resolve.outputs.topology == 'federated'
+      id: build
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        CP_REPO: ${{ steps.resolve.outputs.cp-repo }}
+        TARGET_REPO: ${{ github.repository }}
+        TARGET_REF: ${{ inputs.target-ref }}
+        FETCH_DEPTH: ${{ inputs.fetch-depth }}
+      run: |
+        set -euo pipefail
+        cp_dir="${RUNNER_TEMP}/cp"
+        target_name="${TARGET_REPO##*/}"
+        work_dir="${cp_dir}/.work/${target_name}"
+
+        # Control plane @ main, read-only knowledge root (recursive for .agents mount).
+        depth_args=()
+        if [ "${FETCH_DEPTH}" != "0" ]; then depth_args=(--depth "${FETCH_DEPTH}"); fi
+        gh repo clone "${CP_REPO}" "${cp_dir}" -- --branch main --recurse-submodules "${depth_args[@]}"
+
+        # Ensure the nested work dir can never be committed into the control plane.
+        mkdir -p "${cp_dir}/.work"
+        if ! grep -qxF '.work/' "${cp_dir}/.gitignore" 2>/dev/null; then
+          echo '.work/' >> "${cp_dir}/.gitignore"
+        fi
+
+        # Target repo @ target-ref into the gitignored work dir (writable surface).
+        mkdir -p "$(dirname "${work_dir}")"
+        gh repo clone "${TARGET_REPO}" "${work_dir}" -- --branch "${TARGET_REF}" --recurse-submodules "${depth_args[@]}"
+
+        echo "cp-path=${cp_dir}" >> "$GITHUB_OUTPUT"
+        echo "work-path=${work_dir}" >> "$GITHUB_OUTPUT"
+
+    # 4. Normalise outputs across both branches.
+    - name: Expose layout paths
+      id: layout
+      shell: bash
+      env:
+        TOPOLOGY: ${{ steps.resolve.outputs.topology }}
+        FED_CP: ${{ steps.build.outputs.cp-path }}
+        FED_WORK: ${{ steps.build.outputs.work-path }}
+      run: |
+        if [ "${TOPOLOGY}" = "federated" ]; then
+          echo "cp-path=${FED_CP}" >> "$GITHUB_OUTPUT"
+          echo "work-path=${FED_WORK}" >> "$GITHUB_OUTPUT"
+        else
+          echo "cp-path=" >> "$GITHUB_OUTPUT"
+          echo "work-path=${GITHUB_WORKSPACE}" >> "$GITHUB_OUTPUT"
+        fi

--- a/internal/cli/project.go
+++ b/internal/cli/project.go
@@ -69,6 +69,74 @@ board or the framework mount.`,
 	cmd.AddCommand(newProjectJoinCmd())
 	cmd.AddCommand(newProjectUnlinkCmd())
 	cmd.AddCommand(newProjectSwitchCmd())
+	cmd.AddCommand(newProjectControlPlaneCmd())
+
+	return cmd
+}
+
+// newProjectControlPlaneCmd constructs the `gh agentic project control-plane`
+// subcommand. It prints the control-plane repo (owner/repo) for the current
+// repo's agentic project — the linked repo bearing FEDERATION.md.
+//
+// It is the runtime entry point the CP-rooted checkout composite action calls
+// (with --raw) to discover where the control plane lives. A single-topology
+// repo has no separate control plane: the command prints nothing under --raw
+// and exits 0, so the action falls back to a plain single-repo checkout.
+func newProjectControlPlaneCmd() *cobra.Command {
+	var raw bool
+
+	cmd := &cobra.Command{
+		Use:   "control-plane",
+		Short: "Print the control-plane repo for this repo's project",
+		Long: `Print the control-plane repository (owner/repo) for this repo's agentic
+project — the linked repo whose root contains FEDERATION.md.
+
+With --raw, prints only the owner/repo value on stdout (for scripting/CI). When
+this is a single-topology project (no separate control plane), --raw prints
+nothing and exits 0 so callers can fall back to single-repo behaviour.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deps, err := resolveProjectDeps()
+			if err != nil {
+				return err
+			}
+
+			ctx, err := project.Resolve(deps)
+			if err != nil {
+				return err
+			}
+			if ctx == nil || ctx.ProjectID == "" {
+				if !raw {
+					fmt.Fprintln(cmd.OutOrStdout(), "No control plane: this repo is not affiliated with an agentic project.")
+				}
+				return nil
+			}
+
+			linked, err := deps.FetchLinkedRepos(ctx.ProjectID)
+			if err != nil {
+				return fmt.Errorf("fetching linked repos: %w", err)
+			}
+
+			cp, found, err := project.ResolveControlPlane(linked, deps.RepoHasFederationFile)
+			if err != nil {
+				return err
+			}
+			if !found {
+				if !raw {
+					fmt.Fprintln(cmd.OutOrStdout(), "No federated control plane: single topology (this repo is its own control plane).")
+				}
+				return nil
+			}
+
+			if raw {
+				fmt.Fprintln(cmd.OutOrStdout(), cp.NameWithOwner)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "Control plane: %s\n", cp.NameWithOwner)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&raw, "raw", false, "print only the owner/repo value on stdout (for scripting/CI)")
 
 	return cmd
 }

--- a/internal/project/api.go
+++ b/internal/project/api.go
@@ -5,6 +5,7 @@ package project
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -50,6 +51,10 @@ type FetchLinkedReposFunc func(projectID string) ([]LinkedRepo, error)
 
 // FetchProjectsForRepoFunc fetches projects linked to a repository.
 type FetchProjectsForRepoFunc func(owner, repo string) ([]ProjectInfo, error)
+
+// RepoHasFederationFileFunc reports whether a repository has FEDERATION.md at
+// its root. Used to identify the control plane among a project's linked repos.
+type RepoHasFederationFileFunc func(owner, repo string) (bool, error)
 
 // GetRepoVariableFunc reads a repo-level Actions variable value.
 type GetRepoVariableFunc func(owner, repo, name string) (string, error)
@@ -160,6 +165,27 @@ func DefaultFetchLinkedRepos(projectID string) ([]LinkedRepo, error) {
 		})
 	}
 	return repos, nil
+}
+
+// DefaultRepoHasFederationFile reports whether owner/repo carries FEDERATION.md
+// at its default-branch root, via the REST contents API. A 404 means "no file"
+// (a normal answer, not an error); any other failure is returned as an error.
+func DefaultRepoHasFederationFile(owner, repo string) (bool, error) {
+	client, err := api.DefaultRESTClient()
+	if err != nil {
+		return false, fmt.Errorf("creating REST client: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("repos/%s/%s/contents/%s", owner, repo, federationFileName)
+	var discard json.RawMessage
+	if err := client.Get(endpoint, &discard); err != nil {
+		var httpErr *api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking %s in %s/%s: %w", federationFileName, owner, repo, err)
+	}
+	return true, nil
 }
 
 // graphqlProjectsForRepoResponse is the response shape for the repo projects query.

--- a/internal/project/api_test.go
+++ b/internal/project/api_test.go
@@ -170,3 +170,136 @@ func TestDeleteRepoVariable_Success(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+// --- ResolveControlPlane tests ---
+
+// fakeHasFederationFile returns a checker that reports true for the repos in
+// haveFed (by "owner/repo"), records the repos queried, and optionally fails
+// for failOn.
+func fakeHasFederationFile(haveFed map[string]bool, failOn string) (RepoHasFederationFileFunc, *[]string) {
+	queried := &[]string{}
+	fn := func(owner, repo string) (bool, error) {
+		key := owner + "/" + repo
+		*queried = append(*queried, key)
+		if failOn != "" && key == failOn {
+			return false, errors.New("boom")
+		}
+		return haveFed[key], nil
+	}
+	return fn, queried
+}
+
+func TestResolveControlPlane_FindsManifestRepoNotFirst(t *testing.T) {
+	linked := []LinkedRepo{
+		{NameWithOwner: "org/domain-a"},
+		{NameWithOwner: "org/control-plane"},
+		{NameWithOwner: "org/domain-b"},
+	}
+	check, queried := fakeHasFederationFile(map[string]bool{"org/control-plane": true}, "")
+
+	cp, ok, err := ResolveControlPlane(linked, check)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if cp.NameWithOwner != "org/control-plane" {
+		t.Errorf("expected org/control-plane, got %s", cp.NameWithOwner)
+	}
+	// Should stop at the first match — domain-b is never queried.
+	if got := *queried; len(got) != 2 || got[len(got)-1] != "org/control-plane" {
+		t.Errorf("expected to stop at the manifest repo, queried: %v", got)
+	}
+}
+
+func TestResolveControlPlane_NoManifestRepo(t *testing.T) {
+	linked := []LinkedRepo{
+		{NameWithOwner: "org/domain-a"},
+		{NameWithOwner: "org/domain-b"},
+	}
+	check, _ := fakeHasFederationFile(map[string]bool{}, "")
+
+	_, ok, err := ResolveControlPlane(linked, check)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false when no linked repo carries FEDERATION.md")
+	}
+}
+
+func TestResolveControlPlane_EmptyLinked(t *testing.T) {
+	check, queried := fakeHasFederationFile(map[string]bool{}, "")
+	_, ok, err := ResolveControlPlane(nil, check)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false for empty linked repos")
+	}
+	if len(*queried) != 0 {
+		t.Errorf("expected no checks for empty linked, queried: %v", *queried)
+	}
+}
+
+func TestResolveControlPlane_CheckErrorPropagates(t *testing.T) {
+	linked := []LinkedRepo{{NameWithOwner: "org/domain-a"}}
+	check, _ := fakeHasFederationFile(map[string]bool{}, "org/domain-a")
+
+	_, ok, err := ResolveControlPlane(linked, check)
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+	if ok {
+		t.Error("expected ok=false on error")
+	}
+}
+
+func TestResolveControlPlane_SkipsMalformedEntries(t *testing.T) {
+	linked := []LinkedRepo{
+		{NameWithOwner: "not-a-valid-entry"},
+		{NameWithOwner: "org/control-plane"},
+	}
+	check, queried := fakeHasFederationFile(map[string]bool{"org/control-plane": true}, "")
+
+	cp, ok, err := ResolveControlPlane(linked, check)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok || cp.NameWithOwner != "org/control-plane" {
+		t.Errorf("expected to skip malformed entry and resolve control-plane, got ok=%v cp=%s", ok, cp.NameWithOwner)
+	}
+	// The malformed entry is never queried.
+	for _, q := range *queried {
+		if q == "not-a-valid-entry" {
+			t.Errorf("malformed entry should not be queried, queried: %v", *queried)
+		}
+	}
+}
+
+// --- splitOwnerRepo tests ---
+
+func TestSplitOwnerRepo(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantOwner string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{"org/repo", "org", "repo", true},
+		{"Org/Repo-Name", "Org", "Repo-Name", true},
+		{"noslash", "", "", false},
+		{"/repo", "", "", false},
+		{"owner/", "", "", false},
+		{"", "", "", false},
+		{"a/b/c", "a", "b/c", true},
+	}
+	for _, c := range cases {
+		owner, repo, ok := splitOwnerRepo(c.in)
+		if owner != c.wantOwner || repo != c.wantRepo || ok != c.wantOK {
+			t.Errorf("splitOwnerRepo(%q) = (%q,%q,%v), want (%q,%q,%v)",
+				c.in, owner, repo, ok, c.wantOwner, c.wantRepo, c.wantOK)
+		}
+	}
+}

--- a/internal/project/deps.go
+++ b/internal/project/deps.go
@@ -18,9 +18,10 @@ type Deps struct {
 	// Root is the local repository root path.
 	Root string
 
-	FetchLinkedRepos     FetchLinkedReposFunc
-	FetchProjectsForRepo FetchProjectsForRepoFunc
-	GetRepoVariable      GetRepoVariableFunc
+	FetchLinkedRepos      FetchLinkedReposFunc
+	FetchProjectsForRepo  FetchProjectsForRepoFunc
+	RepoHasFederationFile RepoHasFederationFileFunc
+	GetRepoVariable       GetRepoVariableFunc
 	SetRepoVariable      SetRepoVariableFunc
 	DeleteRepoVariable   DeleteRepoVariableFunc
 	ReadAIVersion        func(root string) (string, error)
@@ -55,6 +56,7 @@ func DefaultDeps(owner, repoName, root string) Deps {
 		Root:                     root,
 		FetchLinkedRepos:         DefaultFetchLinkedRepos,
 		FetchProjectsForRepo:     DefaultFetchProjectsForRepo,
+		RepoHasFederationFile:    DefaultRepoHasFederationFile,
 		GetRepoVariable:          DefaultGetRepoVariable,
 		SetRepoVariable:          DefaultSetRepoVariable,
 		DeleteRepoVariable:       DefaultDeleteRepoVariable,

--- a/internal/project/topology_detect.go
+++ b/internal/project/topology_detect.go
@@ -1,6 +1,9 @@
 package project
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // Pure topology-detection helpers. Extracted from api.go so they stay
 // covered by the project package's test suite — the rest of api.go is
@@ -30,9 +33,52 @@ func DetectTopology(currentOwnerRepo string, linked []LinkedRepo) Topology {
 // ControlPlaneRepo returns the control plane repo from the linked repos.
 // For Single topology this is the current repo; for Federated it is the
 // linked repo. Returns false when there are no linked repos.
+//
+// NOTE: this uses a positional heuristic (first linked repo). For federation
+// the authoritative rule is "the repo bearing FEDERATION.md" — see
+// ResolveControlPlane, which identifies the control plane by the manifest.
 func ControlPlaneRepo(linked []LinkedRepo) (LinkedRepo, bool) {
 	if len(linked) == 0 {
 		return LinkedRepo{}, false
 	}
 	return linked[0], true
+}
+
+// ResolveControlPlane identifies the control-plane repo among a project's
+// linked repos as the one whose root contains FEDERATION.md. It checks each
+// linked repo via hasFederationFile and returns the first match.
+//
+// When no linked repo carries the manifest — single topology, or a project
+// with no federation requirements repo — it returns ok=false with a nil
+// error, so callers fall back to single-repo behaviour. A check failure for
+// any repo is surfaced as an error rather than silently skipped.
+//
+// Unlike ControlPlaneRepo, this does not assume the control plane is the first
+// linked repo; it identifies it by the manifest, per the federation model
+// (knowledge-plane.md: "the repo whose root contains FEDERATION.md").
+func ResolveControlPlane(linked []LinkedRepo, hasFederationFile RepoHasFederationFileFunc) (LinkedRepo, bool, error) {
+	for _, r := range linked {
+		owner, repo, ok := splitOwnerRepo(r.NameWithOwner)
+		if !ok {
+			continue
+		}
+		has, err := hasFederationFile(owner, repo)
+		if err != nil {
+			return LinkedRepo{}, false, fmt.Errorf("resolving control plane: %w", err)
+		}
+		if has {
+			return r, true, nil
+		}
+	}
+	return LinkedRepo{}, false, nil
+}
+
+// splitOwnerRepo splits an "owner/repo" string into its parts. ok is false
+// when the input is not in owner/repo form (empty or missing a segment).
+func splitOwnerRepo(nameWithOwner string) (owner, repo string, ok bool) {
+	parts := strings.SplitN(nameWithOwner, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }

--- a/skills/gh-agentic/SKILL.md
+++ b/skills/gh-agentic/SKILL.md
@@ -243,6 +243,8 @@ Subcommands and flags:
   - `--interactive` (`-i`)
 - `gh agentic project unlink`
   - `--yes` (`-y`)
+- `gh agentic project control-plane` — print the control-plane repo (the linked repo bearing FEDERATION.md) for this repo's project.
+  - `--raw` — print only `owner/repo` on stdout; prints nothing and exits 0 for single topology (no separate control plane). Used by the CP-rooted checkout composite action to discover the control plane.
 
 ### `gh agentic status` (group)
 


### PR DESCRIPTION
Foundation for the CP-rooted execution model (Feature #858, part of the federated-pipeline rework #855). Delivers the two validated tasks; the live-pipeline wiring is deferred (see below).

## What's in this PR

- **#865 — CP resolution.** `project.ResolveControlPlane` identifies the control plane among a Project's linked repos as the one bearing `FEDERATION.md` (not the old positional heuristic), plus `DefaultRepoHasFederationFile` (REST contents, 404 ⇒ absent). 6 unit tests.
- **#866 — CLI + composite action.**
  - `gh agentic project control-plane [--raw]` — thin entry point wrapping the resolver; `--raw` prints `owner/repo`, single topology prints nothing and exits 0.
  - `.github/actions/cp-rooted-checkout` — composite action that resolves the CP, checks out CP@main (read-only docs root) and clones the target repo into a gitignored `.work/<repo>`; single-topology falls back to a plain checkout.

## Validation

- **Unit:** full suite green; SKILL-sync test green; vet clean.
- **Live (OpenBSS federation):**
  - Resolution returned `OpenBSS/openbss` from both the CP and a real domain repo (`platform-portal`) — exercises AGENTIC_PROJECT_ID read → linked-repos GraphQL → per-repo FEDERATION.md check.
  - A throwaway runner harness (since cleaned up) proved the CP-rooted layout: docs co-located (`docs/ARCHITECTURE.md` present), target cloned into gitignored `.work/`, CP working tree not polluted by the nested clone.
  - Refinement from the run: use `.git/info/exclude` so the read-only CP stays pristine.

## Deferred — Task #867 (release-gated)

Wiring the four execution jobs (feature-design / dev-session / compliance-verify / pr-review) in `agentic-pipeline.yml` is **not** in this PR. The composite action's `gh extension install --pin <ver>` step can only run `project control-plane` once a gh-agentic release ships the command — so #867 and the action's install step get their final end-to-end validation against the federation **after** this lands and a version is cut. Tracked in #867.

## Notes

- Left the existing `ControlPlaneRepo(linked[0])` heuristic untouched — reconciling it with the FEDERATION.md rule touches init/check/switch (a broad multi-caller change), flagged as a follow-up.
- Implementation is interactive per LOCALRULES (touches skills / CLI surface / a composite action).

Part of #858. Does not close it — Task #867 remains.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)