### PR TITLE
feat: Federated control-plane creation and domain registration flow

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -100,7 +100,7 @@ change membership, or --force to re-run setup from scratch.`,
 					Description("How will this repo be used?").
 					Options(
 						huh.NewOption("Single  — this repo is the control plane (one repo does everything)", "single"),
-						huh.NewOption("Federated  — this repo joins an existing federated project", "federated"),
+						huh.NewOption("Federated  — this repo is the control plane of a federated project", "federated"),
 					).
 					Value(&topology),
 			))
@@ -135,34 +135,9 @@ change membership, or --force to re-run setup from scratch.`,
 				return nil
 			}
 
-			// Federated path: list federated projects, user picks one.
-			fmt.Fprintf(w, "\n  Fetching federated projects for %s...\n\n", deps.Owner)
-			projects, err := project.ListFederatedProjects(deps)
-			if err != nil {
-				return fmt.Errorf("listing federated projects: %w", err)
-			}
-			if len(projects) == 0 {
-				return fmt.Errorf("no federated agentic projects found for %s — run 'gh agentic project create' on the control plane repo first", deps.Owner)
-			}
-
-			var projectID string
-			var options []huh.Option[string]
-			for _, p := range projects {
-				options = append(options, huh.NewOption(p.Title, p.ID))
-			}
-			projectForm := huh.NewForm(huh.NewGroup(
-				huh.NewSelect[string]().
-					Title("Select federated project").
-					Description("The federated project to join").
-					Options(options...).
-					Value(&projectID),
-			))
-			if err := projectForm.Run(); err != nil {
-				return fmt.Errorf("project selection: %w", err)
-			}
-
-			// Collect configuration — topology is federated (already captured),
-			// project ID comes from the list picker above (not a form field).
+			// Federated path: create a federated control plane (#875). Domain
+			// repos are registered from the control plane via
+			// 'gh agentic project join <owner/repo> --domain', not initialised here.
 			initCfg, err := initpkg.CollectConfigInteractive(w, deps.RepoFullName, initpkg.FormDeps{
 				RunForm:         initpkg.DefaultFormRun,
 				RunCommand:      auth.DefaultRunCommand,
@@ -175,9 +150,8 @@ change membership, or --force to re-run setup from scratch.`,
 			}
 
 			if err := project.InitRepo(w, deps, project.InitRepoConfig{
-				Mode:      project.InitModeFederated,
-				ProjectID: projectID,
-				InitCfg:   initCfg,
+				Mode:    project.InitModeFederated,
+				InitCfg: initCfg,
 			}); err != nil {
 				return err
 			}

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1003,8 +1003,13 @@ func checkFederationProjectSync(deps CheckDeps) Group {
 		}
 	}
 
-	// AC-2: project-linked repos absent from the manifest.
+	// AC-2: project-linked repos absent from the manifest. The control-plane repo
+	// itself is linked to its own Project but is legitimately not a domain repo,
+	// so it is excluded from the unlisted warning (#875).
 	for _, r := range linked {
+		if strings.EqualFold(r.NameWithOwner, deps.RepoFullName) {
+			continue
+		}
 		if !manifestSet[strings.ToLower(r.NameWithOwner)] {
 			g.Results = append(g.Results, CheckResult{
 				Name:    fmt.Sprintf("federation-sync:unlisted:%s", r.NameWithOwner),

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1856,3 +1856,50 @@ func TestIsPureCodeDomainRepo_NegativeCases(t *testing.T) {
 		})
 	}
 }
+
+// TestCheckFederationProjectSync_CPRepoNotFlaggedUnlisted verifies the #875
+// refinement: the control-plane repo itself, linked to its own Project but not a
+// domain repo, is not flagged `unlisted`.
+func TestCheckFederationProjectSync_CPRepoNotFlaggedUnlisted(t *testing.T) {
+	root := t.TempDir()
+	writeFederationManifest(t, root, "acme/domain")
+	deps := CheckDeps{
+		Root:                 root,
+		RepoFullName:         "acme/cp",
+		ProjectID:            "PVT_abc",
+		FetchLinkedRepos:     fakeFetchLinkedRepos("acme/domain", "acme/cp"),
+		FetchOwnerAndRepoIDs: fakeFetchOwnerAndRepoIDs("acme/domain"),
+	}
+
+	g := checkFederationProjectSync(deps)
+	for _, r := range g.Results {
+		if r.Name == "federation-sync:unlisted:acme/cp" {
+			t.Error("the control-plane repo must not be flagged unlisted against its own Project")
+		}
+	}
+}
+
+// TestCheckFederationProjectSync_DomainRepoUnlisted_Warns verifies AC-3: a
+// project-linked repo absent from FEDERATION.md is flagged as drift.
+func TestCheckFederationProjectSync_DomainRepoUnlisted_Warns(t *testing.T) {
+	root := t.TempDir()
+	writeFederationManifest(t, root, "acme/domain")
+	deps := CheckDeps{
+		Root:                 root,
+		RepoFullName:         "acme/cp",
+		ProjectID:            "PVT_abc",
+		FetchLinkedRepos:     fakeFetchLinkedRepos("acme/domain", "acme/extra"),
+		FetchOwnerAndRepoIDs: fakeFetchOwnerAndRepoIDs("acme/domain"),
+	}
+
+	g := checkFederationProjectSync(deps)
+	var found bool
+	for _, r := range g.Results {
+		if r.Name == "federation-sync:unlisted:acme/extra" && r.Status == Warning {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected acme/extra (linked, not in manifest) flagged unlisted, got: %+v", g.Results)
+	}
+}

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1296,7 +1296,10 @@ func TestCheckFederationManifest_MalformedYAML_Fail(t *testing.T) {
 	}
 }
 
-func TestCheckFederationManifest_EmptyDomainsList_Fail(t *testing.T) {
+// TestCheckFederationManifest_EmptyDomains_Pass verifies that a freshly-created
+// control plane's empty `domains:` manifest is valid (#875) — no domains
+// registered yet — and produces a single Pass result with no domain-docs warnings.
+func TestCheckFederationManifest_EmptyDomains_Pass(t *testing.T) {
 	root := t.TempDir()
 	_ = os.WriteFile(filepath.Join(root, "FEDERATION.md"), []byte("domains: []\n"), 0o644)
 	deps := CheckDeps{Root: root}
@@ -1304,14 +1307,10 @@ func TestCheckFederationManifest_EmptyDomainsList_Fail(t *testing.T) {
 	g := checkFederationManifest(deps)
 
 	if len(g.Results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(g.Results))
+		t.Fatalf("expected 1 result (manifest valid, no domains), got %d: %+v", len(g.Results), g.Results)
 	}
-	r := g.Results[0]
-	if r.Status != Fail {
-		t.Errorf("status: got %v, want Fail", r.Status)
-	}
-	if !strings.Contains(r.Message, "domains list is empty") {
-		t.Errorf("message: got %q, expected 'domains list is empty'", r.Message)
+	if g.Results[0].Status != Pass {
+		t.Errorf("status: got %v, want Pass for an empty-but-valid manifest; message: %q", g.Results[0].Status, g.Results[0].Message)
 	}
 }
 

--- a/internal/project/create.go
+++ b/internal/project/create.go
@@ -145,6 +145,15 @@ func Create(w io.Writer, deps Deps, cfg CreateConfig) error {
 	fmt.Fprintf(w, "  Scaffolding project from template...\n")
 	scaffoldProject(w, deps, projectID, ownerType)
 
+	// Step 9a (#875): a federated control plane scaffolds its FEDERATION.md
+	// (empty — no domains yet) and federated-tier system docs. Single topology
+	// has no federation manifest. Non-fatal: warn but do not abort.
+	if topology == TopologyStringFederation {
+		if err := ScaffoldFederation(w, deps.Root); err != nil {
+			fmt.Fprintf(w, "  %s  Could not scaffold federation files: %v\n", ui.StatusWarning.Render("⚠"), err)
+		}
+	}
+
 	fmt.Fprintln(w, "")
 	fmt.Fprintf(w, "  %s\n\n", ui.StatusOK.Render("Agentic project created and control plane configured"))
 	return nil

--- a/internal/project/federation.go
+++ b/internal/project/federation.go
@@ -102,13 +102,14 @@ func ReadFederation(root string) (*Federation, error) {
 	}
 
 	if len(fed.Domains) == 0 {
-		// Hard-cut: a flat `repos:` manifest is rejected with migration guidance
-		// rather than silently treated as empty.
+		// A flat `repos:` manifest is rejected with migration guidance; an empty
+		// `domains:` list is valid — a freshly-created control plane with no
+		// domains registered yet (domains are added later via `project join`).
 		var flat flatFederation
 		if yaml.Unmarshal(data, &flat) == nil && len(flat.Repos) > 0 {
 			return nil, fmt.Errorf("FEDERATION.md: flat `repos:` schema is no longer supported — group repos under `domains:`")
 		}
-		return nil, fmt.Errorf("FEDERATION.md: domains list is empty")
+		return &fed, nil
 	}
 
 	if err := validateFederation(&fed); err != nil {
@@ -121,9 +122,8 @@ func ReadFederation(root string) (*Federation, error) {
 // ReadFederation (after parsing) and WriteFederation (before writing) so a
 // malformed in-memory Federation never reaches disk.
 func validateFederation(fed *Federation) error {
-	if len(fed.Domains) == 0 {
-		return fmt.Errorf("FEDERATION.md: domains list is empty")
-	}
+	// An empty domains list is valid — a control plane with no domains registered
+	// yet. Per-domain/per-repo rules below only apply when domains are present.
 	seenRepo := make(map[string]bool)
 	seenDomain := make(map[string]bool)
 	for di, d := range fed.Domains {

--- a/internal/project/federation_test.go
+++ b/internal/project/federation_test.go
@@ -151,23 +151,36 @@ func TestReadFederation_MalformedYAML_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestReadFederation_EmptyDomainsList_ReturnsError(t *testing.T) {
+func TestReadFederation_EmptyDomainsList_Valid(t *testing.T) {
 	dir := t.TempDir()
 	writeManifest(t, dir, "domains: []\n")
 
-	_, err := ReadFederation(dir)
-	if err == nil || !strings.Contains(err.Error(), "domains list is empty") {
-		t.Fatalf("expected 'domains list is empty', got: %v", err)
+	fed, err := ReadFederation(dir)
+	if err != nil {
+		t.Fatalf("empty domains should be valid (CP with no domains yet), got: %v", err)
+	}
+	if len(fed.Domains) != 0 {
+		t.Errorf("expected 0 domains, got %d", len(fed.Domains))
 	}
 }
 
-func TestReadFederation_MissingDomainsKey_ReturnsError(t *testing.T) {
+func TestWriteFederation_AllowsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteFederation(dir, &Federation{}); err != nil {
+		t.Fatalf("expected WriteFederation to accept an empty manifest, got: %v", err)
+	}
+	fed, err := ReadFederation(dir)
+	if err != nil || len(fed.Domains) != 0 {
+		t.Fatalf("empty manifest round-trip failed: err=%v domains=%d", err, len(fed.Domains))
+	}
+}
+
+func TestReadFederation_MissingDomainsKey_Valid(t *testing.T) {
 	dir := t.TempDir()
 	writeManifest(t, dir, "something: else\n")
 
-	_, err := ReadFederation(dir)
-	if err == nil || !strings.Contains(err.Error(), "domains list is empty") {
-		t.Fatalf("expected 'domains list is empty', got: %v", err)
+	if _, err := ReadFederation(dir); err != nil {
+		t.Fatalf("a manifest with no domains key should be valid (empty), got: %v", err)
 	}
 }
 

--- a/internal/project/init.go
+++ b/internal/project/init.go
@@ -3,34 +3,31 @@ package project
 import (
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
-	"strings"
 
 	initpkg "github.com/eddiecarpenter/gh-agentic/internal/init"
-	"github.com/eddiecarpenter/gh-agentic/internal/mount"
 	"github.com/eddiecarpenter/gh-agentic/internal/ui"
 )
 
-// InitMode indicates whether the repo is being set up as a single control
-// plane or as a domain repo joining a federated project.
+// InitMode indicates whether the repo is being set up as a single-topology
+// control plane or as a federated control plane.
 type InitMode int
 
 const (
-	InitModeSingle    InitMode = iota // Create new project, set up as control plane.
-	InitModeFederated                 // Join existing federated project.
+	InitModeSingle    InitMode = iota // Create a single-topology control plane.
+	InitModeFederated                 // Create a federated control plane.
 )
 
 // InitRepoConfig holds the collected configuration for project init.
 type InitRepoConfig struct {
-	Mode      InitMode
-	ProjectID string              // Federated mode only — selected project.
-	InitCfg   *initpkg.InitConfig // Full wizard config.
+	Mode    InitMode
+	InitCfg *initpkg.InitConfig // Full wizard config.
 }
 
 // InitRepo performs first-time setup for a repo.
-// For single: creates project + mount + configure secrets/variables.
-// For federated: joins existing federated project + mount at CP version + configure.
+// For single: creates a single-topology project + mount + configure secrets/variables.
+// For federated: creates a federated control plane — project + an empty FEDERATION.md
+// + federated-tier system docs + mount. Domain repos are registered from the control
+// plane via 'gh agentic project join', not via init.
 func InitRepo(w io.Writer, deps Deps, cfg InitRepoConfig) error {
 	// Guard: must not already be affiliated.
 	existing, _ := deps.GetRepoVariable(deps.Owner, deps.RepoName, ProjectVarName)
@@ -55,7 +52,7 @@ func InitRepo(w io.Writer, deps Deps, cfg InitRepoConfig) error {
 	case InitModeSingle:
 		return initSingle(w, deps, cfg.InitCfg)
 	case InitModeFederated:
-		return initFederated(w, deps, cfg)
+		return initFederatedCP(w, deps, cfg.InitCfg)
 	default:
 		return fmt.Errorf("unknown init mode")
 	}
@@ -91,117 +88,31 @@ func initSingle(w io.Writer, deps Deps, cfg *initpkg.InitConfig) error {
 	return nil
 }
 
-// initFederated joins this repo to an existing federated project and configures it.
-func initFederated(w io.Writer, deps Deps, cfg InitRepoConfig) error {
-	fmt.Fprintln(w, "  Joining federated project...")
+// initFederatedCP creates a federated control plane: a project board, an empty
+// FEDERATION.md + federated-tier system docs (both scaffolded by Create), the
+// framework mount, and the standard agent / config files. Domain repos are
+// registered from the control plane via 'gh agentic project join', not via init.
+func initFederatedCP(w io.Writer, deps Deps, cfg *initpkg.InitConfig) error {
+	fmt.Fprintln(w, "  Creating federated control plane...")
 	fmt.Fprintln(w)
 
-	// Get the control plane version.
-	linked, err := deps.FetchLinkedRepos(cfg.ProjectID)
-	if err != nil {
-		return fmt.Errorf("fetching linked repos: %w", err)
+	createCfg := CreateConfig{
+		Title:    deps.RepoName,
+		Version:  cfg.Version,
+		Topology: TopologyStringFederation,
 	}
-	cp, ok := ControlPlaneRepo(linked)
-	if !ok {
-		return fmt.Errorf("no control plane found for this project")
-	}
-	parts := strings.SplitN(cp.NameWithOwner, "/", 2)
-	if len(parts) != 2 {
-		return fmt.Errorf("cannot parse control plane repo name: %s", cp.NameWithOwner)
-	}
-
-	cpVersion, err := deps.GetRepoVariable(parts[0], parts[1], FrameworkVersionVarName)
-	if err != nil || cpVersion == "" {
-		// Fall back to latest release.
-		releases, relErr := deps.FetchReleases(mount.FrameworkRepo)
-		if relErr != nil || len(releases) == 0 {
-			return fmt.Errorf("cannot determine framework version from control plane and no releases available")
-		}
-		cpVersion = releases[0].TagName
-		fmt.Fprintf(w, "  %s  Control plane version not set — using latest: %s\n", ui.StatusWarning.Render("⚠"), cpVersion)
-	} else {
-		fmt.Fprintf(w, "  %s  Control plane framework version: %s\n", ui.StatusOK.Render("✓"), cpVersion)
-	}
-
-	// Set AGENTIC_PROJECT_ID.
-	fmt.Fprintf(w, "  Setting %s...\n", ProjectVarName)
-	if err := deps.SetRepoVariable(deps.Owner, deps.RepoName, ProjectVarName, cfg.ProjectID); err != nil {
-		return fmt.Errorf("setting %s: %w", ProjectVarName, err)
-	}
-	fmt.Fprintf(w, "  %s  %s set\n", ui.StatusOK.Render("✓"), ProjectVarName)
-
-	// Mount the framework at the control plane version. The mounted version
-	// is tracked via .agents/.git metadata — no flat .ai-version file is
-	// written (removed by feature #571 / task #585).
-	aiDir := filepath.Join(deps.Root, ".agents")
-	freshMount := false
-	if _, err := os.Stat(aiDir); os.IsNotExist(err) {
-		fmt.Fprintf(w, "  Mounting framework %s...\n", cpVersion)
-		if err := mount.DownloadFramework(deps.Root, cpVersion, deps.Clone); err != nil {
-			return fmt.Errorf("mounting framework: %w", err)
-		}
-		fmt.Fprintf(w, "  %s  Framework mounted at %s\n", ui.StatusOK.Render("✓"), cpVersion)
-		freshMount = true
-	} else {
-		localVersion, _ := mount.ReadAIVersionFromGit(deps.Root)
-		if localVersion == "" {
-			localVersion = "(unknown)"
-		}
-		fmt.Fprintf(w, "  %s  Framework already mounted at %s\n", ui.StatusOK.Render("✓"), localVersion)
-	}
-
-	// Scaffold agent instruction files and wrapper workflows on fresh mounts.
-	// Skipped when the framework was already present to avoid clobbering edits.
-	if freshMount {
-		if err := mount.ScaffoldProjectFiles(w, deps.Root, cpVersion); err != nil {
-			return fmt.Errorf("scaffolding project files: %w", err)
-		}
-		if err := mount.ScaffoldLocalRules(w, deps.Root, deps.RepoName, deps.Owner, "federated"); err != nil {
-			return fmt.Errorf("scaffolding LOCALRULES.md: %w", err)
-		}
+	if err := Create(w, deps, createCfg); err != nil {
+		return fmt.Errorf("creating control plane: %w", err)
 	}
 
 	// Configure secrets, variables, and agent access.
-	if cfg.InitCfg != nil && cfg.InitCfg.RepoFullName != "" {
-		if err := initpkg.ConfigureRepo(w, cfg.InitCfg, deps.Run); err != nil {
+	if cfg != nil && cfg.RepoFullName != "" {
+		if err := initpkg.ConfigureRepo(w, cfg, deps.Run); err != nil {
 			return fmt.Errorf("configuring repo: %w", err)
 		}
 	}
 
 	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %s\n\n", ui.StatusOK.Render("Repository initialised as federated domain repo"))
+	fmt.Fprintf(w, "  %s\n\n", ui.StatusOK.Render("Repository initialised as federated control plane"))
 	return nil
-}
-
-// ListFederatedProjects returns only projects whose control plane has AGENTIC_TOPOLOGY=federated.
-func ListFederatedProjects(deps Deps) ([]ProjectInfo, error) {
-	ownerType, err := deps.DetectOwnerType(deps.Owner)
-	if err != nil {
-		ownerType = "User"
-	}
-	all, err := deps.FetchProjectsForOwner(deps.Owner, ownerType)
-	if err != nil {
-		return nil, fmt.Errorf("fetching projects: %w", err)
-	}
-
-	var federated []ProjectInfo
-	for _, p := range all {
-		linked, err := deps.FetchLinkedRepos(p.ID)
-		if err != nil {
-			continue
-		}
-		cp, ok := ControlPlaneRepo(linked)
-		if !ok {
-			continue
-		}
-		parts := strings.SplitN(cp.NameWithOwner, "/", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		topo, _ := deps.GetRepoVariable(parts[0], parts[1], TopologyVarName)
-		if topo == "federated" {
-			federated = append(federated, p)
-		}
-	}
-	return federated, nil
 }

--- a/internal/project/init_test.go
+++ b/internal/project/init_test.go
@@ -32,8 +32,7 @@ func TestInitRepo_FederatedUserOwner_RefusesWithVerbatimError(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := InitRepo(&buf, deps, InitRepoConfig{
-		Mode:      InitModeFederated,
-		ProjectID: "PVT_fed",
+		Mode: InitModeFederated,
 	})
 	if err == nil {
 		t.Fatal("expected error for federated init on user-owned repo")
@@ -86,42 +85,35 @@ func TestInitRepo_SingleUserOwner_DoesNotRefuse(t *testing.T) {
 	}
 }
 
-// TestInitRepo_FederatedOrgOwner_Proceeds baselines that federated init on
-// an org-owned repo is not accidentally refused.
-func TestInitRepo_FederatedOrgOwner_Proceeds(t *testing.T) {
+// TestInitRepo_FederatedOrgOwner_CreatesControlPlane verifies that federated
+// init on an org-owned repo creates a federated control plane (#875): the org
+// guard does not fire, and an empty FEDERATION.md is scaffolded.
+func TestInitRepo_FederatedOrgOwner_CreatesControlPlane(t *testing.T) {
+	withFakeInstall(t)
 	deps := testDeps("acme", "repo")
+	deps.Root = t.TempDir()
 	deps.GetRepoVariable = func(o, r, n string) (string, error) {
-		switch n {
-		case ProjectVarName:
-			return "", errors.New("not set") // not yet affiliated
-		case FrameworkVersionVarName:
-			return "v2.0.10", nil
-		}
-		return "", errors.New("unknown")
+		return "", errors.New("not set") // not yet affiliated
 	}
-	deps.FetchLinkedRepos = func(projectID string) ([]LinkedRepo, error) {
-		return []LinkedRepo{{Name: "cp", NameWithOwner: "acme/cp"}}, nil
-	}
-	deps.DetectOwnerType = func(owner string) (string, error) {
-		return "Organization", nil
-	}
-	// Allow the federated init to walk through without shelling out.
+	deps.FetchProjectsForRepo = func(o, r string) ([]ProjectInfo, error) { return nil, nil }
+	deps.DetectOwnerType = func(owner string) (string, error) { return "Organization", nil }
+	deps.FetchOwnerAndRepoIDs = func(owner, repo string) (string, string, error) { return "O_acme", "R_repo", nil }
+	deps.CreateProject = func(ownerID, title string) (string, error) { return "PVT_cp", nil }
+	deps.LinkRepoToProject = func(projectID, repoID string) error { return nil }
 	deps.SetRepoVariable = func(o, r, n, v string) error { return nil }
 	deps.Clone = func(repoURL, tag, destDir string) error { return nil }
 
 	var buf bytes.Buffer
+	// No RepoFullName → ConfigureRepo is a no-op; Version drives the create.
 	err := InitRepo(&buf, deps, InitRepoConfig{
-		Mode:      InitModeFederated,
-		ProjectID: "PVT_fed",
-		// No InitCfg so ConfigureRepo is skipped.
+		Mode:    InitModeFederated,
+		InitCfg: &initpkg.InitConfig{Version: "v2.0.10"},
 	})
-	// A non-guard error (e.g. mount-related) is acceptable here — we're
-	// asserting the guard did NOT fire. If an error occurs it must not be
-	// the federated-owner message.
 	if err != nil {
-		wrongMsg := "Federated topology requires a GitHub Organization"
-		if got := err.Error(); len(got) >= len(wrongMsg) && got[:len(wrongMsg)] == wrongMsg {
-			t.Fatalf("guard fired unexpectedly for org owner: %v", err)
-		}
+		t.Fatalf("federated control-plane init should succeed for an org owner, got: %v", err)
+	}
+	// A federated control plane scaffolds an empty-but-valid FEDERATION.md.
+	if !IsFederationRepo(deps.Root) {
+		t.Error("expected FEDERATION.md to be scaffolded for a federated control plane")
 	}
 }

--- a/internal/project/join_test.go
+++ b/internal/project/join_test.go
@@ -174,3 +174,34 @@ func TestUnlink_Blocked_SingleWithDocsContent(t *testing.T) {
 		t.Errorf("expected 'blocked' in error, got: %v", err)
 	}
 }
+
+// TestJoinDomain_RegistersMultipleReposUnderOneDomain verifies AC-2 (#875): two
+// joins under one --domain register the domain with both repos, both linked.
+func TestJoinDomain_RegistersMultipleReposUnderOneDomain(t *testing.T) {
+	tmp := t.TempDir()
+	deps := testDeps("cp-owner", "cp")
+	deps.Root = tmp
+	deps.SetRepoVariable = func(o, r, n, v string) error { return nil }
+	deps.FetchOwnerAndRepoIDs = func(o, r string) (string, string, error) { return "o", "id-" + r, nil }
+	var linked []string
+	deps.LinkRepoToProject = func(p, r string) error { linked = append(linked, r); return nil }
+
+	var buf bytes.Buffer
+	if err := JoinDomain(&buf, deps, "PVT_cp", "cp-owner", "rating", "charging", "Charging domain", "Rating"); err != nil {
+		t.Fatalf("join 1: %v", err)
+	}
+	if err := JoinDomain(&buf, deps, "PVT_cp", "cp-owner", "balance", "charging", "Charging domain", "Balance"); err != nil {
+		t.Fatalf("join 2: %v", err)
+	}
+
+	fed, err := ReadFederation(tmp)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(fed.Domains) != 1 || len(fed.Domains[0].Repos) != 2 {
+		t.Fatalf("expected one domain with two repos, got %d domain(s)", len(fed.Domains))
+	}
+	if len(linked) != 2 {
+		t.Errorf("expected both repos linked to the project, got %d", len(linked))
+	}
+}

--- a/internal/project/scaffold_federation.go
+++ b/internal/project/scaffold_federation.go
@@ -1,0 +1,90 @@
+package project
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/eddiecarpenter/gh-agentic/internal/ui"
+)
+
+// systemDocTemplates are the federated-tier documentation files a control plane
+// scaffolds on creation (#875), per concepts/knowledge-plane.md: SYSTEM_BRIEF
+// answers "why the system as a whole exists" and SYSTEM_ARCHITECTURE answers
+// "the seams between repos". They are written only when absent.
+var systemDocTemplates = map[string]string{
+	"docs/SYSTEM_BRIEF.md":        systemBriefTemplate,
+	"docs/SYSTEM_ARCHITECTURE.md": systemArchitectureTemplate,
+}
+
+// ScaffoldFederation scaffolds the control plane's federation artefacts: an
+// empty-but-valid FEDERATION.md (no domains registered yet — domains are added
+// later via `gh agentic project join`) and the federated-tier system docs. Both
+// are write-if-absent, so re-running never clobbers existing content.
+func ScaffoldFederation(w io.Writer, root string) error {
+	if !IsFederationRepo(root) {
+		if err := WriteFederation(root, &Federation{}); err != nil {
+			return fmt.Errorf("scaffolding FEDERATION.md: %w", err)
+		}
+		fmt.Fprintf(w, "  %s  FEDERATION.md scaffolded (no domains registered yet)\n", ui.StatusOK.Render("✓"))
+	}
+
+	for path, tmpl := range systemDocTemplates {
+		full := filepath.Join(root, path)
+		if _, err := os.Stat(full); err == nil {
+			continue // never overwrite an existing doc
+		}
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return fmt.Errorf("scaffolding %s: %w", path, err)
+		}
+		if err := os.WriteFile(full, []byte(tmpl), 0o644); err != nil {
+			return fmt.Errorf("scaffolding %s: %w", path, err)
+		}
+		fmt.Fprintf(w, "  %s  %s scaffolded\n", ui.StatusOK.Render("✓"), path)
+	}
+	return nil
+}
+
+const systemBriefTemplate = `# SYSTEM_BRIEF.md
+
+> Federated-tier brief (control plane). Answers **why the system as a whole
+> exists** — the system-level need, not how any one repo works internally.
+> Domain-level briefs live under docs/domains/<domain>/.
+
+## What this system is
+
+<One paragraph: the system this federation delivers, in business terms.>
+
+## Why it exists
+
+<The system-level need. What problem does the whole federation solve that no
+single domain repo solves alone?>
+
+## Domains
+
+<Each domain in FEDERATION.md, one line on what it owns. Keep in step with the
+manifest as domains are registered via 'gh agentic project join'.>
+`
+
+const systemArchitectureTemplate = `# SYSTEM_ARCHITECTURE.md
+
+> Federated-tier architecture (control plane). Answers **the seams between
+> repos** — cross-cutting concerns and the contracts that join domains. It must
+> never describe how a single repo works internally (that is the domain's own
+> ARCHITECTURE.md under docs/domains/<domain>/).
+
+## System context
+
+<The major domains and how they relate at the seams — events, APIs, shared
+contracts. A diagram or bullet list of the integration points.>
+
+## Cross-cutting concerns
+
+<Concerns that span domains: auth, observability, shared schemas, etc.>
+
+## Contracts between domains
+
+<The interfaces domains depend on across the seam — event schemas, API
+boundaries, shared data shapes.>
+`

--- a/internal/project/scaffold_federation.go
+++ b/internal/project/scaffold_federation.go
@@ -43,6 +43,7 @@ func ScaffoldFederation(w io.Writer, root string) error {
 		}
 		fmt.Fprintf(w, "  %s  %s scaffolded\n", ui.StatusOK.Render("✓"), path)
 	}
+	fmt.Fprintf(w, "  Register domain repos from here with: gh agentic project join <owner/repo> --domain <name>\n")
 	return nil
 }
 

--- a/internal/project/scaffold_federation_test.go
+++ b/internal/project/scaffold_federation_test.go
@@ -1,0 +1,47 @@
+package project
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScaffoldFederation_CreatesManifestAndDocs(t *testing.T) {
+	dir := t.TempDir()
+	if err := ScaffoldFederation(&bytes.Buffer{}, dir); err != nil {
+		t.Fatalf("ScaffoldFederation: %v", err)
+	}
+	fed, err := ReadFederation(dir)
+	if err != nil {
+		t.Fatalf("scaffolded FEDERATION.md should be valid: %v", err)
+	}
+	if len(fed.Domains) != 0 {
+		t.Errorf("expected an empty manifest, got %d domains", len(fed.Domains))
+	}
+	for _, doc := range []string{"docs/SYSTEM_BRIEF.md", "docs/SYSTEM_ARCHITECTURE.md"} {
+		if _, err := os.Stat(filepath.Join(dir, doc)); err != nil {
+			t.Errorf("expected %s to be scaffolded: %v", doc, err)
+		}
+	}
+}
+
+func TestScaffoldFederation_DoesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, validManifest)
+	_ = os.MkdirAll(filepath.Join(dir, "docs"), 0o755)
+	custom := []byte("# custom brief\n")
+	_ = os.WriteFile(filepath.Join(dir, "docs", "SYSTEM_BRIEF.md"), custom, 0o644)
+
+	if err := ScaffoldFederation(&bytes.Buffer{}, dir); err != nil {
+		t.Fatalf("ScaffoldFederation: %v", err)
+	}
+	fed, err := ReadFederation(dir)
+	if err != nil || len(fed.Domains) != 2 {
+		t.Fatalf("existing FEDERATION.md must not be overwritten: err=%v domains=%d", err, len(fed.Domains))
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "docs", "SYSTEM_BRIEF.md"))
+	if string(got) != string(custom) {
+		t.Error("existing SYSTEM_BRIEF.md must not be overwritten")
+	}
+}


### PR DESCRIPTION
## Summary

Implements **Feature #875** — a first-class path to *create* a federated control plane,
and the domain-registration story around it. Part of #870. Builds on #874's `join` +
`WriteFederation`.

## What changed

**T1 — CP-creation scaffolding** (`internal/project`)
- An empty `domains:` `FEDERATION.md` is now valid ("control plane, no domains yet") —
  `ReadFederation`/`WriteFederation`/`check` accept it; the flat `repos:` schema is still rejected.
- `project.ScaffoldFederation` writes an empty `FEDERATION.md` + `docs/SYSTEM_BRIEF.md` +
  `docs/SYSTEM_ARCHITECTURE.md` (write-if-absent); `project.Create` invokes it for a federated CP.

**T2 — `init` federated path creates a control plane** (`internal/cli/init.go`, `internal/project/init.go`)
- `gh agentic init` → federated now *creates* a control plane (board + manifest + system docs +
  mount). The obsolete "join an existing federated project as a domain repo" init flow is removed —
  domain repos are registered from the CP via `gh agentic project join` (#874).

**T3 — registration + drift verification** (`internal/doctor`, tests)
- The control-plane repo is excluded from the federation-sync `unlisted` drift warning.
- Tests confirm AC-2 (two `join`s under one `--domain` register the domain with both repos) and
  AC-3 (manifest↔Project drift over the grouped schema). The create output points at `project join`.

## Testing

`go build ./...` and `go test ./...` pass. AC-1/AC-2/AC-3 all covered by unit tests.

## Tasks

Closes #894, closes #895, closes #896.

Closes #875

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)
