### PR TITLE
feat: Control-plane feature issues with a target-repo field

### DIFF
--- a/concepts/knowledge-plane.md
+++ b/concepts/knowledge-plane.md
@@ -350,19 +350,34 @@ gap in `project check` output.
 Requirements and features are GitHub Issues, not files. The knowledge plane
 does not store them.
 
-- **Cross-domain requirements** live as Issues on the **control plane** repo.
-  The scoping session produces **one Feature per affected domain**, each
-  Feature living in its own domain repo, each linked to the parent
-  Requirement via `Closes part of owner/cp-repo#N`.
-- **Domain-scoped requirements** live as Issues on the domain repo itself.
-- **Features are always per-repo.** A feature maps to a single branch in a
-  single repo. Cross-domain ordering is expressed with
-  `blocked-by: owner/repo#N` on the dependent feature; the human holds
-  `in-design` on a dependent feature until its blocker closes.
+- **Requirements** live as Issues on the **control plane** repo.
+- **Features also live on the control plane**, as same-repo sub-issues of their
+  parent Requirement. A federated Feature records the single implementation repo
+  it targets in a "Target repo" ProjectV2 field (the owner is always the
+  control-plane owner; the field holds the bare repo name); the pipeline reads
+  that field to clone the target. This reverses the earlier model (#825), where
+  Features were created in their target domain repo via cross-repo sub-issues —
+  domain repos are now pure code with no pipeline of their own, so a Feature
+  issue placed there would have no workflow to fire.
+- **Features are always single-target.** A feature maps to a single branch in a
+  single implementation repo. A feature whose work spans two repos is split at
+  scoping into one Feature per repo, each with its own target. Ordering is
+  expressed with `blocked-by: #N` on the dependent feature (same-repo issue
+  references on the control plane); the human holds the design trigger on a
+  dependent feature until its blocker closes.
 
 This is why no filesystem `docs/requirements/` directory exists. The
 motivation shared across repos lives in the Requirement issue's body on the CP,
 referenced by every child Feature.
+
+**CP-event triggering contract.** Because Features live on the control plane, the
+pipeline fires on **control-plane issue events**: applying a trigger label (e.g.
+`in-design`, `in-development`) to a Feature on the control plane starts the
+corresponding phase, which reads the Feature's "Target repo" field to know which
+repo to clone into `./project`. This CP-event triggering and the checkout it
+drives are implemented by the pipeline workflow (Feature #873); requirement
+scoping's job is to place the Feature on the control plane with its "Target repo"
+field set, so the trigger has a well-formed issue to key off.
 
 ---
 

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -214,6 +214,7 @@ func buildPipelineCheckDeps(pdeps project.Deps) (doctor.CheckDeps, error) {
 		FetchProjectTitle:        project.DefaultFetchProjectTitle,
 		FetchProjectFields:       project.DefaultFetchProjectFields,
 		UpdateStatusFieldOptions: project.DefaultUpdateStatusFieldOptions,
+		CreateProjectField:       project.DefaultCreateProjectField,
 		FetchLinkedRepos:         project.DefaultFetchLinkedRepos,
 		FetchOwnerAndRepoIDs:     project.DefaultFetchOwnerAndRepoIDs,
 		LinkRepoToProject:        project.DefaultLinkRepoToProject,

--- a/internal/cli/status_feature.go
+++ b/internal/cli/status_feature.go
@@ -148,6 +148,7 @@ func writeFeatureRaw(w io.Writer, f *projectstatus.Feature, verbose bool) error 
 		{"stage", string(f.Stage)},
 		{"title", f.Title},
 		{"owning_repo", f.OwningRepo},
+		{"target_repo", rawTargetRepoValue(f.TargetRepo)},
 	}
 	if verbose {
 		header = append(header,
@@ -207,6 +208,15 @@ func writeFeatureRaw(w io.Writer, f *projectstatus.Feature, verbose bool) error 
 // rawParentRequirementValue renders the parent-requirement number for the
 // `parent_requirement` header field, or an empty string when the feature
 // has no parent requirement on the project board.
+// rawTargetRepoValue renders the Target repo field value; an unset target is
+// reported as "(unset)" so consumers never assume a repo (#872, AC-2).
+func rawTargetRepoValue(target string) string {
+	if strings.TrimSpace(target) == "" {
+		return "(unset)"
+	}
+	return target
+}
+
 func rawParentRequirementValue(p *projectstatus.RequirementSummary) string {
 	if p == nil {
 		return ""

--- a/internal/cli/status_feature_test.go
+++ b/internal/cli/status_feature_test.go
@@ -278,6 +278,35 @@ func TestRunStatusFeature_RawVerbatimBody(t *testing.T) {
 	}
 }
 
+// TestRunStatusFeature_RawTargetRepo verifies the target_repo line (#872, AC-2):
+// the value when the Target repo field is set, and "(unset)" when it is absent so
+// consumers never assume a repo.
+func TestRunStatusFeature_RawTargetRepo(t *testing.T) {
+	now := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{"set", "charging-rating", "target_repo: charging-rating"},
+		{"unset", "", "target_repo: (unset)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := []projectstatus.ProjectIssue{
+				{Number: 492, Title: "feat: x", Body: "b", Stage: projectstatus.StageInDevelopment, Type: "feature", State: "open", OwningRepo: "eddiecarpenter/gh-agentic", TargetRepo: tc.target, CreatedAt: now, LastTransitionedAt: now},
+			}
+			sd := featureDetailFixture(issues, nil, nil, nil, nil)
+			buf := &bytes.Buffer{}
+			if err := runStatusFeature(buf, io.Discard, 492, statusDetailFlags{raw: true}, sd); err != nil {
+				t.Fatalf("runStatusFeature --raw: %v", err)
+			}
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("expected %q in raw output; got:\n%s", tc.want, buf.String())
+			}
+		})
+	}
+}
+
 // TestRunStatusFeature_RawSeparatorAlwaysPresent verifies the `---`
 // separator is emitted even when the issue body is empty.
 func TestRunStatusFeature_RawSeparatorAlwaysPresent(t *testing.T) {

--- a/internal/cli/testdata/status_raw/feature_detail.raw
+++ b/internal/cli/testdata/status_raw/feature_detail.raw
@@ -2,6 +2,7 @@ number: 492
 stage: in-development
 title: feat: status command
 owning_repo: eddiecarpenter/gh-agentic
+target_repo: (unset)
 blocked_by:
 parent_requirement: 457
 branch: feature/492 (merged)

--- a/internal/cli/testdata/status_raw/feature_detail_verbose.raw
+++ b/internal/cli/testdata/status_raw/feature_detail_verbose.raw
@@ -2,6 +2,7 @@ number: 492
 stage: in-development
 title: feat: status command
 owning_repo: eddiecarpenter/gh-agentic
+target_repo: (unset)
 created_at: 2026-04-18
 last_transitioned_at: 2026-04-18
 blocked_by:

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -35,6 +35,10 @@ type CheckDeps struct {
 	// project.DefaultUpdateStatusFieldOptions.
 	FetchProjectFields       project.FetchProjectFieldsFunc
 	UpdateStatusFieldOptions project.UpdateStatusFieldOptionsFunc
+	// CreateProjectField is used by RepairPipeline to create the "Target repo"
+	// field (#872) when it is missing on a federation control-plane project.
+	// Repair-only; the check command leaves it nil.
+	CreateProjectField project.CreateProjectFieldFunc
 	// FetchLinkedRepos, FetchOwnerAndRepoIDs, and LinkRepoToProject are used
 	// by checkFederationProjectSync (check) and RepairPipeline (repair) to
 	// detect and fix drift between FEDERATION.md and the GitHub Project's
@@ -226,6 +230,7 @@ func checksForTopologyWithLabels(deps CheckDeps) []checkGroupStep {
 			{"Checking pipeline labels...", checkLabels},
 			{"Checking project reachability...", checkProjectReachability},
 			{"Checking project status options...", checkProjectStatusOptions},
+			{"Checking project target-repo field...", checkProjectTargetRepoField},
 		}
 		return base
 	}
@@ -250,6 +255,9 @@ func checksForTopologyWithLabels(deps CheckDeps) []checkGroupStep {
 		// Project status options run after reachability — no point checking options
 		// on a project that isn't reachable.
 		{"Checking project status options...", checkProjectStatusOptions},
+		// Target-repo field: required on federation control-plane projects (#872);
+		// skipped for single topology.
+		{"Checking project target-repo field...", checkProjectTargetRepoField},
 		// Federation manifest: validates FEDERATION.md when present; passes silently
 		// when absent (single topology).
 		{"Checking federation manifest...", checkFederationManifest},
@@ -712,6 +720,63 @@ func checkProjectStatusOptions(deps CheckDeps) Group {
 	g.Results = append(g.Results, CheckResult{
 		Name: "status-options", Status: Pass,
 		Message: fmt.Sprintf("project status options OK (%d options)", len(existing)),
+	})
+	return g
+}
+
+// checkProjectTargetRepoField verifies the project board carries the
+// "Target repo" field (#872) that control-plane Feature issues use to record
+// their target domain repo. A missing field is repairable.
+func checkProjectTargetRepoField(deps CheckDeps) Group {
+	g := Group{Name: "Project target-repo field"}
+
+	// The Target repo field is a federation concern — single-topology projects
+	// have no separate target repo, so the field is not required there.
+	if !project.IsFederationRepo(deps.Root) {
+		g.Results = append(g.Results, CheckResult{
+			Name: "target-repo-field", Status: Pass,
+			Message: "target-repo field not required — single topology",
+		})
+		return g
+	}
+
+	projectID := strings.TrimSpace(deps.ProjectID)
+	if projectID == "" {
+		g.Results = append(g.Results, CheckResult{
+			Name: "target-repo-field", Status: Warning,
+			Message: "target-repo field check skipped — AGENTIC_PROJECT_ID not configured",
+		})
+		return g
+	}
+	if deps.FetchProjectFields == nil {
+		g.Results = append(g.Results, CheckResult{
+			Name: "target-repo-field", Status: Warning,
+			Message: "target-repo field check skipped — no GraphQL client",
+		})
+		return g
+	}
+
+	fields, err := deps.FetchProjectFields(projectID)
+	if err != nil {
+		g.Results = append(g.Results, CheckResult{
+			Name: "target-repo-field", Status: Warning,
+			Message: "target-repo field check skipped — could not fetch fields: " + err.Error(),
+		})
+		return g
+	}
+
+	if _, ok := project.FindField(fields, project.TargetRepoFieldName); !ok {
+		g.Results = append(g.Results, CheckResult{
+			Name: "target-repo-field", Status: Fail,
+			Message:     fmt.Sprintf("project %q field is missing", project.TargetRepoFieldName),
+			Remediation: "run 'gh agentic repair'",
+		})
+		return g
+	}
+
+	g.Results = append(g.Results, CheckResult{
+		Name: "target-repo-field", Status: Pass,
+		Message: fmt.Sprintf("project %q field present", project.TargetRepoFieldName),
 	})
 	return g
 }

--- a/internal/doctor/repair.go
+++ b/internal/doctor/repair.go
@@ -365,6 +365,34 @@ func RepairPipeline(deps CheckDeps, setLabel func(string)) RepairResult {
 					result.Repaired++
 				}
 
+			case r.Name == "target-repo-field":
+				if setLabel != nil {
+					setLabel("Repairing: project target-repo field...")
+				}
+				if deps.FetchProjectFields == nil || deps.CreateProjectField == nil {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Cannot repair target-repo field — no GraphQL client available",
+							ui.StatusDanger.Render("✗")))
+					result.Unrepaired++
+					continue
+				}
+				if created, _, err := project.EnsureTargetRepoField(deps.ProjectID, deps.FetchProjectFields, deps.CreateProjectField); err != nil {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Could not create %q field: %v",
+							ui.StatusDanger.Render("✗"), project.TargetRepoFieldName, err))
+					result.Unrepaired++
+				} else if created {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Created project %q field",
+							ui.StatusOK.Render("✓"), project.TargetRepoFieldName))
+					result.Repaired++
+				} else {
+					result.Lines = append(result.Lines,
+						fmt.Sprintf("  %s  Project %q field already present",
+							ui.StatusOK.Render("✓"), project.TargetRepoFieldName))
+					result.Repaired++
+				}
+
 			case strings.HasPrefix(r.Name, "federation-sync:not-linked:"):
 				// Manifest repo not linked to the federation project — link it
 				// automatically using the repo node ID stored in r.Data at check time.

