### PR TITLE
feat: Domain-grouped federation manifest and two-tier knowledge plane

### DIFF
--- a/concepts/knowledge-plane.md
+++ b/concepts/knowledge-plane.md
@@ -81,6 +81,33 @@ Domain repos are plain single-topology repos. They do not carry any special
 filesystem mount or marker variable. The federation is declared from the control plane
 outward, not from domain repos inward.
 
+#### Domain documentation tier (#871)
+
+Under the domain-grouped `FEDERATION.md` schema, a *domain* is one or more
+repos, and a domain's documentation lives centrally on the control plane —
+not scattered across its member repos. The knowledge plane has exactly two
+tiers, both homed on the control plane:
+
+- **Federated / system tier** — the shared architecture and principles, at the
+  control-plane `docs/` root (e.g. `SYSTEM_BRIEF.md`, `SYSTEM_ARCHITECTURE.md`).
+  Never decentralised into domain repos.
+- **Domain tier** — each domain's documentation under `docs/domains/<domain>/`,
+  where `<domain>` is the domain's slug from `FEDERATION.md`. A domain spanning
+  several repos therefore has a single documentation home.
+
+There is no separate per-service documentation tier: member repos carry code,
+not design docs. A domain whose repo list has one entry is just a single-repo
+domain — its docs still live at `docs/domains/<domain>/`.
+
+`gh agentic check` emits a *soft* warning (never a failure) when a manifest
+domain has no `docs/domains/<domain>/` directory yet, since domain docs are
+authored incrementally.
+
+> The broader realignment of this concept to the control-plane-centralized
+> execution model (pipeline-on-CP, pure-code domain repos) is tracked under
+> requirement #870 / Feature #876; this section introduces the domain
+> documentation tier and the `docs/domains/<domain>/` convention.
+
 ---
 
 ## Naming — scope-explicit

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -31,11 +31,11 @@ type infoData struct {
 	projectHint string
 	topology    string // display value: "Single" or "Federation"
 
-	// federation manifest (Feature #824) — populated when FEDERATION.md
-	// is present at the repo root. Exactly one of federationRepos or
-	// federationError will be non-zero when FEDERATION.md is present.
-	federationRepos []project.FederationRepo
-	federationError string
+	// federation manifest — populated when FEDERATION.md is present at the
+	// repo root. Exactly one of federationDomains or federationError will be
+	// non-zero when FEDERATION.md is present. (#871 — domain-grouped schema.)
+	federationDomains []project.FederationDomain
+	federationError   string
 
 	// framework
 	localVersion  string
@@ -172,7 +172,7 @@ func collectInfo(data *infoData, version, date string, fetchReleases func(repo s
 		if err != nil {
 			data.federationError = err.Error()
 		} else {
-			data.federationRepos = fed.AllRepos()
+			data.federationDomains = fed.Domains
 		}
 	}
 
@@ -301,7 +301,7 @@ func printInfo(w io.Writer, data *infoData) {
 	}
 
 	// --- Federation section (shown only when FEDERATION.md is present) ---
-	if len(data.federationRepos) > 0 || data.federationError != "" {
+	if len(data.federationDomains) > 0 || data.federationError != "" {
 		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "  "+ui.SectionHeading.Render("Federation"))
 		fmt.Fprintln(w, "  "+ui.Divider(48))
@@ -309,9 +309,11 @@ func printInfo(w io.Writer, data *infoData) {
 			fmt.Fprintf(w, "  %s\n", ui.StatusWarning.Render("⚠ FEDERATION.md present but could not be parsed: "+data.federationError))
 		} else {
 			fmt.Fprintf(w, "  This is a federation requirements repository.\n")
-			fmt.Fprintf(w, "  Target repositories:\n")
-			for _, repo := range data.federationRepos {
-				fmt.Fprintf(w, "    - %s: %s\n", repo.Name, repo.Purpose)
+			for _, d := range data.federationDomains {
+				fmt.Fprintf(w, "  Domain %s — %s\n", d.Name, d.Purpose)
+				for _, repo := range d.Repos {
+					fmt.Fprintf(w, "    - %s: %s\n", repo.Name, repo.Purpose)
+				}
 			}
 		}
 	}

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -172,7 +172,7 @@ func collectInfo(data *infoData, version, date string, fetchReleases func(repo s
 		if err != nil {
 			data.federationError = err.Error()
 		} else {
-			data.federationRepos = fed.Repos
+			data.federationRepos = fed.AllRepos()
 		}
 	}
 

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -23,37 +23,33 @@ func TestPrintInfo_NoFederation_NoFederationSection(t *testing.T) {
 	}
 }
 
-// TestPrintInfo_FederationRepos_ShowsSection verifies that when federation
-// repos are populated, printInfo renders a "Federation" section with each
-// repo name and purpose listed.
-func TestPrintInfo_FederationRepos_ShowsSection(t *testing.T) {
+// TestPrintInfo_FederationDomains_ShowsGroupedSection verifies AC-1: when
+// federation domains are populated, printInfo renders a "Federation" section
+// listing each domain with its purpose and member repos (grouped, #871).
+func TestPrintInfo_FederationDomains_ShowsGroupedSection(t *testing.T) {
 	data := &infoData{
 		version:   "v2.0.0",
 		repoLabel: "acme/cp",
 		topology:  "Federation",
-		federationRepos: []project.FederationRepo{
-			{Name: "acme/domain-a", Purpose: "Primary domain"},
-			{Name: "acme/domain-b", Purpose: "Analytics domain"},
+		federationDomains: []project.FederationDomain{
+			{Name: "charging", Purpose: "Rating and balance", Repos: []project.FederationRepo{
+				{Name: "acme/charging-rating", Purpose: "Rating engine"},
+				{Name: "acme/charging-balance", Purpose: "Balance management"},
+			}},
+			{Name: "billing", Purpose: "Invoicing", Repos: []project.FederationRepo{
+				{Name: "acme/billing", Purpose: "Bill runs"},
+			}},
 		},
 	}
 	out := printInfoToString(data)
-	if !strings.Contains(out, "Federation") {
-		t.Errorf("expected 'Federation' section heading, got:\n%s", out)
-	}
-	if !strings.Contains(out, "acme/domain-a") {
-		t.Errorf("expected first repo name 'acme/domain-a' in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "Primary domain") {
-		t.Errorf("expected first repo purpose 'Primary domain' in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "acme/domain-b") {
-		t.Errorf("expected second repo name 'acme/domain-b' in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "Analytics domain") {
-		t.Errorf("expected second repo purpose 'Analytics domain' in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "Target repositories") {
-		t.Errorf("expected 'Target repositories' label, got:\n%s", out)
+	for _, want := range []string{
+		"Federation",
+		"charging", "Rating and balance", "acme/charging-rating", "Rating engine", "acme/charging-balance",
+		"billing", "Invoicing", "acme/billing", "Bill runs",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in grouped federation output, got:\n%s", want, out)
+		}
 	}
 }
 
@@ -111,8 +107,10 @@ func TestPrintInfo_NoControlPlane(t *testing.T) {
 		version:   "v2.0.0",
 		repoLabel: "acme/cp",
 		topology:  "Federation",
-		federationRepos: []project.FederationRepo{
-			{Name: "acme/domain", Purpose: "Domain repo"},
+		federationDomains: []project.FederationDomain{
+			{Name: "platform", Purpose: "Platform", Repos: []project.FederationRepo{
+				{Name: "acme/domain", Purpose: "Domain repo"},
+			}},
 		},
 	}
 	out := printInfoToString(data)

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -733,7 +733,7 @@ func checkFederationManifest(deps CheckDeps) Group {
 		return g
 	}
 
-	_, err := project.ReadFederation(deps.Root)
+	fed, err := project.ReadFederation(deps.Root)
 	if err != nil {
 		g.Results = append(g.Results, CheckResult{
 			Name:    "federation-manifest",
@@ -748,6 +748,23 @@ func checkFederationManifest(deps CheckDeps) Group {
 		Status:  Pass,
 		Message: "FEDERATION.md is valid",
 	})
+
+	// Soft check (#871): each domain's documentation lives at
+	// docs/domains/<domain>/. A missing folder is a Warning, never a Fail —
+	// domain docs are authored incrementally and must not block the manifest
+	// from validating.
+	for _, d := range fed.Domains {
+		dir := filepath.Join(deps.Root, "docs", "domains", d.Name)
+		if info, statErr := os.Stat(dir); statErr != nil || !info.IsDir() {
+			g.Results = append(g.Results, CheckResult{
+				Name:        fmt.Sprintf("federation-manifest:domain-docs:%s", d.Name),
+				Status:      Warning,
+				Message:     fmt.Sprintf("domain %q has no docs/domains/%s/ directory yet", d.Name, d.Name),
+				Remediation: fmt.Sprintf("add docs/domains/%s/ on the control plane when domain docs are ready", d.Name),
+			})
+		}
+	}
+
 	return g
 }
 

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -826,13 +826,14 @@ func checkFederationProjectSync(deps CheckDeps) Group {
 	for _, r := range linked {
 		linkedSet[strings.ToLower(r.NameWithOwner)] = true
 	}
-	manifestSet := make(map[string]bool, len(fed.Repos))
-	for _, r := range fed.Repos {
+	manifestRepos := fed.AllRepos()
+	manifestSet := make(map[string]bool, len(manifestRepos))
+	for _, r := range manifestRepos {
 		manifestSet[strings.ToLower(r.Name)] = true
 	}
 
 	// Per-manifest-repo checks: reachability (AC-3) then link status (AC-1).
-	for _, repo := range fed.Repos {
+	for _, repo := range manifestRepos {
 		parts := strings.SplitN(repo.Name, "/", 2)
 		if len(parts) != 2 {
 			continue // validated by ReadFederation; skip malformed entry defensively

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1192,16 +1192,69 @@ func TestCheckFederationManifest_ValidFile_Pass(t *testing.T) {
 	root := t.TempDir()
 	manifest := "domains:\n  - name: acme\n    purpose: Acme domain\n    repos:\n      - name: acme/domain\n        purpose: Domain repo\n"
 	_ = os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte(manifest), 0o644)
+	// Domain docs present so the soft doc-folder check (#871) does not warn.
+	_ = os.MkdirAll(filepath.Join(root, "docs", "domains", "acme"), 0o755)
 	deps := CheckDeps{Root: root}
 
 	g := checkFederationManifest(deps)
 
 	if len(g.Results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(g.Results))
+		t.Fatalf("expected 1 result, got %d: %+v", len(g.Results), g.Results)
 	}
 	r := g.Results[0]
 	if r.Status != Pass {
 		t.Errorf("status: got %v, want Pass; message: %q", r.Status, r.Message)
+	}
+}
+
+// TestCheckFederationManifest_MissingDomainDocs_Warns verifies the soft check
+// (#871): a valid manifest whose domain lacks docs/domains/<domain>/ still
+// validates (Pass) but emits a Warning — never a Fail.
+func TestCheckFederationManifest_MissingDomainDocs_Warns(t *testing.T) {
+	root := t.TempDir()
+	manifest := "domains:\n  - name: acme\n    purpose: Acme domain\n    repos:\n      - name: acme/domain\n        purpose: Domain repo\n"
+	_ = os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte(manifest), 0o644)
+	// No docs/domains/acme/ directory.
+
+	g := checkFederationManifest(CheckDeps{Root: root})
+
+	var hasValidPass, hasDocsWarn, hasFail bool
+	for _, r := range g.Results {
+		if r.Name == "federation-manifest" && r.Status == Pass {
+			hasValidPass = true
+		}
+		if r.Name == "federation-manifest:domain-docs:acme" && r.Status == Warning {
+			hasDocsWarn = true
+		}
+		if r.Status == Fail {
+			hasFail = true
+		}
+	}
+	if !hasValidPass {
+		t.Error("expected the manifest to still validate (Pass)")
+	}
+	if !hasDocsWarn {
+		t.Errorf("expected a soft Warning for missing docs/domains/acme/, got: %+v", g.Results)
+	}
+	if hasFail {
+		t.Errorf("the soft doc-folder check must never Fail, got: %+v", g.Results)
+	}
+}
+
+// TestCheckFederationManifest_DomainDocsPresent_NoWarn verifies no domain-docs
+// warning fires when docs/domains/<domain>/ exists.
+func TestCheckFederationManifest_DomainDocsPresent_NoWarn(t *testing.T) {
+	root := t.TempDir()
+	manifest := "domains:\n  - name: acme\n    purpose: Acme domain\n    repos:\n      - name: acme/domain\n        purpose: Domain repo\n"
+	_ = os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte(manifest), 0o644)
+	_ = os.MkdirAll(filepath.Join(root, "docs", "domains", "acme"), 0o755)
+
+	g := checkFederationManifest(CheckDeps{Root: root})
+
+	for _, r := range g.Results {
+		if strings.HasPrefix(r.Name, "federation-manifest:domain-docs:") {
+			t.Errorf("expected no domain-docs warning when the dir exists, got: %+v", r)
+		}
 	}
 }
 

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1190,7 +1190,7 @@ func TestCheckFederationManifest_NoFile_Pass(t *testing.T) {
 
 func TestCheckFederationManifest_ValidFile_Pass(t *testing.T) {
 	root := t.TempDir()
-	manifest := "repos:\n  - name: acme/domain\n    purpose: Domain repo\n"
+	manifest := "domains:\n  - name: acme\n    purpose: Acme domain\n    repos:\n      - name: acme/domain\n        purpose: Domain repo\n"
 	_ = os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte(manifest), 0o644)
 	deps := CheckDeps{Root: root}
 
@@ -1243,9 +1243,9 @@ func TestCheckFederationManifest_MalformedYAML_Fail(t *testing.T) {
 	}
 }
 
-func TestCheckFederationManifest_EmptyReposList_Fail(t *testing.T) {
+func TestCheckFederationManifest_EmptyDomainsList_Fail(t *testing.T) {
 	root := t.TempDir()
-	_ = os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte("repos: []\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte("domains: []\n"), 0o644)
 	deps := CheckDeps{Root: root}
 
 	g := checkFederationManifest(deps)
@@ -1257,8 +1257,8 @@ func TestCheckFederationManifest_EmptyReposList_Fail(t *testing.T) {
 	if r.Status != Fail {
 		t.Errorf("status: got %v, want Fail", r.Status)
 	}
-	if !strings.Contains(r.Message, "repos list is empty") {
-		t.Errorf("message: got %q, expected 'repos list is empty'", r.Message)
+	if !strings.Contains(r.Message, "domains list is empty") {
+		t.Errorf("message: got %q, expected 'domains list is empty'", r.Message)
 	}
 }
 
@@ -1413,9 +1413,9 @@ func TestCheckLegacyFederationConfig_MultipleItems_MultipleWarnings(t *testing.T
 // writeFederationManifest writes a minimal valid FEDERATION.md to root.
 func writeFederationManifest(t *testing.T, root string, repos ...string) {
 	t.Helper()
-	content := "repos:\n"
+	content := "domains:\n  - name: test-domain\n    purpose: test domain\n    repos:\n"
 	for _, r := range repos {
-		content += fmt.Sprintf("  - name: %s\n    purpose: test repo\n", r)
+		content += fmt.Sprintf("      - name: %s\n        purpose: test repo\n", r)
 	}
 	if err := os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte(content), 0o644); err != nil {
 		t.Fatalf("writing FEDERATION.md: %v", err)

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1560,6 +1560,44 @@ func TestCheckFederationProjectSync_ManifestRepoLinked_Pass(t *testing.T) {
 	}
 }
 
+// TestCheckFederationProjectSync_MultiDomain_AllReposChecked verifies the sync
+// check flattens repos across domains (domains→repos via AllRepos): a linked
+// repo in any domain produces a Pass result for that repo (#871).
+func TestCheckFederationProjectSync_MultiDomain_AllReposChecked(t *testing.T) {
+	root := t.TempDir()
+	manifest := `domains:
+  - name: charging
+    purpose: Charging
+    repos:
+      - name: acme/charging
+        purpose: Charging repo
+  - name: billing
+    purpose: Billing
+    repos:
+      - name: acme/billing
+        purpose: Billing repo
+`
+	_ = os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte(manifest), 0o644)
+	deps := CheckDeps{
+		Root:                 root,
+		ProjectID:            "PVT_abc",
+		FetchLinkedRepos:     fakeFetchLinkedRepos("acme/charging", "acme/billing"),
+		FetchOwnerAndRepoIDs: fakeFetchOwnerAndRepoIDs("acme/charging", "acme/billing"),
+	}
+
+	g := checkFederationProjectSync(deps)
+
+	linked := map[string]bool{}
+	for _, r := range g.Results {
+		if r.Status == Pass && strings.HasPrefix(r.Name, "federation-sync:linked:") {
+			linked[r.Name] = true
+		}
+	}
+	if !linked["federation-sync:linked:acme/charging"] || !linked["federation-sync:linked:acme/billing"] {
+		t.Errorf("expected both domains' repos checked as linked, got results: %+v", g.Results)
+	}
+}
+
 // TestCheckFederationProjectSync_ManifestRepoNotLinked_Fail verifies AC-1: a
 // manifest repo that is accessible but not linked produces a Fail result with
 // the repo node ID in Data and a repair Remediation.

--- a/internal/doctor/repair_test.go
+++ b/internal/doctor/repair_test.go
@@ -430,7 +430,7 @@ func injectFederationSyncFixture(t *testing.T, ownerRepo, repoNodeID string, lin
 	root := setupHealthyRepo(t)
 
 	// Write a valid FEDERATION.md with the target repo.
-	manifest := fmt.Sprintf("repos:\n  - name: %s\n    purpose: test\n", ownerRepo)
+	manifest := fmt.Sprintf("domains:\n  - name: test-domain\n    purpose: test domain\n    repos:\n      - name: %s\n        purpose: test\n", ownerRepo)
 	_ = os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte(manifest), 0o644)
 
 	linkCalls := &[][]string{}

--- a/internal/project/context_test.go
+++ b/internal/project/context_test.go
@@ -57,9 +57,12 @@ func TestResolve_NoFederationMD_ReturnsSingleTopology(t *testing.T) {
 // FEDERATION.md presence at deps.Root produces topology="federation".
 func TestResolve_FederationMDPresent_ReturnsFederationTopology(t *testing.T) {
 	dir := t.TempDir()
-	content := `repos:
-  - name: org/domain-one
-    purpose: "First domain"
+	content := `domains:
+  - name: example-domain
+    purpose: "Example domain"
+    repos:
+      - name: org/domain-one
+        purpose: "First domain"
 `
 	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
 		t.Fatalf("writing FEDERATION.md: %v", err)
@@ -251,9 +254,12 @@ func TestResolve_PermissionError_SetsProjectIDReadFailed(t *testing.T) {
 // presence is detected even when the repo has no AGENTIC_PROJECT_ID.
 func TestResolve_FederationMDPresent_AndNoProjectID(t *testing.T) {
 	dir := t.TempDir()
-	content := `repos:
-  - name: org/domain-one
-    purpose: "First domain"
+	content := `domains:
+  - name: example-domain
+    purpose: "Example domain"
+    repos:
+      - name: org/domain-one
+        purpose: "First domain"
 `
 	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
 		t.Fatalf("writing FEDERATION.md: %v", err)

--- a/internal/project/federation.go
+++ b/internal/project/federation.go
@@ -4,27 +4,62 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
-// FederationRepo represents a single target repository listed in FEDERATION.md.
+// FederationRepo represents a single target repository within a domain.
 type FederationRepo struct {
 	// Name is the full "owner/repo" identifier of the target repository.
 	Name string `yaml:"name"`
-	// Purpose is a human-readable description of this repo's role in the federation.
+	// Purpose is a human-readable description of this repo's role in the domain.
 	Purpose string `yaml:"purpose"`
+}
+
+// FederationDomain groups one or more repos under a named domain. A domain is
+// the unit of documentation tiering: its docs live centrally on the control
+// plane under docs/domains/<name>/.
+type FederationDomain struct {
+	// Name is a filesystem-safe slug; it maps to docs/domains/<name>/.
+	Name string `yaml:"name"`
+	// Purpose is a human-readable description of the domain.
+	Purpose string `yaml:"purpose"`
+	// Repos are the implementation repositories that make up this domain.
+	// A single-repo domain is valid — its list has one entry.
+	Repos []FederationRepo `yaml:"repos"`
 }
 
 // Federation holds the parsed contents of a FEDERATION.md manifest file.
 type Federation struct {
-	// Repos is the list of target repositories declared in the manifest.
+	// Domains groups the federation's repos under the domains they implement.
+	Domains []FederationDomain `yaml:"domains"`
+}
+
+// flatFederation is used only to detect the legacy flat `repos:` schema so
+// ReadFederation can reject it with a migration-guiding error.
+type flatFederation struct {
 	Repos []FederationRepo `yaml:"repos"`
 }
 
 // federationFileName is the canonical name of the federation manifest file.
 const federationFileName = "FEDERATION.md"
+
+// domainNamePattern validates a domain name as a filesystem-safe slug, since
+// each domain maps to a docs/domains/<name>/ folder.
+var domainNamePattern = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// AllRepos flattens the manifest's domains into a single ordered slice of
+// repos, preserving domain and in-domain order. Consumers that need the flat
+// target set use this rather than re-walking the nesting.
+func (f *Federation) AllRepos() []FederationRepo {
+	var repos []FederationRepo
+	for _, d := range f.Domains {
+		repos = append(repos, d.Repos...)
+	}
+	return repos
+}
 
 // IsFederationRepo returns true when a FEDERATION.md file exists at root.
 // It uses os.Stat only — no YAML decode — so it is fast and has no side effects.
@@ -35,15 +70,21 @@ func IsFederationRepo(root string) bool {
 	return err == nil
 }
 
-// ReadFederation reads and validates the FEDERATION.md manifest at root.
-// It returns the first validation error found:
+// ReadFederation reads and validates the domain-grouped FEDERATION.md manifest
+// at root. It returns the first validation error found:
 //   - file present but empty → "FEDERATION.md: file is empty"
 //   - YAML parse error → "FEDERATION.md: YAML parse error: <detail>"
-//   - repos list absent or empty → "FEDERATION.md: repos list is empty"
-//   - entry N missing name → "FEDERATION.md: entry N: name is required"
-//   - entry N missing/blank purpose → "FEDERATION.md: entry N: purpose is required"
-//   - entry N name not in owner/repo format → "FEDERATION.md: entry N: name must be in owner/repo format"
-//   - duplicate name → "FEDERATION.md: duplicate repo <name>"
+//   - legacy flat `repos:` schema → "FEDERATION.md: flat `repos:` schema is no longer supported — group repos under `domains:`"
+//   - domains list absent or empty → "FEDERATION.md: domains list is empty"
+//   - domain missing name → "FEDERATION.md: domain N: name is required"
+//   - domain name not a slug → "FEDERATION.md: domain <name>: name must be a lowercase slug ([a-z0-9-])"
+//   - domain missing/blank purpose → "FEDERATION.md: domain <name>: purpose is required"
+//   - duplicate domain → "FEDERATION.md: duplicate domain <name>"
+//   - domain with no repos → "FEDERATION.md: domain <name>: repos list is empty"
+//   - repo missing name → "FEDERATION.md: domain <name>: repo N: name is required"
+//   - repo missing/blank purpose → "FEDERATION.md: domain <name>: repo <name>: purpose is required"
+//   - repo name not owner/repo → "FEDERATION.md: domain <name>: repo <name>: name must be in owner/repo format"
+//   - duplicate repo across the manifest → "FEDERATION.md: duplicate repo <name>"
 func ReadFederation(root string) (*Federation, error) {
 	path := filepath.Join(root, federationFileName)
 	data, err := os.ReadFile(path)
@@ -60,34 +101,62 @@ func ReadFederation(root string) (*Federation, error) {
 		return nil, fmt.Errorf("FEDERATION.md: YAML parse error: %s", err.Error())
 	}
 
-	if len(fed.Repos) == 0 {
-		return nil, fmt.Errorf("FEDERATION.md: repos list is empty")
+	if len(fed.Domains) == 0 {
+		// Hard-cut: a flat `repos:` manifest is rejected with migration guidance
+		// rather than silently treated as empty.
+		var flat flatFederation
+		if yaml.Unmarshal(data, &flat) == nil && len(flat.Repos) > 0 {
+			return nil, fmt.Errorf("FEDERATION.md: flat `repos:` schema is no longer supported — group repos under `domains:`")
+		}
+		return nil, fmt.Errorf("FEDERATION.md: domains list is empty")
 	}
 
-	seen := make(map[string]bool, len(fed.Repos))
-	for i, repo := range fed.Repos {
-		entry := i + 1
-		if repo.Name == "" {
-			return nil, fmt.Errorf("FEDERATION.md: entry %d: name is required", entry)
+	seenRepo := make(map[string]bool)
+	seenDomain := make(map[string]bool)
+	for di, d := range fed.Domains {
+		domainNo := di + 1
+		if d.Name == "" {
+			return nil, fmt.Errorf("FEDERATION.md: domain %d: name is required", domainNo)
 		}
-		if strings.TrimSpace(repo.Purpose) == "" {
-			return nil, fmt.Errorf("FEDERATION.md: entry %d: purpose is required", entry)
+		if !domainNamePattern.MatchString(d.Name) {
+			return nil, fmt.Errorf("FEDERATION.md: domain %q: name must be a lowercase slug ([a-z0-9-])", d.Name)
 		}
-		if !isValidOwnerRepo(repo.Name) {
-			return nil, fmt.Errorf("FEDERATION.md: entry %d: name must be in owner/repo format", entry)
+		if strings.TrimSpace(d.Purpose) == "" {
+			return nil, fmt.Errorf("FEDERATION.md: domain %q: purpose is required", d.Name)
 		}
-		lower := strings.ToLower(repo.Name)
-		if seen[lower] {
-			return nil, fmt.Errorf("FEDERATION.md: duplicate repo %q", repo.Name)
+		domainKey := strings.ToLower(d.Name)
+		if seenDomain[domainKey] {
+			return nil, fmt.Errorf("FEDERATION.md: duplicate domain %q", d.Name)
 		}
-		seen[lower] = true
+		seenDomain[domainKey] = true
+
+		if len(d.Repos) == 0 {
+			return nil, fmt.Errorf("FEDERATION.md: domain %q: repos list is empty", d.Name)
+		}
+		for ri, repo := range d.Repos {
+			repoNo := ri + 1
+			if repo.Name == "" {
+				return nil, fmt.Errorf("FEDERATION.md: domain %q: repo %d: name is required", d.Name, repoNo)
+			}
+			if strings.TrimSpace(repo.Purpose) == "" {
+				return nil, fmt.Errorf("FEDERATION.md: domain %q: repo %q: purpose is required", d.Name, repo.Name)
+			}
+			if !isValidOwnerRepo(repo.Name) {
+				return nil, fmt.Errorf("FEDERATION.md: domain %q: repo %q: name must be in owner/repo format", d.Name, repo.Name)
+			}
+			repoKey := strings.ToLower(repo.Name)
+			if seenRepo[repoKey] {
+				return nil, fmt.Errorf("FEDERATION.md: duplicate repo %q", repo.Name)
+			}
+			seenRepo[repoKey] = true
+		}
 	}
 
 	return &fed, nil
 }
 
 // isValidOwnerRepo returns true when name is in "owner/repo" format with
-// non-empty owner and repo parts. A simple split-count check per the task spec.
+// non-empty owner and repo parts.
 func isValidOwnerRepo(name string) bool {
 	parts := strings.SplitN(name, "/", 3)
 	return len(parts) == 2 && parts[0] != "" && parts[1] != ""

--- a/internal/project/federation_test.go
+++ b/internal/project/federation_test.go
@@ -7,11 +7,33 @@ import (
 	"testing"
 )
 
-func TestIsFederationRepo_FilePresent_ReturnsTrue(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte("repos:\n  - name: owner/repo\n    purpose: test\n"), 0644); err != nil {
+// validManifest is a domain-grouped FEDERATION.md fixture with two domains,
+// one of which spans two repos.
+const validManifest = `domains:
+  - name: charging
+    purpose: "Rating, balance, charging events"
+    repos:
+      - name: owner/charging-rating
+        purpose: "Rating engine"
+      - name: owner/charging-balance
+        purpose: "Balance management"
+  - name: billing
+    purpose: "Invoice generation"
+    repos:
+      - name: owner/billing-domain
+        purpose: "Bill runs and statements"
+`
+
+func writeManifest(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
 		t.Fatalf("writing FEDERATION.md: %v", err)
 	}
+}
+
+func TestIsFederationRepo_FilePresent_ReturnsTrue(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, validManifest)
 	if !IsFederationRepo(dir) {
 		t.Error("IsFederationRepo: expected true when FEDERATION.md exists, got false")
 	}
@@ -26,256 +48,287 @@ func TestIsFederationRepo_FileAbsent_ReturnsFalse(t *testing.T) {
 
 func TestReadFederation_ValidManifest_ParsedCorrectly(t *testing.T) {
 	dir := t.TempDir()
-	content := `repos:
-  - name: owner/repo-one
-    purpose: "First domain area"
-  - name: owner/repo-two
-    purpose: "Second domain area"
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
+	writeManifest(t, dir, validManifest)
 
 	fed, err := ReadFederation(dir)
 	if err != nil {
 		t.Fatalf("ReadFederation: unexpected error: %v", err)
 	}
-	if len(fed.Repos) != 2 {
-		t.Fatalf("expected 2 repos, got %d", len(fed.Repos))
+	if len(fed.Domains) != 2 {
+		t.Fatalf("expected 2 domains, got %d", len(fed.Domains))
 	}
-	if fed.Repos[0].Name != "owner/repo-one" {
-		t.Errorf("repo[0].Name: expected %q, got %q", "owner/repo-one", fed.Repos[0].Name)
+	if fed.Domains[0].Name != "charging" {
+		t.Errorf("domain[0].Name: expected %q, got %q", "charging", fed.Domains[0].Name)
 	}
-	if fed.Repos[0].Purpose != "First domain area" {
-		t.Errorf("repo[0].Purpose: expected %q, got %q", "First domain area", fed.Repos[0].Purpose)
+	if len(fed.Domains[0].Repos) != 2 {
+		t.Fatalf("expected 2 repos in domain charging, got %d", len(fed.Domains[0].Repos))
 	}
-	if fed.Repos[1].Name != "owner/repo-two" {
-		t.Errorf("repo[1].Name: expected %q, got %q", "owner/repo-two", fed.Repos[1].Name)
+	if fed.Domains[0].Repos[0].Name != "owner/charging-rating" {
+		t.Errorf("repo[0].Name: expected %q, got %q", "owner/charging-rating", fed.Domains[0].Repos[0].Name)
+	}
+	if fed.Domains[1].Name != "billing" {
+		t.Errorf("domain[1].Name: expected %q, got %q", "billing", fed.Domains[1].Name)
 	}
 }
 
-func TestReadFederation_ValidManifestSingleRepo_ParsedCorrectly(t *testing.T) {
+func TestReadFederation_AllRepos_Flattens(t *testing.T) {
 	dir := t.TempDir()
-	content := `repos:
-  - name: myorg/my-service
-    purpose: "The only domain repo"
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
+	writeManifest(t, dir, validManifest)
 
 	fed, err := ReadFederation(dir)
 	if err != nil {
 		t.Fatalf("ReadFederation: unexpected error: %v", err)
 	}
-	if len(fed.Repos) != 1 {
-		t.Fatalf("expected 1 repo, got %d", len(fed.Repos))
+	all := fed.AllRepos()
+	if len(all) != 3 {
+		t.Fatalf("AllRepos: expected 3 repos, got %d", len(all))
 	}
-	if fed.Repos[0].Name != "myorg/my-service" {
-		t.Errorf("expected name %q, got %q", "myorg/my-service", fed.Repos[0].Name)
+	want := []string{"owner/charging-rating", "owner/charging-balance", "owner/billing-domain"}
+	for i, w := range want {
+		if all[i].Name != w {
+			t.Errorf("AllRepos[%d]: expected %q, got %q (order must be preserved)", i, w, all[i].Name)
+		}
+	}
+}
+
+// AC-3: a domain with exactly one repo is a valid single-repo domain.
+func TestReadFederation_SingleRepoDomain_ParsedCorrectly(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `domains:
+  - name: platform
+    purpose: "The only domain"
+    repos:
+      - name: myorg/my-service
+        purpose: "The only domain repo"
+`)
+
+	fed, err := ReadFederation(dir)
+	if err != nil {
+		t.Fatalf("ReadFederation: unexpected error: %v", err)
+	}
+	if len(fed.Domains) != 1 || len(fed.Domains[0].Repos) != 1 {
+		t.Fatalf("expected 1 domain with 1 repo, got %d domain(s)", len(fed.Domains))
+	}
+	if fed.AllRepos()[0].Name != "myorg/my-service" {
+		t.Errorf("expected name %q, got %q", "myorg/my-service", fed.AllRepos()[0].Name)
+	}
+}
+
+// Hard-cut: the legacy flat `repos:` schema is rejected with migration guidance.
+func TestReadFederation_FlatSchema_Rejected(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `repos:
+  - name: owner/repo-one
+    purpose: "First"
+`)
+
+	_, err := ReadFederation(dir)
+	if err == nil {
+		t.Fatal("expected an error for the legacy flat schema, got nil")
+	}
+	if !strings.Contains(err.Error(), "flat `repos:` schema is no longer supported") {
+		t.Errorf("error should guide migration to domains, got: %q", err.Error())
 	}
 }
 
 func TestReadFederation_EmptyFile_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte("   \n  "), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
+	writeManifest(t, dir, "   \n  ")
 
 	_, err := ReadFederation(dir)
-	if err == nil {
-		t.Fatal("expected an error for empty file, got nil")
-	}
-	if !strings.Contains(err.Error(), "file is empty") {
-		t.Errorf("error message should contain 'file is empty', got: %q", err.Error())
+	if err == nil || !strings.Contains(err.Error(), "file is empty") {
+		t.Fatalf("expected 'file is empty' error, got: %v", err)
 	}
 }
 
 func TestReadFederation_MalformedYAML_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	// Indentation error — valid YAML tokens but unexpected structure that
-	// produces a YAML parse error.
-	content := `repos:
-  - name: [unclosed bracket
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
+	writeManifest(t, dir, "domains:\n  - name: [unclosed bracket\n")
 
 	_, err := ReadFederation(dir)
-	if err == nil {
-		t.Fatal("expected an error for malformed YAML, got nil")
-	}
-	if !strings.Contains(err.Error(), "YAML parse error") {
-		t.Errorf("error message should contain 'YAML parse error', got: %q", err.Error())
+	if err == nil || !strings.Contains(err.Error(), "YAML parse error") {
+		t.Fatalf("expected 'YAML parse error', got: %v", err)
 	}
 }
 
-func TestReadFederation_EmptyReposList_ReturnsError(t *testing.T) {
+func TestReadFederation_EmptyDomainsList_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	content := `repos: []
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
+	writeManifest(t, dir, "domains: []\n")
 
 	_, err := ReadFederation(dir)
-	if err == nil {
-		t.Fatal("expected an error for empty repos list, got nil")
-	}
-	if !strings.Contains(err.Error(), "repos list is empty") {
-		t.Errorf("error message should contain 'repos list is empty', got: %q", err.Error())
+	if err == nil || !strings.Contains(err.Error(), "domains list is empty") {
+		t.Fatalf("expected 'domains list is empty', got: %v", err)
 	}
 }
 
-func TestReadFederation_MissingReposKey_ReturnsError(t *testing.T) {
+func TestReadFederation_MissingDomainsKey_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	content := `something: else
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
+	writeManifest(t, dir, "something: else\n")
 
 	_, err := ReadFederation(dir)
-	if err == nil {
-		t.Fatal("expected an error when repos key is absent, got nil")
-	}
-	if !strings.Contains(err.Error(), "repos list is empty") {
-		t.Errorf("error message should contain 'repos list is empty', got: %q", err.Error())
+	if err == nil || !strings.Contains(err.Error(), "domains list is empty") {
+		t.Fatalf("expected 'domains list is empty', got: %v", err)
 	}
 }
 
-func TestReadFederation_MissingName_ReturnsError(t *testing.T) {
+func TestReadFederation_DomainMissingName_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	content := `repos:
-  - purpose: "Some purpose"
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
+	writeManifest(t, dir, `domains:
+  - purpose: "no name"
+    repos:
+      - name: owner/repo
+        purpose: "p"
+`)
+
+	_, err := ReadFederation(dir)
+	if err == nil || !strings.Contains(err.Error(), "name is required") {
+		t.Fatalf("expected domain 'name is required', got: %v", err)
 	}
+}
+
+func TestReadFederation_DomainBadSlug_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `domains:
+  - name: "Not A Slug"
+    purpose: "p"
+    repos:
+      - name: owner/repo
+        purpose: "p"
+`)
+
+	_, err := ReadFederation(dir)
+	if err == nil || !strings.Contains(err.Error(), "lowercase slug") {
+		t.Fatalf("expected slug error, got: %v", err)
+	}
+}
+
+func TestReadFederation_DomainMissingPurpose_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `domains:
+  - name: charging
+    purpose: "   "
+    repos:
+      - name: owner/repo
+        purpose: "p"
+`)
+
+	_, err := ReadFederation(dir)
+	if err == nil || !strings.Contains(err.Error(), "purpose is required") {
+		t.Fatalf("expected domain 'purpose is required', got: %v", err)
+	}
+}
+
+func TestReadFederation_DuplicateDomain_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `domains:
+  - name: charging
+    purpose: "p"
+    repos:
+      - name: owner/repo-a
+        purpose: "p"
+  - name: charging
+    purpose: "p"
+    repos:
+      - name: owner/repo-b
+        purpose: "p"
+`)
+
+	_, err := ReadFederation(dir)
+	if err == nil || !strings.Contains(err.Error(), "duplicate domain") {
+		t.Fatalf("expected 'duplicate domain', got: %v", err)
+	}
+}
+
+func TestReadFederation_DomainEmptyRepos_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `domains:
+  - name: charging
+    purpose: "p"
+    repos: []
+`)
+
+	_, err := ReadFederation(dir)
+	if err == nil || !strings.Contains(err.Error(), "repos list is empty") {
+		t.Fatalf("expected 'repos list is empty', got: %v", err)
+	}
+}
+
+// AC-2: a repo with no name yields an error naming the offending domain.
+func TestReadFederation_RepoMissingName_ErrorNamesDomain(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `domains:
+  - name: charging
+    purpose: "p"
+    repos:
+      - purpose: "no name"
+`)
 
 	_, err := ReadFederation(dir)
 	if err == nil {
-		t.Fatal("expected an error for missing name, got nil")
+		t.Fatal("expected an error for missing repo name, got nil")
 	}
 	if !strings.Contains(err.Error(), "name is required") {
-		t.Errorf("error message should contain 'name is required', got: %q", err.Error())
+		t.Errorf("expected 'name is required', got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "charging") {
+		t.Errorf("expected the error to name the offending domain 'charging', got: %q", err.Error())
 	}
 }
 
-func TestReadFederation_MissingPurpose_ReturnsError(t *testing.T) {
+func TestReadFederation_RepoMissingPurpose_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	content := `repos:
-  - name: owner/repo-name
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
+	writeManifest(t, dir, `domains:
+  - name: charging
+    purpose: "p"
+    repos:
+      - name: owner/repo
+        purpose: "   "
+`)
 
 	_, err := ReadFederation(dir)
-	if err == nil {
-		t.Fatal("expected an error for missing purpose, got nil")
-	}
-	if !strings.Contains(err.Error(), "purpose is required") {
-		t.Errorf("error message should contain 'purpose is required', got: %q", err.Error())
+	if err == nil || !strings.Contains(err.Error(), "purpose is required") {
+		t.Fatalf("expected repo 'purpose is required', got: %v", err)
 	}
 }
 
-func TestReadFederation_BlankPurpose_ReturnsError(t *testing.T) {
-	dir := t.TempDir()
-	content := `repos:
-  - name: owner/repo-name
-    purpose: "   "
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
-
-	_, err := ReadFederation(dir)
-	if err == nil {
-		t.Fatal("expected an error for blank purpose, got nil")
-	}
-	if !strings.Contains(err.Error(), "purpose is required") {
-		t.Errorf("error message should contain 'purpose is required', got: %q", err.Error())
-	}
-}
-
-func TestReadFederation_BadNameFormat_ReturnsError(t *testing.T) {
-	tests := []struct {
-		name    string
-		badName string
-	}{
-		{name: "no slash", badName: "justareponame"},
-		{name: "double slash", badName: "owner/repo/extra"},
-		{name: "empty owner", badName: "/repoonly"},
-		{name: "empty repo", badName: "owneronly/"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+func TestReadFederation_RepoBadNameFormat_ReturnsError(t *testing.T) {
+	for _, badName := range []string{"justareponame", "owner/repo/extra", "/repoonly", "owneronly/"} {
+		t.Run(badName, func(t *testing.T) {
 			dir := t.TempDir()
-			content := "repos:\n  - name: " + tc.badName + "\n    purpose: \"A purpose\"\n"
-			if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-				t.Fatalf("writing FEDERATION.md: %v", err)
-			}
+			writeManifest(t, dir, "domains:\n  - name: charging\n    purpose: \"p\"\n    repos:\n      - name: "+badName+"\n        purpose: \"p\"\n")
 
 			_, err := ReadFederation(dir)
-			if err == nil {
-				t.Fatalf("expected error for name %q, got nil", tc.badName)
-			}
-			if !strings.Contains(err.Error(), "owner/repo format") {
-				t.Errorf("error should mention 'owner/repo format', got: %q", err.Error())
+			if err == nil || !strings.Contains(err.Error(), "owner/repo format") {
+				t.Fatalf("expected 'owner/repo format' error for %q, got: %v", badName, err)
 			}
 		})
 	}
 }
 
-func TestReadFederation_DuplicateName_ReturnsError(t *testing.T) {
+func TestReadFederation_DuplicateRepoAcrossDomains_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	content := `repos:
-  - name: owner/repo-name
-    purpose: "First"
-  - name: owner/repo-name
-    purpose: "Second"
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
+	writeManifest(t, dir, `domains:
+  - name: charging
+    purpose: "p"
+    repos:
+      - name: Owner/Shared-Repo
+        purpose: "p"
+  - name: billing
+    purpose: "p"
+    repos:
+      - name: owner/shared-repo
+        purpose: "p"
+`)
 
 	_, err := ReadFederation(dir)
-	if err == nil {
-		t.Fatal("expected an error for duplicate repo name, got nil")
-	}
-	if !strings.Contains(err.Error(), "duplicate repo") {
-		t.Errorf("error message should contain 'duplicate repo', got: %q", err.Error())
-	}
-}
-
-func TestReadFederation_DuplicateNameCaseInsensitive_ReturnsError(t *testing.T) {
-	dir := t.TempDir()
-	content := `repos:
-  - name: Owner/Repo-Name
-    purpose: "First"
-  - name: owner/repo-name
-    purpose: "Second"
-`
-	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
-		t.Fatalf("writing FEDERATION.md: %v", err)
-	}
-
-	_, err := ReadFederation(dir)
-	if err == nil {
-		t.Fatal("expected an error for case-insensitive duplicate repo name, got nil")
-	}
-	if !strings.Contains(err.Error(), "duplicate repo") {
-		t.Errorf("error message should contain 'duplicate repo', got: %q", err.Error())
+	if err == nil || !strings.Contains(err.Error(), "duplicate repo") {
+		t.Fatalf("expected case-insensitive 'duplicate repo' across domains, got: %v", err)
 	}
 }
 
 func TestReadFederation_FileNotFound_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	// No file written — ReadFederation should report the OS error.
-	_, err := ReadFederation(dir)
-	if err == nil {
+	if _, err := ReadFederation(dir); err == nil {
 		t.Fatal("expected an error when FEDERATION.md is absent, got nil")
 	}
 }

--- a/internal/project/info_test.go
+++ b/internal/project/info_test.go
@@ -155,7 +155,7 @@ func TestPrintInfo_Federated(t *testing.T) {
 	// Topology is now derived from FEDERATION.md presence — write the file
 	// into a real tempdir so IsFederationRepo returns true.
 	dir := t.TempDir()
-	content := "repos:\n  - name: org/domain-one\n    purpose: \"First domain\"\n"
+	content := "domains:\n  - name: example-domain\n    purpose: \"Example domain\"\n    repos:\n      - name: org/domain-one\n        purpose: \"First domain\"\n"
 	if err := os.WriteFile(filepath.Join(dir, federationFileName), []byte(content), 0644); err != nil {
 		t.Fatalf("writing FEDERATION.md: %v", err)
 	}


### PR DESCRIPTION
## Summary

Implements **Feature #871** — the domain-grouped `FEDERATION.md` schema and the
two-tier knowledge plane — the foundational feature of requirement **#870**
(control-plane-centralized federated pipeline execution, ratifying decision #869).

`FEDERATION.md` moves from a flat `repos:` list to a domain-grouped schema
(`domains:` → repos). A *domain* is one or more repos; a domain's documentation
lives centrally on the control plane under `docs/domains/<domain>/`.

## What changed

- **Schema + validation** (`internal/project/federation.go`): new
  `FederationDomain{ Name, Purpose, Repos }`; `Federation.Domains` + an
  `AllRepos()` flatten helper. `ReadFederation` validates the nested shape and
  **hard-cuts** the legacy flat `repos:` schema with a migration-guiding error.
- **Consumers**: `gh agentic info` renders the federation section grouped by
  domain (purpose + member repos); the `doctor` federation-sync check flattens
  domains→repos via `AllRepos()`.
- **Two-tier knowledge plane**: documented in `concepts/knowledge-plane.md`
  (federated docs at `docs/` root, domain docs at `docs/domains/<domain>/`, no
  service tier). `gh agentic check` gains a **soft** warning (never a failure)
  when a manifest domain has no `docs/domains/<domain>/` directory yet.

## Contract

`FEDERATION.md` is a contract — the schema change is recorded in decision issue
**#877** (consumers checked + migration plan; hard-cut, no production manifests).

## Testing

- `go build ./...` and `go test ./...` pass.
- Acceptance criteria all covered: AC-1 (grouped `info` render), AC-2 (validation
  error names the offending domain), AC-3 (single-repo domain accepted).

## Tasks

Closes #878, closes #879, closes #880.

Closes #871

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)
