### PR TITLE
feat: Pure-code domain repos with register-only join and code-only checks

### DIFF
--- a/internal/cli/project.go
+++ b/internal/cli/project.go
@@ -306,37 +306,23 @@ func resolveProjectID(deps project.Deps, arg string) (string, error) {
 	return "", fmt.Errorf("no project named %q found for %s", arg, deps.Owner)
 }
 
-// newProjectJoinCmd constructs the `gh agentic project join` subcommand.
+// newProjectJoinCmd constructs the `gh agentic project join` subcommand. Run on
+// the control plane, it registers a domain repo (pure code — no framework mount).
 func newProjectJoinCmd() *cobra.Command {
-	var list, interactive bool
+	var domain, purpose, domainPurpose string
 
 	cmd := &cobra.Command{
-		Use:   "join [project-name]",
-		Short: "Join an existing project as a domain repo",
-		Long: `Bring this repo into an existing project as a domain repo.
+		Use:   "join <owner/repo>",
+		Short: "Register a domain repo with this control plane (no framework mount)",
+		Long: `Register a domain repository with this federated control plane.
 
-For interactive first-time setup, prefer 'project init' — it guides you through
-topology selection and runs this step automatically.
-
-Use this command directly when scripting or re-joining after an unlink. The
-project name is matched case-insensitively; quote names that contain spaces.`,
-		Example: `  # List available projects
-  gh agentic project join --list
-
-  # Interactive — select from the list
-  gh agentic project join --interactive
-
-  # Direct — provide the project name (quote names with spaces)
-  gh agentic project join "My Agentic Project"`,
-		Args: cobra.MaximumNArgs(1),
+Run on the control plane. Adds <owner/repo> to the domain-grouped FEDERATION.md
+under --domain (creating the domain if it does not exist yet), links the repo to
+the GitHub Project, and sets AGENTIC_PROJECT_ID on the target repo. The domain
+repo is pure code — no framework is mounted into it.`,
+		Example: `  gh agentic project join acme/billing-svc --domain billing --purpose "Bill runs"`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// No flags and no args — show help.
-			if !list && !interactive && len(args) == 0 {
-				return cmd.Help()
-			}
-
-			// Refuse on the framework source. Joining another project
-			// would overwrite the framework's own AGENTIC_PROJECT_ID.
 			root, rerr := os.Getwd()
 			if rerr != nil {
 				return fmt.Errorf("resolving working directory: %w", rerr)
@@ -344,101 +330,66 @@ project name is matched case-insensitively; quote names that contain spaces.`,
 			if err := refuseIfFrameworkSource(cmd, root, "project join"); err != nil {
 				return err
 			}
+			if strings.TrimSpace(domain) == "" {
+				return fmt.Errorf("--domain is required (the domain the repo belongs to)")
+			}
+			parts := strings.SplitN(args[0], "/", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				return fmt.Errorf("expected <owner/repo>, got %q", args[0])
+			}
+			targetOwner, targetRepo := parts[0], parts[1]
 
 			deps, err := resolveProjectDeps()
 			if err != nil {
 				return err
 			}
-
-			// --list: print available projects and exit.
-			if list {
-				return printAvailableProjects(cmd, deps)
+			ctx, err := project.Resolve(deps)
+			if err != nil {
+				return err
+			}
+			if ctx == nil || ctx.ProjectID == "" {
+				return fmt.Errorf("this repo is not a control plane (no agentic project) — run 'gh agentic project create' first")
 			}
 
-			projectID := ""
-			if len(args) == 1 {
-				projectID, err = resolveProjectID(deps, args[0])
+			// A new domain needs a purpose collected before JoinDomain creates it.
+			newDomain := true
+			if fed, ferr := project.ReadFederation(deps.Root); ferr == nil {
+				newDomain = !fed.HasDomain(domain)
+			}
+			if strings.TrimSpace(purpose) == "" {
+				purpose, err = promptText(fmt.Sprintf("Purpose of %s within the federation", args[0]))
 				if err != nil {
 					return err
 				}
-			} else {
-				// --interactive: show pre-guard warning then project picker.
-				preGuard, err := project.EvalPreJoinWarning(deps)
+			}
+			if newDomain && strings.TrimSpace(domainPurpose) == "" {
+				domainPurpose, err = promptText(fmt.Sprintf("Purpose of the new domain %q", domain))
 				if err != nil {
-					return fmt.Errorf("pre-join check: %w", err)
-				}
-				switch preGuard.Guard {
-				case project.JoinGuardBlocked:
-					return fmt.Errorf("%s", preGuard.Message)
-				case project.JoinGuardWarnConfirm:
-					fmt.Fprintf(cmd.OutOrStdout(), "  %s  %s\n\n", ui.StatusWarning.Render("⚠"), preGuard.Message)
-					ok, err := deps.Confirm("Proceed?")
-					if err != nil {
-						return fmt.Errorf("confirmation failed: %w", err)
-					}
-					if !ok {
-						return fmt.Errorf("aborted by user")
-					}
-				}
-
-				ownerType, err := deps.DetectOwnerType(deps.Owner)
-				if err != nil {
-					ownerType = "User"
-				}
-
-				var projects []project.ProjectInfo
-				var fetchErr error
-				_ = ui.RunWithSpinner(cmd.OutOrStdout(), "Fetching agentic projects...", func() error {
-					projects, fetchErr = deps.FetchProjectsForOwner(deps.Owner, ownerType)
-					return fetchErr
-				})
-				if fetchErr != nil {
-					return fmt.Errorf("fetching projects: %w", fetchErr)
-				}
-				if len(projects) == 0 {
-					return fmt.Errorf("no projects found for %s", deps.Owner)
-				}
-
-				currentID := currentProjectID(deps)
-
-				var options []huh.Option[string]
-				for _, p := range projects {
-					label := p.Title
-					if p.ID == currentID {
-						label += " (current)"
-					}
-					options = append(options, huh.NewOption(label, p.ID))
-				}
-
-				form := huh.NewForm(
-					huh.NewGroup(
-						huh.NewSelect[string]().
-							Title("Select project").
-							Description("GitHub ProjectV2 to affiliate this repository with").
-							Options(options...).
-							Value(&projectID),
-					),
-				)
-				if err := form.Run(); err != nil {
-					return fmt.Errorf("form error: %w", err)
+					return err
 				}
 			}
 
-			if projectID == "" {
-				return fmt.Errorf("project name is required")
-			}
-
-			if len(args) == 1 {
-				return project.Join(cmd.OutOrStdout(), deps, projectID)
-			}
-			return project.JoinConfirmed(cmd.OutOrStdout(), deps, projectID)
+			return project.JoinDomain(cmd.OutOrStdout(), deps, ctx.ProjectID, targetOwner, targetRepo, domain, domainPurpose, purpose)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&list, "list", "l", false, "list available projects and exit")
-	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "select project interactively")
+	cmd.Flags().StringVar(&domain, "domain", "", "domain the repo belongs to (required)")
+	cmd.Flags().StringVar(&purpose, "purpose", "", "the repo's purpose within its domain")
+	cmd.Flags().StringVar(&domainPurpose, "domain-purpose", "", "purpose of the domain (used when creating a new domain)")
 
 	return cmd
+}
+
+// promptText runs a single huh text input and returns the trimmed, non-empty value.
+func promptText(title string) (string, error) {
+	var v string
+	if err := huh.NewForm(huh.NewGroup(huh.NewInput().Title(title).Value(&v))).Run(); err != nil {
+		return "", fmt.Errorf("input form: %w", err)
+	}
+	if strings.TrimSpace(v) == "" {
+		return "", fmt.Errorf("%q is required", title)
+	}
+	return v, nil
 }
 
 // printAvailableProjects fetches and prints the projects available to the owner.

--- a/internal/cli/project_test.go
+++ b/internal/cli/project_test.go
@@ -144,7 +144,7 @@ func TestProjectCmd_SubcommandsRegistered(t *testing.T) {
 
 	// project group now holds only lifecycle operations.
 	// init/check/repair/upgrade are top-level commands.
-	for _, want := range []string{"create [title]", "join [project-name]", "unlink", "switch [project-name]"} {
+	for _, want := range []string{"create [title]", "join <owner/repo>", "unlink", "switch [project-name]"} {
 		if !subs[want] {
 			t.Errorf("subcommand %q not registered under project", want)
 		}

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -235,6 +235,18 @@ func checksForTopologyWithLabels(deps CheckDeps) []checkGroupStep {
 		return base
 	}
 
+	// Feature #874: a pure-code domain repo carries AGENTIC_PROJECT_ID but no
+	// .agents mount and no FEDERATION.md — the control plane holds the framework.
+	// It runs only the minimal checks: it is registered code, not a framework
+	// consumer, so mount/content/label/workflow checks do not apply.
+	if isPureCodeDomainRepo(deps) {
+		return []checkGroupStep{
+			{"Identifying repo role...", checkDomainRepo},
+			{"Checking repository...", checkRepository},
+			{"Checking project reachability...", checkProjectReachability},
+		}
+	}
+
 	// Feature #824: topology is now binary (single / federation). All repos
 	// run the same set of checks regardless of topology variant.
 	base := []checkGroupStep{
@@ -270,6 +282,46 @@ func checksForTopologyWithLabels(deps CheckDeps) []checkGroupStep {
 		{"Checking legacy federation config...", checkLegacyFederationConfig},
 	}
 	return base
+}
+
+// checkDomainRepo reports that the current repo is a registered pure-code domain
+// (execution) repo (#874): it carries AGENTIC_PROJECT_ID but no .agents mount —
+// the framework is managed on the control plane, not here. This is the correct,
+// passing state for a domain repo; the mount / pipeline-infrastructure checks do
+// not apply because the domain repo is not under framework control.
+func checkDomainRepo(deps CheckDeps) Group {
+	g := Group{Name: "Domain repo"}
+	g.Results = append(g.Results, CheckResult{
+		Name:    "domain-repo",
+		Status:  Pass,
+		Message: "pure-code domain (execution) repo — the framework is managed on the control plane; this repo carries code only and is not under framework control here",
+	})
+	return g
+}
+
+// isPureCodeDomainRepo reports whether deps describes a registered pure-code
+// domain repo (#874): it carries AGENTIC_PROJECT_ID but has no .agents mount,
+// is not the framework source, and is not a federation requirements repo (no
+// FEDERATION.md). Such a repo is validated as code, not as a framework consumer.
+//
+// Detection is absence-based: a domain repo carrying a stale .agents from the
+// pre-pivot model is NOT distinguishable here from a single-topology repo, and
+// its cleanup is handled by the #876 migration where the control-plane context
+// is available.
+func isPureCodeDomainRepo(deps CheckDeps) bool {
+	if deps.FrameworkSource {
+		return false
+	}
+	if strings.TrimSpace(deps.ProjectID) == "" {
+		return false
+	}
+	if project.IsFederationRepo(deps.Root) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(deps.Root, ".agents")); err == nil {
+		return false
+	}
+	return true
 }
 
 // checksForTopology returns the ordered list of check functions for the given topology.

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1794,3 +1794,66 @@ func TestCheckFederationProjectSync_NotWiredForFrameworkSource(t *testing.T) {
 		}
 	}
 }
+
+// TestPureCodeDomainRepo_MinimalChecks verifies a registered pure-code domain
+// repo (AGENTIC_PROJECT_ID + no .agents + no FEDERATION.md) runs only the
+// minimal check list and skips the framework-mount / labels / workflow checks
+// (#874).
+func TestPureCodeDomainRepo_MinimalChecks(t *testing.T) {
+	tmp := t.TempDir() // no .agents, no FEDERATION.md
+	deps := CheckDeps{Root: tmp, ProjectID: "PVT_domain"}
+
+	if !isPureCodeDomainRepo(deps) {
+		t.Fatal("expected a registered pure-code domain repo to be detected")
+	}
+	steps := checksForTopologyWithLabels(deps)
+
+	labels := map[string]bool{}
+	for _, s := range steps {
+		labels[s.label] = true
+	}
+	if !labels["Identifying repo role..."] {
+		t.Errorf("domain repo should emit the domain-role notice, got: %v", labels)
+	}
+	if !labels["Checking repository..."] || !labels["Checking project reachability..."] {
+		t.Errorf("domain repo should run repository + project reachability, got: %v", labels)
+	}
+	for _, skipped := range []string{"Checking framework mount...", "Checking pipeline labels...", "Checking workflows...", "Checking agent files..."} {
+		if labels[skipped] {
+			t.Errorf("domain repo should skip %q", skipped)
+		}
+	}
+}
+
+func TestIsPureCodeDomainRepo_NegativeCases(t *testing.T) {
+	withAgents := func() string {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, ".agents"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+	withManifest := func() string {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "FEDERATION.md"), []byte("domains: []\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+	cases := []struct {
+		name string
+		deps CheckDeps
+	}{
+		{"no project id", CheckDeps{Root: t.TempDir()}},
+		{"framework source", CheckDeps{Root: t.TempDir(), ProjectID: "P", FrameworkSource: true}},
+		{"has .agents (single/CP)", CheckDeps{Root: withAgents(), ProjectID: "P"}},
+		{"has FEDERATION.md (CP)", CheckDeps{Root: withManifest(), ProjectID: "P"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if isPureCodeDomainRepo(c.deps) {
+				t.Errorf("%s must not be classified as a pure-code domain repo", c.name)
+			}
+		})
+	}
+}

--- a/internal/project/federation.go
+++ b/internal/project/federation.go
@@ -111,48 +111,111 @@ func ReadFederation(root string) (*Federation, error) {
 		return nil, fmt.Errorf("FEDERATION.md: domains list is empty")
 	}
 
+	if err := validateFederation(&fed); err != nil {
+		return nil, err
+	}
+	return &fed, nil
+}
+
+// validateFederation applies the domain-grouped manifest rules. It is shared by
+// ReadFederation (after parsing) and WriteFederation (before writing) so a
+// malformed in-memory Federation never reaches disk.
+func validateFederation(fed *Federation) error {
+	if len(fed.Domains) == 0 {
+		return fmt.Errorf("FEDERATION.md: domains list is empty")
+	}
 	seenRepo := make(map[string]bool)
 	seenDomain := make(map[string]bool)
 	for di, d := range fed.Domains {
 		domainNo := di + 1
 		if d.Name == "" {
-			return nil, fmt.Errorf("FEDERATION.md: domain %d: name is required", domainNo)
+			return fmt.Errorf("FEDERATION.md: domain %d: name is required", domainNo)
 		}
 		if !domainNamePattern.MatchString(d.Name) {
-			return nil, fmt.Errorf("FEDERATION.md: domain %q: name must be a lowercase slug ([a-z0-9-])", d.Name)
+			return fmt.Errorf("FEDERATION.md: domain %q: name must be a lowercase slug ([a-z0-9-])", d.Name)
 		}
 		if strings.TrimSpace(d.Purpose) == "" {
-			return nil, fmt.Errorf("FEDERATION.md: domain %q: purpose is required", d.Name)
+			return fmt.Errorf("FEDERATION.md: domain %q: purpose is required", d.Name)
 		}
 		domainKey := strings.ToLower(d.Name)
 		if seenDomain[domainKey] {
-			return nil, fmt.Errorf("FEDERATION.md: duplicate domain %q", d.Name)
+			return fmt.Errorf("FEDERATION.md: duplicate domain %q", d.Name)
 		}
 		seenDomain[domainKey] = true
 
 		if len(d.Repos) == 0 {
-			return nil, fmt.Errorf("FEDERATION.md: domain %q: repos list is empty", d.Name)
+			return fmt.Errorf("FEDERATION.md: domain %q: repos list is empty", d.Name)
 		}
 		for ri, repo := range d.Repos {
 			repoNo := ri + 1
 			if repo.Name == "" {
-				return nil, fmt.Errorf("FEDERATION.md: domain %q: repo %d: name is required", d.Name, repoNo)
+				return fmt.Errorf("FEDERATION.md: domain %q: repo %d: name is required", d.Name, repoNo)
 			}
 			if strings.TrimSpace(repo.Purpose) == "" {
-				return nil, fmt.Errorf("FEDERATION.md: domain %q: repo %q: purpose is required", d.Name, repo.Name)
+				return fmt.Errorf("FEDERATION.md: domain %q: repo %q: purpose is required", d.Name, repo.Name)
 			}
 			if !isValidOwnerRepo(repo.Name) {
-				return nil, fmt.Errorf("FEDERATION.md: domain %q: repo %q: name must be in owner/repo format", d.Name, repo.Name)
+				return fmt.Errorf("FEDERATION.md: domain %q: repo %q: name must be in owner/repo format", d.Name, repo.Name)
 			}
 			repoKey := strings.ToLower(repo.Name)
 			if seenRepo[repoKey] {
-				return nil, fmt.Errorf("FEDERATION.md: duplicate repo %q", repo.Name)
+				return fmt.Errorf("FEDERATION.md: duplicate repo %q", repo.Name)
 			}
 			seenRepo[repoKey] = true
 		}
 	}
+	return nil
+}
 
-	return &fed, nil
+// HasDomain reports whether a domain with the given name (case-insensitive)
+// already exists in the manifest.
+func (f *Federation) HasDomain(name string) bool {
+	for _, d := range f.Domains {
+		if strings.EqualFold(d.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// AddRepo registers repoName under the named domain, lazy-creating the domain
+// (with domainPurpose) when it does not yet exist. It returns whether a new
+// domain was created. It errors when repoName is already registered in any
+// domain — a repo belongs to exactly one domain.
+func (f *Federation) AddRepo(domain, domainPurpose, repoName, repoPurpose string) (createdDomain bool, err error) {
+	for _, d := range f.Domains {
+		for _, r := range d.Repos {
+			if strings.EqualFold(r.Name, repoName) {
+				return false, fmt.Errorf("repo %q is already registered in domain %q", repoName, d.Name)
+			}
+		}
+	}
+	repo := FederationRepo{Name: repoName, Purpose: repoPurpose}
+	for i := range f.Domains {
+		if strings.EqualFold(f.Domains[i].Name, domain) {
+			f.Domains[i].Repos = append(f.Domains[i].Repos, repo)
+			return false, nil
+		}
+	}
+	f.Domains = append(f.Domains, FederationDomain{Name: domain, Purpose: domainPurpose, Repos: []FederationRepo{repo}})
+	return true, nil
+}
+
+// WriteFederation writes the domain-grouped manifest to FEDERATION.md at root,
+// round-tripping the schema ReadFederation parses. The manifest is validated
+// before writing so a malformed in-memory Federation never reaches disk.
+func WriteFederation(root string, fed *Federation) error {
+	if err := validateFederation(fed); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(fed)
+	if err != nil {
+		return fmt.Errorf("FEDERATION.md: marshalling: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, federationFileName), data, 0644); err != nil {
+		return fmt.Errorf("FEDERATION.md: %w", err)
+	}
+	return nil
 }
 
 // isValidOwnerRepo returns true when name is in "owner/repo" format with

--- a/internal/project/federation_test.go
+++ b/internal/project/federation_test.go
@@ -332,3 +332,78 @@ func TestReadFederation_FileNotFound_ReturnsError(t *testing.T) {
 		t.Fatal("expected an error when FEDERATION.md is absent, got nil")
 	}
 }
+
+func TestWriteFederation_RoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, validManifest)
+	fed, err := ReadFederation(dir)
+	if err != nil {
+		t.Fatalf("ReadFederation: %v", err)
+	}
+
+	created, err := fed.AddRepo("billing", "Invoice generation", "owner/billing-statements", "Statements")
+	if err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if created {
+		t.Error("expected createdDomain=false for an existing domain")
+	}
+	if err := WriteFederation(dir, fed); err != nil {
+		t.Fatalf("WriteFederation: %v", err)
+	}
+
+	reread, err := ReadFederation(dir)
+	if err != nil {
+		t.Fatalf("re-ReadFederation: %v", err)
+	}
+	if len(reread.AllRepos()) != 4 {
+		t.Fatalf("expected 4 repos after round-trip, got %d", len(reread.AllRepos()))
+	}
+	var found bool
+	for _, r := range reread.AllRepos() {
+		if r.Name == "owner/billing-statements" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the added repo did not survive the write/read round-trip")
+	}
+}
+
+func TestWriteFederation_RejectsInvalid(t *testing.T) {
+	dir := t.TempDir()
+	fed := &Federation{Domains: []FederationDomain{{Name: "charging", Purpose: "p", Repos: nil}}}
+	if err := WriteFederation(dir, fed); err == nil {
+		t.Fatal("expected WriteFederation to reject an invalid manifest")
+	}
+	if IsFederationRepo(dir) {
+		t.Error("an invalid manifest must not be written to disk")
+	}
+}
+
+func TestFederation_AddRepo_LazyCreatesDomain(t *testing.T) {
+	fed := &Federation{}
+	created, err := fed.AddRepo("billing", "Invoicing", "acme/billing", "Bill runs")
+	if err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if !created {
+		t.Error("expected createdDomain=true for a new domain")
+	}
+	if !fed.HasDomain("Billing") {
+		t.Error("HasDomain should match case-insensitively")
+	}
+	if len(fed.Domains) != 1 || len(fed.Domains[0].Repos) != 1 {
+		t.Fatalf("expected 1 domain with 1 repo, got %d domains", len(fed.Domains))
+	}
+}
+
+func TestFederation_AddRepo_RejectsDuplicate(t *testing.T) {
+	fed := &Federation{}
+	if _, err := fed.AddRepo("charging", "C", "acme/svc", "p"); err != nil {
+		t.Fatalf("first AddRepo: %v", err)
+	}
+	if _, err := fed.AddRepo("billing", "B", "Acme/SVC", "p"); err == nil {
+		t.Fatal("expected a duplicate-repo error (case-insensitive) across domains")
+	}
+}

--- a/internal/project/join.go
+++ b/internal/project/join.go
@@ -1,96 +1,61 @@
 package project
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
-	"github.com/eddiecarpenter/gh-agentic/internal/mount"
 	"github.com/eddiecarpenter/gh-agentic/internal/ui"
 )
 
-// Join affiliates this repository with an existing project as a domain repo.
-// It evaluates the guard, handles warnings and confirmation, then calls joinWork.
-func Join(w io.Writer, deps Deps, projectID string) error {
-	guard, err := EvalJoinGuard(deps, projectID)
+// JoinDomain registers a domain repo with the control-plane project. Run on the
+// control plane, it adds targetOwner/targetRepo to FEDERATION.md under the named
+// domain (lazy-creating the domain with domainPurpose when it does not yet
+// exist), links the repo to the Project, and sets AGENTIC_PROJECT_ID on the
+// target repo. It does NOT mount the framework — domain repos are pure code.
+func JoinDomain(w io.Writer, deps Deps, projectID, targetOwner, targetRepo, domain, domainPurpose, repoPurpose string) error {
+	ownerRepo := targetOwner + "/" + targetRepo
+
+	// Read the manifest, or start an empty one when the control plane has no
+	// FEDERATION.md yet (the first join bootstraps it).
+	fed, err := ReadFederation(deps.Root)
 	if err != nil {
-		return fmt.Errorf("evaluating join guard: %w", err)
-	}
-
-	switch guard.Guard {
-	case JoinGuardBlocked:
-		return fmt.Errorf("blocked: %s", guard.Message)
-
-	case JoinGuardSameProject:
-		fmt.Fprintf(w, "  %s  %s\n\n", ui.StatusOK.Render("✓"), guard.Message)
-		return nil
-
-	case JoinGuardWarnConfirm:
-		fmt.Fprintf(w, "  %s  %s\n", ui.StatusWarning.Render("⚠"), guard.Message)
-		ok, err := deps.Confirm("Proceed?")
-		if err != nil {
-			return fmt.Errorf("confirmation failed: %w", err)
-		}
-		if !ok {
-			return fmt.Errorf("aborted by user")
-		}
-	}
-	// JoinGuardClear falls through here.
-	return joinWork(w, deps, projectID)
-}
-
-// JoinConfirmed affiliates this repository with a project, skipping the guard evaluation.
-// Use this when the caller has already evaluated and confirmed any warnings (e.g. the
-// interactive CLI path that shows the warning before a project selection UI).
-func JoinConfirmed(w io.Writer, deps Deps, projectID string) error {
-	// Still handle the same-project case — no-op if already affiliated.
-	currentID, _ := deps.GetRepoVariable(deps.Owner, deps.RepoName, ProjectVarName)
-	if currentID == projectID {
-		name := ProjectDisplayName(deps, projectID)
-		fmt.Fprintf(w, "  %s  this repo is already part of agentic project %s\n\n", ui.StatusOK.Render("✓"), name)
-		return nil
-	}
-	return joinWork(w, deps, projectID)
-}
-
-// joinWork performs the actual join steps: setting the variable and mounting the framework.
-func joinWork(w io.Writer, deps Deps, projectID string) error {
-	// Resolve project name for display (best-effort — fall back to ID on error).
-	projectName := ProjectDisplayName(deps, projectID)
-
-	// Set AGENTIC_PROJECT_ID.
-	fmt.Fprintf(w, "  Setting %s...\n", ProjectVarName)
-	if err := deps.SetRepoVariable(deps.Owner, deps.RepoName, ProjectVarName, projectID); err != nil {
-		return fmt.Errorf("setting %s: %w", ProjectVarName, err)
-	}
-	fmt.Fprintf(w, "  %s  %s set\n", ui.StatusOK.Render("✓"), ProjectVarName)
-
-	// Mount framework if not already present.
-	aiDir := filepath.Join(deps.Root, ".agents")
-	if _, err := os.Stat(aiDir); os.IsNotExist(err) {
-		releases, err := deps.FetchReleases(mount.FrameworkRepo)
-		if err != nil {
-			return fmt.Errorf("fetching framework releases: %w", err)
-		}
-		if len(releases) == 0 {
-			return fmt.Errorf("no framework releases found")
-		}
-		latest := releases[0].TagName
-		fmt.Fprintf(w, "  Mounting framework %s...\n", latest)
-		if err := mount.DownloadFramework(deps.Root, latest, deps.Clone); err != nil {
-			return fmt.Errorf("mounting framework: %w", err)
-		}
-		fmt.Fprintf(w, "  %s  Framework mounted at %s\n", ui.StatusOK.Render("✓"), latest)
-	} else {
-		version, _ := deps.ReadAIVersion(deps.Root)
-		if version != "" {
-			fmt.Fprintf(w, "  %s  Framework already mounted at %s\n", ui.StatusOK.Render("✓"), version)
+		if errors.Is(err, os.ErrNotExist) {
+			fed = &Federation{}
+		} else {
+			return err
 		}
 	}
 
-	fmt.Fprintln(w, "")
-	fmt.Fprintf(w, "  %s\n\n", ui.StatusOK.Render("Joined project \""+projectName+"\""))
+	created, err := fed.AddRepo(domain, domainPurpose, ownerRepo, repoPurpose)
+	if err != nil {
+		return err
+	}
+	if err := WriteFederation(deps.Root, fed); err != nil {
+		return err
+	}
+	if created {
+		fmt.Fprintf(w, "  %s  Created domain %q\n", ui.StatusOK.Render("✓"), domain)
+	}
+	fmt.Fprintf(w, "  %s  Registered %s under domain %q in FEDERATION.md\n", ui.StatusOK.Render("✓"), ownerRepo, domain)
+
+	// Link the target repo to the federation Project.
+	_, repoID, err := deps.FetchOwnerAndRepoIDs(targetOwner, targetRepo)
+	if err != nil {
+		return fmt.Errorf("resolving %s node IDs: %w", ownerRepo, err)
+	}
+	if err := deps.LinkRepoToProject(projectID, repoID); err != nil {
+		return fmt.Errorf("linking %s to the project: %w", ownerRepo, err)
+	}
+	fmt.Fprintf(w, "  %s  Linked %s to the project\n", ui.StatusOK.Render("✓"), ownerRepo)
+
+	// Register the repo by setting AGENTIC_PROJECT_ID on the target domain repo.
+	// No framework mount — domain repos are pure code.
+	if err := deps.SetRepoVariable(targetOwner, targetRepo, ProjectVarName, projectID); err != nil {
+		return fmt.Errorf("setting %s on %s: %w", ProjectVarName, ownerRepo, err)
+	}
+	fmt.Fprintf(w, "  %s  Set %s on %s — no framework mounted (domain repos are pure code)\n", ui.StatusOK.Render("✓"), ProjectVarName, ownerRepo)
 	return nil
 }
 

--- a/internal/project/join_test.go
+++ b/internal/project/join_test.go
@@ -9,171 +9,69 @@ import (
 	"testing"
 )
 
-// --- Join ---
+// --- JoinDomain ---
 
-func TestJoin_Clear_SetsVariable(t *testing.T) {
+func TestJoinDomain_RegistersRepo_NoMount(t *testing.T) {
 	tmp := t.TempDir()
-	withFakeInstall(t)
-
-	var setVar string
-	deps := testDeps("owner", "repo")
+	deps := testDeps("cp-owner", "cp")
 	deps.Root = tmp
-	deps.GetRepoVariable = func(o, r, n string) (string, error) {
-		return "", errors.New("not set")
-	}
+	var setOwner, setRepo, setVal string
 	deps.SetRepoVariable = func(o, r, n, v string) error {
 		if n == ProjectVarName {
-			setVar = v
+			setOwner, setRepo, setVal = o, r, v
 		}
 		return nil
 	}
-	deps.Clone = func(repoURL, tag, destDir string) error { return nil }
-
-	var buf bytes.Buffer
-	if err := Join(&buf, deps, "PVT_target"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	deps.FetchOwnerAndRepoIDs = func(o, r string) (string, string, error) {
+		return "ownerID", "repoID-" + r, nil
 	}
-
-	if setVar != "PVT_target" {
-		t.Errorf("expected AGENTIC_PROJECT_ID set to PVT_target, got %q", setVar)
-	}
-
-	// .agents/ should now exist via the install stub.
-	if _, err := os.Stat(filepath.Join(tmp, ".agents", "RULEBOOK.md")); err != nil {
-		t.Errorf("expected .agents/RULEBOOK.md to exist after install: %v", err)
-	}
-}
-
-func TestJoin_SameProject_NoOp(t *testing.T) {
-	deps := testDeps("owner", "repo")
-	deps.GetRepoVariable = func(o, r, n string) (string, error) {
-		return "PVT_same", nil
-	}
-
-	var setCalled bool
-	deps.SetRepoVariable = func(o, r, n, v string) error {
-		setCalled = true
+	var linkedRepoID string
+	deps.LinkRepoToProject = func(projectID, repoID string) error {
+		linkedRepoID = repoID
 		return nil
 	}
 
 	var buf bytes.Buffer
-	if err := Join(&buf, deps, "PVT_same"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err := JoinDomain(&buf, deps, "PVT_cp", "cp-owner", "billing-svc", "billing", "Billing domain", "Bill runs"); err != nil {
+		t.Fatalf("JoinDomain: %v", err)
 	}
-	if setCalled {
-		t.Error("expected SetRepoVariable NOT to be called for same project")
+
+	fed, err := ReadFederation(tmp)
+	if err != nil {
+		t.Fatalf("ReadFederation after join: %v", err)
+	}
+	if !fed.HasDomain("billing") {
+		t.Error("expected the billing domain to be created")
+	}
+	all := fed.AllRepos()
+	if len(all) != 1 || all[0].Name != "cp-owner/billing-svc" {
+		t.Errorf("expected cp-owner/billing-svc registered, got %+v", all)
+	}
+	if setOwner != "cp-owner" || setRepo != "billing-svc" || setVal != "PVT_cp" {
+		t.Errorf("expected AGENTIC_PROJECT_ID=PVT_cp on cp-owner/billing-svc, got %s/%s=%s", setOwner, setRepo, setVal)
+	}
+	if linkedRepoID != "repoID-billing-svc" {
+		t.Errorf("expected the target repo linked to the project, got %q", linkedRepoID)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".agents")); !os.IsNotExist(err) {
+		t.Error("JoinDomain must not mount the framework into the control-plane working dir")
 	}
 }
 
-func TestJoin_WarnConfirm_Confirmed(t *testing.T) {
+func TestJoinDomain_RejectsDuplicateRepo(t *testing.T) {
 	tmp := t.TempDir()
-	withFakeInstall(t)
-
-	deps := testDeps("owner", "repo")
+	deps := testDeps("cp-owner", "cp")
 	deps.Root = tmp
-	deps.GetRepoVariable = func(o, r, n string) (string, error) {
-		return "PVT_old", nil
-	}
-	// Federated → WarnConfirm.
-	deps.FetchLinkedRepos = func(projectID string) ([]LinkedRepo, error) {
-		return []LinkedRepo{{Name: "other", NameWithOwner: "owner/other"}}, nil
-	}
-	deps.Confirm = func(prompt string) (bool, error) { return true, nil }
-
-	var setVar string
-	deps.SetRepoVariable = func(o, r, n, v string) error {
-		setVar = v
-		return nil
-	}
-	deps.Clone = func(repoURL, tag, destDir string) error { return nil }
-
-	var buf bytes.Buffer
-	if err := Join(&buf, deps, "PVT_new"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if setVar != "PVT_new" {
-		t.Errorf("expected AGENTIC_PROJECT_ID set to PVT_new, got %q", setVar)
-	}
-}
-
-func TestJoin_WarnConfirm_Denied(t *testing.T) {
-	deps := testDeps("owner", "repo")
-	deps.GetRepoVariable = func(o, r, n string) (string, error) {
-		return "PVT_old", nil
-	}
-	deps.FetchLinkedRepos = func(projectID string) ([]LinkedRepo, error) {
-		return []LinkedRepo{{Name: "other", NameWithOwner: "owner/other"}}, nil
-	}
-	deps.Confirm = func(prompt string) (bool, error) { return false, nil }
-
-	var buf bytes.Buffer
-	err := Join(&buf, deps, "PVT_new")
-	if err == nil {
-		t.Fatal("expected error when user denies confirmation")
-	}
-	if !strings.Contains(err.Error(), "aborted") {
-		t.Errorf("expected 'aborted' in error, got: %v", err)
-	}
-}
-
-func TestJoin_Blocked(t *testing.T) {
-	tmp := t.TempDir()
-	docsDir := tmp + "/docs"
-	if err := os.MkdirAll(docsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(docsDir+"/readme.md", []byte("content"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	deps := testDeps("owner", "repo")
-	deps.Root = tmp
-	deps.GetRepoVariable = func(o, r, n string) (string, error) {
-		return "PVT_old", nil
-	}
-	// Single topology + docs content → Blocked.
-	deps.FetchLinkedRepos = func(projectID string) ([]LinkedRepo, error) {
-		return []LinkedRepo{{Name: "repo", NameWithOwner: "owner/repo"}}, nil
-	}
-
-	var buf bytes.Buffer
-	err := Join(&buf, deps, "PVT_new")
-	if err == nil {
-		t.Fatal("expected error when join is blocked")
-	}
-	if !strings.Contains(err.Error(), "blocked") {
-		t.Errorf("expected 'blocked' in error, got: %v", err)
-	}
-}
-
-func TestJoin_FrameworkAlreadyMounted(t *testing.T) {
-	tmp := t.TempDir()
-	// Create .agents/ to simulate already mounted.
-	aiDir := tmp + "/.agents"
-	if err := os.MkdirAll(aiDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	deps := testDeps("owner", "repo")
-	deps.Root = tmp
-	deps.GetRepoVariable = func(o, r, n string) (string, error) {
-		return "", errors.New("not set")
-	}
 	deps.SetRepoVariable = func(o, r, n, v string) error { return nil }
-	deps.ReadAIVersion = func(root string) (string, error) { return "v2.0.10", nil }
-
-	var cloneCalled bool
-	deps.Clone = func(repoURL, tag, destDir string) error {
-		cloneCalled = true
-		return nil
-	}
+	deps.FetchOwnerAndRepoIDs = func(o, r string) (string, string, error) { return "o", "r", nil }
+	deps.LinkRepoToProject = func(p, r string) error { return nil }
 
 	var buf bytes.Buffer
-	if err := Join(&buf, deps, "PVT_target"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err := JoinDomain(&buf, deps, "PVT_cp", "cp-owner", "svc", "charging", "C", "p"); err != nil {
+		t.Fatalf("first JoinDomain: %v", err)
 	}
-	if cloneCalled {
-		t.Error("expected Clone NOT to be called when .agents/ already exists")
+	if err := JoinDomain(&buf, deps, "PVT_cp", "cp-owner", "svc", "billing", "B", "p"); err == nil {
+		t.Fatal("expected a duplicate-repo error on re-registering the same repo")
 	}
 }
 

--- a/internal/project/switch.go
+++ b/internal/project/switch.go
@@ -17,7 +17,17 @@ func SwitchProject(w io.Writer, deps Deps, newProjectID string) error {
 	if err != nil || currentID == "" {
 		return fmt.Errorf("this repo is not affiliated with a project — run 'gh agentic project init' first")
 	}
-	return JoinConfirmed(w, deps, newProjectID)
+	if currentID == newProjectID {
+		fmt.Fprintf(w, "  %s  this repo is already part of agentic project %s\n\n", ui.StatusOK.Render("✓"), ProjectDisplayName(deps, newProjectID))
+		return nil
+	}
+	// Re-point AGENTIC_PROJECT_ID. No framework mount — switching membership is
+	// metadata only (domain repos are pure code; the control plane carries the mount).
+	if err := deps.SetRepoVariable(deps.Owner, deps.RepoName, ProjectVarName, newProjectID); err != nil {
+		return fmt.Errorf("setting %s: %w", ProjectVarName, err)
+	}
+	fmt.Fprintf(w, "  %s  Moved to agentic project %s\n\n", ui.StatusOK.Render("✓"), ProjectDisplayName(deps, newProjectID))
+	return nil
 }
 
 // SwitchVersionPreflight holds the pre-resolved data from preflight checks,

--- a/skills/gh-agentic/SKILL.md
+++ b/skills/gh-agentic/SKILL.md
@@ -234,10 +234,12 @@ Subcommands and flags:
 - `gh agentic project create [title]`
   - `--version` — framework version to mount (default: latest).
   - `--interactive` (`-i`) — collect title + version via form.
-- `gh agentic project join [project-name]` — inline app-install check.
-  - `--list` (`-l`)
-  - `--interactive` (`-i`)
-  - `--skip-app-install`
+- `gh agentic project join <owner/repo>` — CP-side: register a domain repo with
+  this control plane (writes `FEDERATION.md`, links the Project, sets the target
+  repo's `AGENTIC_PROJECT_ID`; **no framework mount** — domain repos are pure code).
+  - `--domain` — domain the repo belongs to (required; lazy-created if new).
+  - `--purpose` — the repo's purpose within its domain.
+  - `--domain-purpose` — purpose of the domain (used when creating a new domain).
 - `gh agentic project switch [project-name]`
   - `--list` (`-l`)
   - `--interactive` (`-i`)
@@ -442,8 +444,9 @@ Bypass via `--skip-app-install`.
   idempotent. Run it whenever `check` reports failures.
 - **Always re-run `check` after `repair`** — confirm the repair
   succeeded.
-- **Do not run `project join` on an uninitialised repo** — run
-  `gh agentic init` first.
+- **Run `project join` on the control plane** — it registers a named domain
+  repo (`<owner/repo> --domain`) into the federation; it does not affect the
+  current repo or mount the framework.
 - **Use `--raw` for every programmatic read.** Never parse the
   human table.
 - **Use `--raw --verbose` only when timestamps are actually needed.**
@@ -451,7 +454,7 @@ Bypass via `--skip-app-install`.
 - **The `kanban` flag was removed.** Use `gh agentic status pipeline
   --requirements` or `--features`.
 - **The `--json` flag was removed end-to-end.** Use `--raw`.
-- **App install check is inline in `init` and `project join`.**
-  Neither blocks on the install flow. Scrape stdout for the install
-  URL prefix `https://github.com/apps/` or use `--skip-app-install`
-  when the install state is known-good out-of-band.
+- **App install check is inline in `init`.** It does not block on the
+  install flow. Scrape stdout for the install URL prefix
+  `https://github.com/apps/` or use `--skip-app-install` when the install
+  state is known-good out-of-band.


### PR DESCRIPTION
## Summary

Implements **Feature #874** — domain repos become **pure code**, registered from the
control plane with no framework mount. Part of #870.

## What changed

**Manifest helpers** (`internal/project/federation.go`)
- `WriteFederation` round-trips the #871 domain-grouped schema (validated before writing);
  `Federation.AddRepo` lazy-creates a domain and registers a repo (rejecting cross-domain
  duplicates); `Federation.HasDomain`. Validation extracted into a shared
  `validateFederation` used by both Read and Write.

**CP-side register-only `join`** (`internal/project/join.go`, `internal/cli/project.go`)
- `gh agentic project join <owner/repo> --domain <name>` now runs on the control plane:
  `project.JoinDomain` writes the repo into `FEDERATION.md` under the domain, links it to
  the Project, and sets `AGENTIC_PROJECT_ID` on the target repo — **no framework mount**.
- The old domain-side `Join`/`JoinConfirmed`/`joinWork` (which mounted) are removed;
  `project switch` re-points membership without mounting.

**Pure-code domain repo class in `doctor`** (`internal/doctor/checks.go`)
- Absence-based detection (`AGENTIC_PROJECT_ID` + no `.agents` + no `FEDERATION.md` + not
  framework source) selects a minimal check list — a domain-role notice plus repository and
  project-reachability — skipping all mount/label/workflow/manifest checks. `check` in a
  domain repo correctly reports it is a pure-code execution repo managed by the control
  plane.

## Scope note (AC-3 → #876)

Stale-`.agents` cleanup for migrated domain repos is **deferred to #876**: `FEDERATION.md`
is the authority for domain membership and is local on the control plane, so the
manifest-driven cleanup belongs to the CP-side migration, not a domain-side repair.

## Testing

`go build ./...` and `go test ./...` pass. Unit tests cover `WriteFederation` round-trip,
`AddRepo` lazy-create + dup-reject, `JoinDomain` (register + no mount), and the domain-repo
detection + minimal check list.

## Tasks

Closes #890, closes #891.

Closes #874

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)