--- a/internal/project/api.go
+++ b/internal/project/api.go
@@ -108,6 +108,10 @@ type FetchProjectFieldsFunc func(projectID string) ([]ProjectField, error)
 // UpdateStatusFieldOptionsFunc replaces the options on a single-select field.
 type UpdateStatusFieldOptionsFunc func(fieldID string, options []StatusOption) error
 
+// CreateProjectFieldFunc creates a new field on a ProjectV2 and returns its
+// node ID. dataType is a ProjectV2CustomFieldType enum value (e.g. "TEXT").
+type CreateProjectFieldFunc func(projectID, name, dataType string) (fieldID string, err error)
+
 // --- Production implementations ---
 //
 // Pure topology-detection helpers (DetectTopology, ControlPlaneRepo)
@@ -520,6 +524,43 @@ func DefaultUpdateStatusFieldOptions(fieldID string, options []StatusOption) err
 		return fmt.Errorf("updating status field options: %w", err)
 	}
 	return nil
+}
+
+// graphqlCreateFieldResponse is the response shape for the createProjectV2Field mutation.
+type graphqlCreateFieldResponse struct {
+	CreateProjectV2Field struct {
+		ProjectV2Field struct {
+			ID string `json:"id"`
+		} `json:"projectV2Field"`
+	} `json:"createProjectV2Field"`
+}
+
+// DefaultCreateProjectField creates a new field on the given ProjectV2 and
+// returns its node ID. dataType is a ProjectV2CustomFieldType enum value such
+// as "TEXT" or "NUMBER".
+func DefaultCreateProjectField(projectID, name, dataType string) (string, error) {
+	client, err := api.DefaultGraphQLClient()
+	if err != nil {
+		return "", fmt.Errorf("creating GraphQL client: %w", err)
+	}
+
+	mutation := `mutation($projectId: ID!, $dataType: ProjectV2CustomFieldType!, $name: String!) {
+		createProjectV2Field(input: {projectId: $projectId, dataType: $dataType, name: $name}) {
+			projectV2Field {
+				... on ProjectV2Field { id }
+			}
+		}
+	}`
+
+	var resp graphqlCreateFieldResponse
+	if err := client.Do(mutation, map[string]interface{}{
+		"projectId": projectID,
+		"dataType":  dataType,
+		"name":      name,
+	}, &resp); err != nil {
+		return "", fmt.Errorf("creating project field %q: %w", name, err)
+	}
+	return resp.CreateProjectV2Field.ProjectV2Field.ID, nil
 }
 
 // graphqlProjectNumberResponse is the response shape for the project number query.

--- a/internal/project/create.go
+++ b/internal/project/create.go
@@ -194,6 +194,18 @@ func scaffoldProject(w io.Writer, deps Deps, projectID, ownerType string) {
 		}
 	}
 
+	// Ensure the "Target repo" field exists (#872) — control-plane Feature
+	// issues record their target domain repo here.
+	if deps.FetchProjectFields != nil && deps.CreateProjectField != nil {
+		if created, _, err := EnsureTargetRepoField(projectID, deps.FetchProjectFields, deps.CreateProjectField); err != nil {
+			fmt.Fprintf(w, "  %s  Could not ensure %q field: %v\n", ui.StatusWarning.Render("⚠"), TargetRepoFieldName, err)
+		} else if created {
+			fmt.Fprintf(w, "  %s  %q field created\n", ui.StatusOK.Render("✓"), TargetRepoFieldName)
+		} else {
+			fmt.Fprintf(w, "  %s  %q field present\n", ui.StatusOK.Render("✓"), TargetRepoFieldName)
+		}
+	}
+
 	// Create views via the REST API.
 	if len(tpl.Views) > 0 {
 		projectNumber, err := deps.FetchProjectNumber(projectID)

--- a/internal/project/deps.go
+++ b/internal/project/deps.go
@@ -36,6 +36,7 @@ type Deps struct {
 	UpdateProject            UpdateProjectFunc
 	FetchProjectFields       FetchProjectFieldsFunc
 	UpdateStatusFieldOptions UpdateStatusFieldOptionsFunc
+	CreateProjectField       CreateProjectFieldFunc
 	FetchProjectNumber       FetchProjectNumberFunc
 	CreateProjectView        CreateProjectViewFunc
 	FetchProjectViews        FetchProjectViewsFunc
@@ -71,6 +72,7 @@ func DefaultDeps(owner, repoName, root string) Deps {
 		UpdateProject:            DefaultUpdateProject,
 		FetchProjectFields:       DefaultFetchProjectFields,
 		UpdateStatusFieldOptions: DefaultUpdateStatusFieldOptions,
+		CreateProjectField:       DefaultCreateProjectField,
 		FetchProjectNumber:       DefaultFetchProjectNumber,
 		CreateProjectView:        DefaultCreateProjectView,
 		FetchProjectViews:        DefaultFetchProjectViews,

--- a/internal/project/fields.go
+++ b/internal/project/fields.go
@@ -1,0 +1,38 @@
+package project
+
+import "fmt"
+
+// TargetRepoFieldName is the name of the ProjectV2 TEXT field that records, on a
+// control-plane Feature issue, the domain repo the Feature targets. The owner is
+// always the control-plane owner; the field holds the bare repo name. (#872)
+const TargetRepoFieldName = "Target repo"
+
+// FindField returns the id of the field whose name matches (case-sensitive on
+// the ProjectV2 field name) and whether it was found.
+func FindField(fields []ProjectField, name string) (string, bool) {
+	for _, f := range fields {
+		if f.Name == name {
+			return f.ID, true
+		}
+	}
+	return "", false
+}
+
+// EnsureTargetRepoField ensures the project has a "Target repo" TEXT field,
+// creating it if absent. It returns whether it created the field and the field
+// id. The fetch/create functions are injected so the same logic serves project
+// creation (project.Deps) and doctor repair (doctor.CheckDeps).
+func EnsureTargetRepoField(projectID string, fetch FetchProjectFieldsFunc, create CreateProjectFieldFunc) (created bool, fieldID string, err error) {
+	fields, err := fetch(projectID)
+	if err != nil {
+		return false, "", fmt.Errorf("fetching project fields: %w", err)
+	}
+	if id, ok := FindField(fields, TargetRepoFieldName); ok {
+		return false, id, nil
+	}
+	id, err := create(projectID, TargetRepoFieldName, "TEXT")
+	if err != nil {
+		return false, "", fmt.Errorf("creating %q field: %w", TargetRepoFieldName, err)
+	}
+	return true, id, nil
+}

--- a/internal/project/fields_test.go
+++ b/internal/project/fields_test.go
@@ -1,0 +1,84 @@
+package project
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFindField(t *testing.T) {
+	fields := []ProjectField{
+		{ID: "f1", Name: "Status", DataType: "SINGLE_SELECT"},
+		{ID: "f2", Name: "Target repo", DataType: "TEXT"},
+	}
+	if id, ok := FindField(fields, "Target repo"); !ok || id != "f2" {
+		t.Errorf("FindField(Target repo) = (%q,%v), want (f2,true)", id, ok)
+	}
+	if _, ok := FindField(fields, "Domain"); ok {
+		t.Error("FindField(Domain): expected not found")
+	}
+}
+
+func TestEnsureTargetRepoField_AlreadyExists_NoCreate(t *testing.T) {
+	fetch := func(string) ([]ProjectField, error) {
+		return []ProjectField{{ID: "existing", Name: TargetRepoFieldName, DataType: "TEXT"}}, nil
+	}
+	createCalled := false
+	create := func(string, string, string) (string, error) {
+		createCalled = true
+		return "", errors.New("should not be called")
+	}
+
+	created, id, err := EnsureTargetRepoField("PVT_1", fetch, create)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created {
+		t.Error("expected created=false when the field already exists")
+	}
+	if id != "existing" {
+		t.Errorf("expected the existing field id, got %q", id)
+	}
+	if createCalled {
+		t.Error("create must not be called when the field exists")
+	}
+}
+
+func TestEnsureTargetRepoField_Absent_Creates(t *testing.T) {
+	fetch := func(string) ([]ProjectField, error) {
+		return []ProjectField{{ID: "f1", Name: "Status"}}, nil
+	}
+	var gotName, gotType string
+	create := func(_ string, name, dataType string) (string, error) {
+		gotName, gotType = name, dataType
+		return "new-field", nil
+	}
+
+	created, id, err := EnsureTargetRepoField("PVT_1", fetch, create)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !created || id != "new-field" {
+		t.Errorf("expected created=true id=new-field, got created=%v id=%q", created, id)
+	}
+	if gotName != TargetRepoFieldName || gotType != "TEXT" {
+		t.Errorf("create called with (%q,%q), want (%q,TEXT)", gotName, gotType, TargetRepoFieldName)
+	}
+}
+
+func TestEnsureTargetRepoField_FetchError_Propagates(t *testing.T) {
+	fetch := func(string) ([]ProjectField, error) { return nil, errors.New("boom") }
+	create := func(string, string, string) (string, error) { return "", nil }
+
+	if _, _, err := EnsureTargetRepoField("PVT_1", fetch, create); err == nil {
+		t.Fatal("expected fetch error to propagate")
+	}
+}
+
+func TestEnsureTargetRepoField_CreateError_Propagates(t *testing.T) {
+	fetch := func(string) ([]ProjectField, error) { return nil, nil }
+	create := func(string, string, string) (string, error) { return "", errors.New("denied") }
+
+	if _, _, err := EnsureTargetRepoField("PVT_1", fetch, create); err == nil {
+		t.Fatal("expected create error to propagate")
+	}
+}

--- a/internal/projectstatus/deps.go
+++ b/internal/projectstatus/deps.go
@@ -25,6 +25,7 @@ type ProjectIssue struct {
 	CreatedAt          time.Time
 	LastTransitionedAt time.Time
 	OwningRepo         string // "owner/name"
+	TargetRepo         string // "Target repo" ProjectV2 field value; "" when unset (#872)
 }
 
 // FetchProjectIssuesFunc returns all issues that appear on the ProjectV2

--- a/internal/projectstatus/queries.go
+++ b/internal/projectstatus/queries.go
@@ -172,6 +172,7 @@ func FetchFeatures(deps Deps, projectID string, includeDone bool) ([]Feature, er
 			CreatedAt:          issue.CreatedAt,
 			LastTransitionedAt: issue.LastTransitionedAt,
 			OwningRepo:         issue.OwningRepo,
+			TargetRepo:         issue.TargetRepo,
 		}
 		populateBlocked(deps, &f.Blocked, issue.OwningRepo, issue.Number, issue.Body)
 		populateTaskCounts(deps, &f)
@@ -237,6 +238,7 @@ func FetchFeature(deps Deps, projectID string, number int) (*Feature, error) {
 		CreatedAt:          found.CreatedAt,
 		LastTransitionedAt: found.LastTransitionedAt,
 		OwningRepo:         found.OwningRepo,
+		TargetRepo:         found.TargetRepo,
 	}
 	populateBlocked(deps, &feature.Blocked, found.OwningRepo, found.Number, found.Body)
 

--- a/internal/projectstatus/queries_default.go
+++ b/internal/projectstatus/queries_default.go
@@ -35,9 +35,12 @@ type graphqlProjectItemsResponse struct {
 				EndCursor   string `json:"endCursor"`
 			} `json:"pageInfo"`
 			Nodes []struct {
-				FieldValueByName struct {
+				Status struct {
 					Name string `json:"name"`
-				} `json:"fieldValueByName"`
+				} `json:"status"`
+				TargetRepo struct {
+					Text string `json:"text"`
+				} `json:"targetRepo"`
 				Content struct {
 					TypeName   string    `json:"__typename"`
 					Number     int       `json:"number"`
@@ -77,8 +80,11 @@ func DefaultFetchProjectIssues(projectID string) ([]ProjectIssue, error) {
 				items(first: 100, after: $after) {
 					pageInfo { hasNextPage endCursor }
 					nodes {
-						fieldValueByName(name: "Status") {
+						status: fieldValueByName(name: "Status") {
 							... on ProjectV2ItemFieldSingleSelectValue { name }
+						}
+						targetRepo: fieldValueByName(name: "Target repo") {
+							... on ProjectV2ItemFieldTextValue { text }
 						}
 						content {
 							__typename
@@ -121,13 +127,14 @@ func DefaultFetchProjectIssues(projectID string) ([]ProjectIssue, error) {
 				Number:             n.Content.Number,
 				Title:              n.Content.Title,
 				Body:               n.Content.Body,
-				Stage:              ParseStage(n.FieldValueByName.Name),
+				Stage:              ParseStage(n.Status.Name),
 				Type:               classifyIssueType(labelNames),
 				State:              strings.ToLower(n.Content.State),
 				Labels:             labelNames,
 				CreatedAt:          n.Content.CreatedAt,
 				LastTransitionedAt: n.Content.UpdatedAt,
 				OwningRepo:         n.Content.Repository.NameWithOwner,
+				TargetRepo:         n.TargetRepo.Text,
 			})
 		}
 

--- a/internal/projectstatus/types.go
+++ b/internal/projectstatus/types.go
@@ -108,6 +108,7 @@ type Feature struct {
 	CreatedAt          time.Time           `json:"created_at"`
 	LastTransitionedAt time.Time           `json:"last_transitioned_at"`
 	OwningRepo         string              `json:"owning_repo"`
+	TargetRepo         string              `json:"target_repo"`
 	Blocked            *BlockedInfo        `json:"blocked"`
 	ParentRequirement  *RequirementSummary `json:"parent_requirement"`
 	Tasks              []TaskRef           `json:"tasks"`

--- a/skills/requirement-scoping/SKILL.md
+++ b/skills/requirement-scoping/SKILL.md
@@ -40,7 +40,7 @@ transitioned to `ready-to-implement`. Headless Feature Design will pick up
 each triggered Feature.
 
 **B. Some Features held.** Some Features triggered, others held at
-`backlog` (cross-repo dependency awaiting upstream PR, or deliberate
+`backlog` (target-repo dependency awaiting an upstream PR, or deliberate
 hold by human). Requirement transitioned to `ready-to-implement`.
 
 **C. All Features held.** Features created but none triggered (all
@@ -580,11 +580,13 @@ artefact 9 is per-Feature.
 **Per-Feature header threading (only when `<federation>` is held).**
 Once artefact 3 has assigned a `<target-repo>` to each Feature, every
 per-Feature artefact gate (4–8) for that Feature MUST show the target
-repo in its header, so the human always sees where the Feature they
-are shaping will be created — e.g. `Artefact 4 — <Feature name>
-(→ owner/repo)`. The same `(→ owner/repo)` annotation appears in the
-step-17 creation render. When `<federation>` is unset, headers carry
-no repo annotation (single-repo flow, unchanged).
+repo in its header, so the human always sees which implementation repo
+the Feature they are shaping will target — e.g. `Artefact 4 —
+<Feature name> (targets <target-repo>)`. The same `(targets …)`
+annotation appears in the step-17 creation render. The Feature itself
+is always created in `<active-repo>` (the control plane); the target
+is recorded in its "Target repo" field. When `<federation>` is unset,
+headers carry no repo annotation (single-repo flow, unchanged).
 
 **Each artefact follows the same gate pattern.** The agent proposes
 content, surfaces it to the human, and invokes `prompt-user`:
@@ -670,34 +672,37 @@ prompt-user(
     - **Cancel** → revert to backlog, raise `USER_CANCELLED`, exit.
 
     **One-repo rule and target-repo assignment (only when
-    `<federation>` is held).** In a federation requirements repo,
-    every Feature must land in exactly one implementation repo —
-    requirements live with domain knowledge, features live with
-    code. Two sub-rules apply at this checkpoint, BEFORE any
-    per-Feature artefact (4–8) runs:
+    `<federation>` is held).** In a federation, the control plane is
+    where Features live: **every Feature is created in the
+    control-plane repo (`<active-repo>`)** and records the single
+    implementation repo it targets via the "Target repo" ProjectV2
+    field. The target repo is data on a control-plane issue, not the
+    repo the issue is created in. Two sub-rules apply at this
+    checkpoint, BEFORE any per-Feature artefact (4–8) runs:
 
     1. **One-repo rule (split).** A Feature whose work spans two
        repos must be split into one Feature per repo, each
-       describing what it does in that repo. When the human names a
-       Feature (or the single-Feature framing) that clearly straddles
-       two manifest repos, surface the split and propose the
-       per-repo Features:
+       describing what it does in that repo and carrying its own
+       target. When the human names a Feature (or the single-Feature
+       framing) that clearly straddles two manifest repos, surface
+       the split and propose the per-repo Features:
        ```
        Feature "<name>" spans <repo-A> and <repo-B>. A Feature must
-       fit one repo, so I'll split it into:
-         - <name> (<repo-A>): <what it does there>
-         - <name> (<repo-B>): <what it does there>
+       target one repo, so I'll split it into:
+         - <name> (→ <repo-A>): <what it does there>
+         - <name> (→ <repo-B>): <what it does there>
        ```
        Confirm the split with the human before proceeding. The split
        Features then each walk artefacts 4–8 independently.
 
-    2. **Target-repo assignment (propose / confirm / override).**
-       For each Feature (after any split), propose a target repo
-       drawn from `<federation>.repos`, citing the manifest purpose
-       that justifies it, then let the human confirm or override:
+    2. **Target-repo assignment (propose / confirm / override /
+       validate).** For each Feature (after any split), propose a
+       target repo drawn from `<federation>.repos`, citing the
+       manifest purpose that justifies it, then let the human confirm
+       or override:
        ```
        prompt-user(
-         question: "Which repo should Feature \"<name>\" land in? I propose <owner/repo> — <manifest purpose>.",
+         question: "Which repo should Feature \"<name>\" target? I propose <owner/repo> — <manifest purpose>.",
          header: "Target repo — <name>",
          options: [
            {label: "<owner/repo> (proposed)",
@@ -712,13 +717,19 @@ prompt-user(
        candidate list as plain conversation (one `owner/repo —
        purpose` per line) and ask the human to reply with the target,
        per the >4-option convention used elsewhere in this skill.
-       Capture the confirmed target as `<target-repo>` for that
-       Feature and hold it through the rest of the walk.
+       The chosen target MUST be one of `<federation>.repos` — if the
+       human supplies a repo not in the manifest, reject it and
+       re-prompt ("only manifest repos are valid targets"). Capture
+       the confirmed target's **bare repo name** (the part after `/`;
+       the owner is always the control-plane owner) as `<target-repo>`
+       for that Feature and hold it through the rest of the walk.
+       `<target-repo>` is the value written to the "Target repo" field
+       at creation (step 18b) — it is NOT the creation repo.
 
     When `<federation>` is unset (single topology), neither sub-rule
-    applies: there is no target-repo question, every Feature's
-    `<target-repo>` is implicitly `<active-repo>`, and the per-Feature
-    headers below carry no repo annotation.
+    applies: there is no target-repo question, no "Target repo" field
+    is set, every Feature is created in `<active-repo>` as today, and
+    the per-Feature headers below carry no repo annotation.
 
 11. **Artefact 4 — Feature definition + User Story (per-Feature).**
     A short paragraph describing what the Feature delivers, plus a
@@ -914,10 +925,12 @@ prompt-user(
     Here is Feature <name> as it would be filed:
     ```
 
-    When `<federation>` is held, the preface MUST name the target
-    repo so placement is explicit before the point of no return:
+    When `<federation>` is held, the preface names the target repo
+    the Feature will carry — the issue itself is filed in the
+    control-plane repo `<active-repo>`, and `<target-repo>` is recorded
+    in its "Target repo" field:
     ```
-    Here is Feature <name> (→ <target-repo>) as it would be filed:
+    Here is Feature <name> (targets <target-repo>) as it would be filed in <active-repo>:
     ```
 
     The body shape is:
@@ -965,35 +978,14 @@ prompt-user(
     Part of #<parent-N> (when multiple Features share the parent)
     ```
 
-    **Pre-flight label check (only when `<federation>` is held).**
-    Before the point-of-no-return confirmation, verify that every
-    distinct `<target-repo>` across the Features about to be created
-    carries the labels issue creation needs. For each distinct target
-    repo, query its labels once:
-
-    ```bash
-    gh label list --repo "<target-repo>" --json name --jq '[.[].name]'
-    ```
-
-    The required set is `feature` and `backlog`, plus
-    `needs-interactive-design` for any Feature targeting that repo
-    whose artefact 7 answer was "Yes". If any required label is
-    missing in any target repo, ABORT before creating a single issue
-    — a cross-repo partial is worse than a same-repo one because
-    cleanup spans repos. Surface:
-
-    ```
-    Cannot create Features — missing pipeline labels:
-      - <target-repo-X>: missing <label>, <label>
-      - <target-repo-Y>: missing <label>
-    Run `gh agentic repair` in each repo above, then re-run scoping.
-    No Feature issues were created.
-    ```
-
-    Raise `ISSUE_CREATION_FAILED` (`ERROR`) and exit. When
-    `<federation>` is unset, the single target is `<active-repo>`;
-    `gh agentic check` already guarantees its labels, so this
-    pre-flight is a no-op (skip it — conditional-step carve-out).
+    **Pre-flight label check.** All Features are created in
+    `<active-repo>` (the control plane), in every topology —
+    federation Features are filed on the control plane and carry their
+    target in a field, not by being created elsewhere. `gh agentic
+    check` already guarantees the control plane carries the `feature`,
+    `backlog`, and `needs-interactive-design` labels, so no per-repo
+    label pre-flight is needed (conditional-step carve-out — there is
+    no second repo to check).
 
     Then surface the **point-of-no-return warning** to the human as
     plain conversation BEFORE the prompt-user call (see "State model
@@ -1034,13 +1026,16 @@ prompt-user(
     Write the Feature body from step 17 to a temporary file using
     the agent's `Write` tool — never via shell `echo` or heredoc, as
     user-supplied content may contain shell metacharacters (backticks,
-    dollar signs, quotes) that would corrupt the file. Then invoke,
-    creating the Feature in its own `<target-repo>` (which is
-    `<active-repo>` when `<federation>` is unset):
+    dollar signs, quotes) that would corrupt the file. Then create the
+    Feature in `<active-repo>` — the control-plane repo — **regardless
+    of topology**. Features always live on the control plane; in a
+    federation the target implementation repo is recorded in the
+    "Target repo" field (step 18b), not by creating the issue
+    elsewhere:
 
     ```bash
     gh issue create \
-      --repo "<target-repo>" \
+      --repo "<active-repo>" \
       --title "<Feature title>" \
       --label "<labels>" \
       --body-file <path-to-temp-file>
@@ -1048,7 +1043,7 @@ prompt-user(
 
     Capture the resulting issue number `<F>` and URL from the
     command's stdout. The output is the full URL
-    (`https://github.com/<target-repo>/issues/<F>`); parse `<F>`
+    (`https://github.com/<active-repo>/issues/<F>`); parse `<F>`
     from the trailing path segment.
 
     **Feature title rule.** ≤70 characters. Noun-phrase summary of
@@ -1058,37 +1053,33 @@ prompt-user(
     title fits, ask the human directly rather than truncating.
 
     **Verification gate.** After each create, query the issue back
-    in the repo it was created in:
+    in `<active-repo>`:
 
     ```bash
-    gh issue view <F> --repo "<target-repo>" --json number,labels --jq '{n:.number, labels:[.labels[].name]}'
+    gh issue view <F> --repo "<active-repo>" --json number,labels --jq '{n:.number, labels:[.labels[].name]}'
     ```
 
     Verify the issue exists with the expected labels. If missing
     or inconsistent, raise `ISSUE_CREATION_FAILED` (`ERROR`).
-    (`gh agentic status feature <F>` aggregates across the
-    federation and also works, but a direct `--repo` query is the
-    unambiguous per-repo check.)
 
     **Partial-creation handling.** If Feature K of N fails (Features
     1..K-1 already exist on GitHub), STOP — do not continue creating
-    Features K+1..N, and DO NOT proceed to step 19, 20, or beyond.
-    Per "State model & cancel semantics", T1→T2 partial leaves the
-    framework in a state the skill cannot auto-recover from. Name the
-    repo each Feature landed in (or failed in), since in a federation
-    they differ:
+    Features K+1..N, and DO NOT proceed to step 18a, 19, 20, or
+    beyond. Per "State model & cancel semantics", T1→T2 partial
+    leaves the framework in a state the skill cannot auto-recover
+    from. All Features are in `<active-repo>`:
 
     ```
-    Partial Feature creation:
-      - #<F1> (<target-repo>) created successfully (labels: ...)
+    Partial Feature creation (all in <active-repo>):
+      - #<F1> created successfully (labels: ...)
       - ...
-      - Feature K "<title>" (<target-repo>) failed: <gh stderr>
+      - Feature K "<title>" failed: <gh stderr>
       - Features K+1..N not attempted
 
     The Requirement remains at Scoping. The successfully-created
     Features are valid pipeline artefacts; the failed one needs
     investigation. Recommended:
-      - Run `gh agentic repair` in <target-repo> for the failed Feature
+      - Run `gh agentic repair` for the control-plane project
       - Re-invoke requirement-scoping; the orphan re-entry flow will
         detect the existing Features and surface them. From there,
         either close them and start over, or complete the work
@@ -1098,26 +1089,56 @@ prompt-user(
     Exit with `ISSUE_CREATION_FAILED`.
 
 18a. **Add each Feature to the GitHub Project.** For each created
-    Feature `<F>`, add it to the project board so it appears in
-    pipeline / kanban views. The project ID lives in
-    `AGENTIC_PROJECT_ID`; the project number is the trailing
-    integer of the project URL. There is one project for the whole
-    federation, and it accepts items from any same-owner repo, so
-    the add uses the Feature's `<target-repo>` issue URL — NOT
-    `<active-repo>`:
+    Feature `<F>`, add it to the project board (so it appears in
+    pipeline / kanban views AND so its "Target repo" field can be set
+    in step 18b). The project ID lives in `AGENTIC_PROJECT_ID`; the
+    project number is the trailing integer of the project URL. The
+    Feature lives in `<active-repo>`, so the add uses the
+    `<active-repo>` issue URL. Capture the returned **item id** for
+    step 18b:
 
     ```bash
     gh project item-add <project-number> \
-      --owner "${target_repo%/*}" \
-      --url "https://github.com/<target-repo>/issues/<F>"
+      --owner "${active_repo%/*}" \
+      --url "https://github.com/<active-repo>/issues/<F>" \
+      --format json --jq '.id'
     ```
 
-    On failure → surface as `WARN`; do NOT block scoping. The
+    On failure → surface as `WARN`; do NOT block scoping (but note
+    step 18b cannot run without the item id — re-run via
+    `gh agentic repair` to add the item, then set the field). The
     Feature exists on GitHub and is wired as a sub-issue; missing
     project membership is a presentational gap that the pipeline
     workflow's `add-issue-to-project.yml` will repair on the next
-    label change. Surface the failed adds in the exit block so
-    the human knows.
+    label change. Surface the failed adds in the exit block.
+
+18b. **Set the "Target repo" field (only when `<federation>` is
+    held).** Record the target implementation repo on the
+    control-plane Feature by setting its "Target repo" ProjectV2 text
+    field to `<target-repo>` (the bare repo name from artefact 3).
+    Resolve the field id once, then update the item captured in 18a:
+
+    ```bash
+    # Resolve the "Target repo" field id once (reuse across Features):
+    FIELD_ID=$(gh api graphql -f query='query($p:ID!){node(id:$p){... on ProjectV2{fields(first:50){nodes{... on ProjectV2FieldCommon{id name}}}}}}' \
+      -F p="$AGENTIC_PROJECT_ID" \
+      --jq '.data.node.fields.nodes[] | select(.name=="Target repo") | .id')
+
+    gh api graphql -f query='
+      mutation($p:ID!, $i:ID!, $f:ID!, $v:String!) {
+        updateProjectV2ItemFieldValue(input:{
+          projectId:$p, itemId:$i, fieldId:$f, value:{text:$v}
+        }) { projectV2Item { id } }
+      }' \
+      -F p="$AGENTIC_PROJECT_ID" \
+      -F i="<item-id from 18a>" \
+      -F f="$FIELD_ID" \
+      -F v="<target-repo>"
+    ```
+
+    If `FIELD_ID` is empty, the project is missing the "Target repo"
+    field — run `gh agentic repair` (which provisions it) and re-try.
+    When `<federation>` is unset, skip this step entirely (no target).
 
 19. **Wire sub-issue relationships.** For each created Feature,
     establish the Feature → parent Requirement link via GitHub's
@@ -1141,18 +1162,17 @@ prompt-user(
       -F num="<requirement-N>" \
       --jq '.data.repository.issue.id')
 
-    # Per Feature, resolve the child node ID then link. The child
-    # lives in its <target-repo>, which may differ from the parent's
-    # repo in a federation — resolve owner/name from <target-repo>,
-    # NOT <active-repo>:
+    # Per Feature, resolve the child node ID then link. The Feature
+    # lives in <active-repo> — the same repo as the parent
+    # Requirement — so this is a same-repo sub-issue link:
     CHILD_NODE_ID=$(gh api graphql -f query='
       query($owner:String!, $name:String!, $num:Int!) {
         repository(owner:$owner, name:$name) {
           issue(number:$num) { id }
         }
       }' \
-      -F owner="${target_repo%/*}" \
-      -F name="${target_repo#*/}" \
+      -F owner="${active_repo%/*}" \
+      -F name="${active_repo#*/}" \
       -F num="<F>" \
       --jq '.data.repository.issue.id')
 
@@ -1166,16 +1186,13 @@ prompt-user(
       -F child="$CHILD_NODE_ID"
     ```
 
-    **Same-owner precondition.** GitHub's sub-issue mechanism links
-    issues only within a single owner (org or user). Every
-    `<target-repo>` in `<federation>` shares the requirements repo's
-    owner — `gh agentic check` (#827) enforces this — so cross-repo
-    sub-issue links resolve. If `addSubIssue` fails with an
-    owner-mismatch error (a manifest listing a foreign-owner repo,
-    which check should have rejected), propagate
-    `ISSUE_CREATION_FAILED` and point the human at `gh agentic check`:
-    a multi-owner federation is out of scope and cannot be wired this
-    way.
+    **Same-repo link.** Both the Requirement and the Feature live in
+    `<active-repo>` (the control plane), so the sub-issue link is
+    always within a single repo — there is no cross-repo or
+    cross-owner concern (this reverses the cross-repo sub-issue
+    placement of #825; the target implementation repo is now carried
+    by the "Target repo" field set in step 18b, not by where the
+    issue lives).
 
     On any other failure (node-ID lookup or the mutation itself),
     propagate `ISSUE_CREATION_FAILED`. The Feature body's
@@ -1232,14 +1249,12 @@ prompt-user(
     decision rule.
 
     ```
-    trigger-design(issue=<F>, repo=<target-repo>)
+    trigger-design(issue=<F>, repo=<active-repo>)
     ```
 
-    Pass `repo=<target-repo>` so the trigger lands on the Feature in
-    the repo it was created in. When `<federation>` is unset,
-    `<target-repo>` equals `<active-repo>` and this is the same as
-    omitting `repo`. `trigger-design` already accepts the optional
-    `repo` argument for cross-repo callers — do not reimplement its
+    The Feature lives in `<active-repo>` (the control plane) in every
+    topology, so the trigger always targets `<active-repo>` — the same
+    as omitting `repo`. Do not reimplement `trigger-design`'s
     label-choice logic here.
 
     The primitive returns `{ trigger_label, status, triggered: true }`
@@ -1290,10 +1305,9 @@ prompt-user(
     Raise `STATUS_TRANSITION_FAILED`.
 
 22. **Annotate held Features.** For each non-triggered Feature,
-    post a comment via `post-issue-comment`, targeting the repo the
-    Feature lives in (`post-issue-comment(repo=<target-repo>,
-    issue=<F>, body=…)`) — in a federation the held Feature may not
-    be in `<active-repo>`:
+    post a comment via `post-issue-comment(repo=<active-repo>,
+    issue=<F>, body=…)` — held Features, like all Features, live in
+    the control-plane repo:
 
     ```
     Held at backlog — not triggered during scoping.
@@ -1303,7 +1317,7 @@ prompt-user(
     presence) and run set-issue-status to In Design when ready.
     ```
 
-    The reason is one of: `cross-repo dependency (awaiting upstream
+    The reason is one of: `target-repo dependency (awaiting an upstream
     PR)`, or `deliberate hold by human`. (Features flagged
     `needs-interactive-design` are no longer auto-held; they're
     triggered to `interactive-design` when selected.)
@@ -1325,19 +1339,20 @@ prompt-user(
 24. **Emit the exit block** matching the actual outcome. All
     variants conform to the same Produced / Blocked / Next shape.
 
-    **Repo annotation (only when `<federation>` is held).** Each
-    created Feature is rendered as `#<F> (owner/repo)` so the session
-    record shows where every Feature landed across the federation.
-    When `<federation>` is unset, the `(owner/repo)` suffix is
-    omitted (all Features are in `<active-repo>`).
+    **Target annotation (only when `<federation>` is held).** Each
+    created Feature is rendered as `#<F> (targets <repo>)` so the
+    session record shows which implementation repo each Feature
+    targets. All Features live in `<active-repo>` (the control plane);
+    the annotation reports the "Target repo" field value. When
+    `<federation>` is unset, the `(targets …)` suffix is omitted.
 
     **Output A — All Features triggered:**
     ```
     === Requirement Scoping Session — Completed ===
 
     Produced:
-      - Feature #<F1> (owner/repo-a) created (triggered for design)
-      - Feature #<F2> (owner/repo-b) created (triggered for design)
+      - Feature #<F1> (targets repo-a) created (triggered for design)
+      - Feature #<F2> (targets repo-b) created (triggered for design)
       - Requirement #<N> transitioned: scoping → ready-to-implement
 
     Blocked: none
@@ -1351,8 +1366,8 @@ prompt-user(
     === Requirement Scoping Session — Completed ===
 
     Produced:
-      - Feature #<F1> (owner/repo-a) created (triggered for design)
-      - Feature #<F2> (owner/repo-b) created (held at backlog — cross-repo dep)
+      - Feature #<F1> (targets repo-a) created (triggered for design)
+      - Feature #<F2> (targets repo-b) created (held at backlog — target awaiting upstream PR)
       - Requirement #<N> transitioned: scoping → ready-to-implement
 
     Blocked: #<F2> — upstream PR
@@ -1366,8 +1381,8 @@ prompt-user(
     === Requirement Scoping Session — Completed ===
 
     Produced:
-      - Feature #<F1> (owner/repo-a) created (held at backlog — cross-repo dep)
-      - Feature #<F2> (owner/repo-b) created (held at backlog — deliberate hold)
+      - Feature #<F1> (targets repo-a) created (held at backlog — target awaiting upstream PR)
+      - Feature #<F2> (targets repo-b) created (held at backlog — deliberate hold)
       - Requirement #<N> transitioned: scoping → ready-to-implement
 
     Blocked: #<F1> — upstream PR; #<F2> — human chose to hold


### PR DESCRIPTION
## Summary

Implements **Feature #872** — the keystone of #870. Feature issues now live on the
**control plane** with their target implementation repo recorded in a structured
ProjectV2 field, reversing the #825 cross-repo sub-issue placement (domain repos are
pure code with no pipeline to fire).

## What changed

**T1 — `Target repo` field provisioning** (`internal/project`, `internal/doctor`)
- `CreateProjectField` (`createProjectV2Field` TEXT mutation) + `CreateProjectFieldFunc` + Deps wiring.
- `fields.go`: pure `FindField` / `EnsureTargetRepoField` helpers (fetch-then-create-if-absent).
- CP `create` ensures the field; `doctor` gains a `project-target-repo-field` check (skips for single topology, repairable for a federation CP) and repair.

**T2 — projectstatus reads the field** (`internal/projectstatus`, `internal/cli`)
- The project-items query reads the "Target repo" value (aliased `fieldValueByName`), carried through `ProjectIssue` → `Feature.TargetRepo`.
- `gh agentic status feature --raw` emits a `target_repo` line; an unset target renders `(unset)` — never assumed (AC-2).

**T3 — `requirement-scoping` rewrite** (`skills/`, `concepts/`)
- Federated scoping creates Features in the control-plane repo, wired as **same-repo** sub-issues, with the "Target repo" field set (validated against `FEDERATION.md`, reject + re-prompt off-manifest). Reverses #825.
- `concepts/knowledge-plane.md` updated to the CP-resident model + documents the CP-event triggering contract for #873.

## Testing

- `go build ./...` and `go test ./...` pass.
- **AC-2** (status reports missing target) is covered by Go unit tests.
- **AC-1 / AC-3** are `requirement-scoping` agent behaviours — to be validated
  interactively against the OpenBSS control plane (its `FEDERATION.md` must first be
  migrated to the domain-grouped schema from #871). Flagged as a follow-up.

## Tasks

Closes #883, closes #884, closes #885.

Closes #872

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)
