### PR TITLE
feat: Pipeline-on-control-plane execution with uniform project layout

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -122,13 +122,25 @@ jobs:
       actions: read
 
     steps:
-      - name: Checkout repository
+      # CP-rooted project layout (#873, adapted from the #867 prototype). The repo
+      # running this workflow IS the control plane — it checks itself out at the
+      # workspace root (knowledge layer: .agents + docs) and clones the feature's
+      # TARGET repo into ./project (the code). Uniform across single and federated
+      # topology — only the target differs (single → the CP repo itself).
+      #
+      # Order matters: the knowledge root is checked out first (it carries .agents),
+      # then setup-goose-env installs gh + goose, and only THEN is the target
+      # resolved with `gh agentic feature target`. Self-hosted runners have no gh
+      # until install-ai-tools runs, so no gh call may precede setup-goose-env.
+      - name: Checkout knowledge root (control plane)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          repository: ${{ github.repository }}
           ref: main
+          path: .
           fetch-depth: 0
           submodules: recursive
-          token: ${{ github.token }}
+          token: ${{ secrets.PIPELINE_PAT }}
 
       - name: Setup Goose environment
         uses: ./.agents/.github/actions/setup-goose-env
@@ -141,10 +153,53 @@ jobs:
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
 
+      # gh is available now (installed by setup-goose-env). Resolve the feature's
+      # TARGET repo from the Target-repo field (#872).
+      - name: Resolve target repo
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
+          GH_REPO: ${{ github.repository }}
+          AGENTIC_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          gh extension install eddiecarpenter/gh-agentic --pin "${AGENTIC_VERSION}" --force
+          target="$(gh agentic feature target "${ISSUE}" --raw)"
+          if [ -z "${target}" ]; then
+            echo "::error::Could not resolve target repo for feature #${ISSUE}."
+            exit 1
+          fi
+          echo "repo=${target}" >> "$GITHUB_OUTPUT"
+          echo "✓ Feature #${ISSUE} targets ${target}."
+
+      # The code, always at ./project: the target repo @ main (feature-design
+      # branches off main inside ./project).
+      - name: Checkout project (code)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ steps.target.outputs.repo }}
+          ref: main
+          path: project
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+
+      # Keep the knowledge root pristine (ignore ./project via repo-local exclude,
+      # not the tracked .gitignore) and export the constant layout anchors.
+      - name: Isolate project and export anchors
+        run: |
+          [ -d .git ] && echo '/project/' >> .git/info/exclude
+          echo "AGENTIC_CP_ROOT=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
+          echo "AGENTIC_PROJECT_DIR=${GITHUB_WORKSPACE}/project" >> "$GITHUB_ENV"
+
+      # Runs with cwd = ./project (the code), but the FRAMEWORK (recipes, skills,
+      # .goose) comes from the knowledge root's mount — the target repo carries no
+      # .agents. So the recipe path and GOOSE_PATH_ROOT are absolute into
+      # $AGENTIC_CP_ROOT/.agents while the agent operates on ./project.
       - name: Run feature-design recipe
+        working-directory: project
         run: |
           goose run \
-            --recipe .agents/.goose/recipes/feature-design.yaml \
+            --recipe ${{ github.workspace }}/.agents/.goose/recipes/feature-design.yaml \
             --params feature_number=${{ github.event.issue.number }}
         env:
           GOOSE_PATH_ROOT: ${{ github.workspace }}/.agents/.goose
@@ -193,8 +248,9 @@ jobs:
       - name: Commit and push feature branch
         id: push
         if: success()
+        working-directory: project
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
           ISSUE: ${{ github.event.issue.number }}
         run: |
           BRANCH=$(git branch --list "feature/${ISSUE}-*" --format='%(refname:short)' | head -1)
@@ -275,45 +331,19 @@ jobs:
       actions: read
 
     steps:
-      # Resolve the branch name before checkout so the checkout ref is known.
-      # Inline (not a composite action) because the workspace has no checkout yet —
-      # local composite actions require the submodule tree to be on disk first.
-      # Uses curl+jq (not gh) because gh is installed by setup-goose-env which
-      # runs after checkout — self-hosted runners do not have gh pre-installed.
-      # Paginated: fetches up to 100 branches per page until branch found or exhausted.
-      - name: Resolve feature branch
-        id: branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ github.event.issue.number }}
-        run: |
-          PAGE=1
-          BRANCH=""
-          while [ -z "${BRANCH}" ]; do
-            RESPONSE=$(curl --proto '=https' --tlsv1.2 -fsSL \
-              -H "Authorization: token ${GH_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${REPO}/branches?per_page=100&page=${PAGE}")
-            BRANCH=$(echo "${RESPONSE}" | jq -r '.[].name' | grep "^feature/${ISSUE}-" | head -1 || true)
-            COUNT=$(echo "${RESPONSE}" | jq '. | length')
-            [ "${COUNT}" -lt 100 ] && break
-            PAGE=$((PAGE + 1))
-          done
-          if [ -z "${BRANCH}" ]; then
-            echo "::error::No branch matching feature/${ISSUE}-* found in ${REPO}."
-            exit 1
-          fi
-          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
-          echo "✓ Found feature branch: ${BRANCH}"
-
-      - name: Checkout repository
+      # CP-rooted project layout (#873). Order: check out the knowledge root (it
+      # carries .agents), install gh + goose via setup-goose-env, THEN resolve the
+      # TARGET repo + feature branch with gh, then clone the code into ./project.
+      # No gh call may precede setup-goose-env (self-hosted runners lack gh).
+      - name: Checkout knowledge root (control plane)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ steps.branch.outputs.name }}
+          repository: ${{ github.repository }}
+          ref: main
+          path: .
           fetch-depth: 0
           submodules: recursive
-          token: ${{ github.token }}
+          token: ${{ secrets.PIPELINE_PAT }}
 
       - name: Setup Goose environment
         uses: ./.agents/.github/actions/setup-goose-env
@@ -326,9 +356,53 @@ jobs:
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
 
+      # gh is available now. Resolve the feature's TARGET repo from the Target-repo
+      # field (#872), then the feature branch within it (paginated, against the
+      # TARGET repo, not the control plane).
+      - name: Resolve target repo and feature branch
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
+          GH_REPO: ${{ github.repository }}
+          AGENTIC_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          gh extension install eddiecarpenter/gh-agentic --pin "${AGENTIC_VERSION}" --force
+          TARGET="$(gh agentic feature target "${ISSUE}" --raw)"
+          if [ -z "${TARGET}" ]; then
+            echo "::error::Could not resolve target repo for feature #${ISSUE}."
+            exit 1
+          fi
+          echo "repo=${TARGET}" >> "$GITHUB_OUTPUT"
+          BRANCH=$(gh api "repos/${TARGET}/branches?per_page=100" --paginate \
+            --jq '.[].name' | grep "^feature/${ISSUE}-" | head -1 || true)
+          if [ -z "${BRANCH}" ]; then
+            echo "::error::No branch matching feature/${ISSUE}-* found in ${TARGET}."
+            exit 1
+          fi
+          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "✓ Feature #${ISSUE} targets ${TARGET}, branch ${BRANCH}."
+
+      # The code, always at ./project: the target repo @ the feature branch.
+      - name: Checkout project (code)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ steps.resolve.outputs.repo }}
+          ref: ${{ steps.resolve.outputs.name }}
+          path: project
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+
+      - name: Isolate project and export anchors
+        run: |
+          [ -d .git ] && echo '/project/' >> .git/info/exclude
+          echo "AGENTIC_CP_ROOT=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
+          echo "AGENTIC_PROJECT_DIR=${GITHUB_WORKSPACE}/project" >> "$GITHUB_ENV"
+
       # Rebase before the Goose session so the agent works against the latest main.
-      # Force-push with --force-with-lease (safe: aborts if someone else pushed).
+      # Operates inside ./project (the code). Force-push with --force-with-lease.
       - name: Rebase feature branch onto main
+        working-directory: project
         run: |
           git config user.email "agent@gh-agentic.io"
           git config user.name "gh-agentic"
@@ -340,19 +414,20 @@ jobs:
             git rebase --abort
             exit 1
           }
-          git push origin HEAD:${{ steps.branch.outputs.name }} --force-with-lease
+          git push origin HEAD:${{ steps.resolve.outputs.name }} --force-with-lease
 
       # Retry up to 3 times: transient Goose/Claude auth errors are common on
-      # first run (credential warm-up). PIPELINE_PAT: go-gh inside Goose reads
-      # AGENTIC_PROJECT_ID via the Actions variables API; github.token does not
-      # reliably propagate through Goose's subprocess environment.
+      # first run (credential warm-up). cwd = ./project (the code); the recipe
+      # path is absolute into the knowledge root's mount. PIPELINE_PAT: go-gh
+      # inside Goose reads AGENTIC_PROJECT_ID via the Actions variables API.
       - name: Run dev-session recipe
         id: goose
+        working-directory: project
         run: |
           for attempt in 1 2 3; do
             echo "--- Dev session attempt ${attempt} ---"
             goose run \
-              --recipe .agents/.goose/recipes/dev-session.yaml \
+              --recipe ${{ github.workspace }}/.agents/.goose/recipes/dev-session.yaml \
               --params feature_number=${{ github.event.issue.number }} && break
             EXIT_CODE=$?
             if [ $attempt -lt 3 ]; then
@@ -370,20 +445,25 @@ jobs:
           GOOSE_DISABLE_SESSION_NAMING: "true"
           GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
 
-      # github.token sufficient for a plain git push (contents: write is declared).
+      # PIPELINE_PAT: the push targets the (cross-repo) target repo; the ./project
+      # checkout is already authenticated with it. Pushes only inside ./project.
       - name: Push branch
         if: success()
-        run: git push origin ${{ steps.branch.outputs.name }}
+        working-directory: project
+        run: git push origin ${{ steps.resolve.outputs.name }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
 
       # PIPELINE_PAT: in-verification must fire the compliance-verify workflow.
       # Skip the transition when the session produced no commits (nothing to verify).
+      # The commit count is read from ./project (the code).
       - name: Apply in-verification label
         id: in_verification
         if: success()
+        working-directory: project
         env:
           GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
+          CP_REPO: ${{ github.repository }}
         run: |
           COMMITS=$(git rev-list --count origin/main..HEAD)
           if [ "${COMMITS}" -eq 0 ]; then
@@ -392,6 +472,7 @@ jobs:
             exit 0
           fi
           gh issue edit ${{ github.event.issue.number }} \
+            --repo "${CP_REPO}" \
             --remove-label "in-development" \
             --add-label "in-verification"
           echo "skipped=false" >> $GITHUB_OUTPUT
@@ -504,41 +585,18 @@ jobs:
       actions: read
 
     steps:
-      # Inline curl+jq (not gh) — workspace not yet checked out here and
-      # gh is not pre-installed on self-hosted runners.
-      - name: Resolve feature branch
-        id: branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ github.event.issue.number }}
-        run: |
-          PAGE=1
-          BRANCH=""
-          while [ -z "${BRANCH}" ]; do
-            RESPONSE=$(curl --proto '=https' --tlsv1.2 -fsSL \
-              -H "Authorization: token ${GH_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${REPO}/branches?per_page=100&page=${PAGE}")
-            BRANCH=$(echo "${RESPONSE}" | jq -r '.[].name' | grep "^feature/${ISSUE}-" | head -1 || true)
-            COUNT=$(echo "${RESPONSE}" | jq '. | length')
-            [ "${COUNT}" -lt 100 ] && break
-            PAGE=$((PAGE + 1))
-          done
-          if [ -z "${BRANCH}" ]; then
-            echo "::error::No branch matching feature/${ISSUE}-* found in ${REPO}."
-            exit 1
-          fi
-          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
-          echo "✓ Found feature branch: ${BRANCH}"
-
-      - name: Checkout repository
+      # CP-rooted project layout (#873). Order: knowledge root → setup-goose-env
+      # (installs gh + goose) → resolve TARGET repo + branch with gh → clone the
+      # code into ./project. No gh call may precede setup-goose-env.
+      - name: Checkout knowledge root (control plane)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ steps.branch.outputs.name }}
+          repository: ${{ github.repository }}
+          ref: main
+          path: .
           fetch-depth: 0
           submodules: recursive
-          token: ${{ github.token }}
+          token: ${{ secrets.PIPELINE_PAT }}
 
       - name: Setup Goose environment
         uses: ./.agents/.github/actions/setup-goose-env
@@ -551,14 +609,58 @@ jobs:
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
 
+      # gh is available now. Resolve the feature's TARGET repo (#872) and the
+      # feature branch within it (paginated, against the TARGET repo).
+      - name: Resolve target repo and feature branch
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
+          GH_REPO: ${{ github.repository }}
+          AGENTIC_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          gh extension install eddiecarpenter/gh-agentic --pin "${AGENTIC_VERSION}" --force
+          TARGET="$(gh agentic feature target "${ISSUE}" --raw)"
+          if [ -z "${TARGET}" ]; then
+            echo "::error::Could not resolve target repo for feature #${ISSUE}."
+            exit 1
+          fi
+          echo "repo=${TARGET}" >> "$GITHUB_OUTPUT"
+          BRANCH=$(gh api "repos/${TARGET}/branches?per_page=100" --paginate \
+            --jq '.[].name' | grep "^feature/${ISSUE}-" | head -1 || true)
+          if [ -z "${BRANCH}" ]; then
+            echo "::error::No branch matching feature/${ISSUE}-* found in ${TARGET}."
+            exit 1
+          fi
+          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "✓ Feature #${ISSUE} targets ${TARGET}, branch ${BRANCH}."
+
+      # The code, always at ./project: the target repo @ the feature branch.
+      - name: Checkout project (code)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ steps.resolve.outputs.repo }}
+          ref: ${{ steps.resolve.outputs.name }}
+          path: project
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+
+      - name: Isolate project and export anchors
+        run: |
+          [ -d .git ] && echo '/project/' >> .git/info/exclude
+          echo "AGENTIC_CP_ROOT=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
+          echo "AGENTIC_PROJECT_DIR=${GITHUB_WORKSPACE}/project" >> "$GITHUB_ENV"
+
       # PIPELINE_PAT: the recipe applies compliance-verified or in-development
       # labels that must trigger downstream workflow runs.
       # SONAR_TOKEN: injected so the compliance-verify skill can detect SonarQube
-      # availability and run analysis when configured.
+      # availability and run analysis when configured. cwd = ./project (the code);
+      # recipe path is absolute into the knowledge root's mount.
       - name: Run compliance-verify recipe
+        working-directory: project
         run: |
           goose run \
-            --recipe .agents/.goose/recipes/compliance-verify.yaml \
+            --recipe ${{ github.workspace }}/.agents/.goose/recipes/compliance-verify.yaml \
             --params feature_number=${{ github.event.issue.number }}
         env:
           GOOSE_PATH_ROOT: ${{ github.workspace }}/.agents/.goose
@@ -573,16 +675,22 @@ jobs:
       # If not (skill handled the FAIL state reset itself), log and exit cleanly.
       # PIPELINE_PAT: the PR creation must fire the pull_request event so
       # pr-review-session can trigger on it.
+      # cwd = ./project (the code) so git ops + `gh pr` default to the TARGET repo,
+      # where the branch and PR live. Feature-issue reads stay explicit on the CP
+      # (--repo "${CP}"). The PR is opened in the target repo; the feature issue it
+      # implements lives on the CP, so the body uses a cross-repo "Closes" reference.
       - name: Open PR if compliance-verified
         id: open_pr
+        working-directory: project
         env:
           GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
+          CP: ${{ github.repository }}
+          TARGET: ${{ steps.resolve.outputs.repo }}
         run: |
-          BRANCH="${{ steps.branch.outputs.name }}"
-          LABELS=$(gh issue view "${ISSUE_NUMBER}" --repo "${REPO}" --json labels --jq '[.labels[].name]')
+          BRANCH="${{ steps.resolve.outputs.name }}"
+          LABELS=$(gh issue view "${ISSUE_NUMBER}" --repo "${CP}" --json labels --jq '[.labels[].name]')
           if ! echo "${LABELS}" | jq -e 'contains(["compliance-verified"])' > /dev/null; then
             echo "compliance-verified label not present — recipe did not pass."
             echo "opened=false" >> $GITHUB_OUTPUT
@@ -594,32 +702,32 @@ jobs:
             echo "opened=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          EXISTING=$(gh pr list --repo "${REPO}" --head "${BRANCH}" --json number --jq '.[0].number')
+          EXISTING=$(gh pr list --repo "${TARGET}" --head "${BRANCH}" --json number --jq '.[0].number')
           if [ -n "${EXISTING}" ]; then
-            echo "PR #${EXISTING} already exists for ${BRANCH} — skipping creation."
+            echo "PR #${EXISTING} already exists for ${BRANCH} in ${TARGET} — skipping creation."
             echo "opened=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          # Read the PR body authored by the compliance-verify skill.
-          # The skill posts a <!-- pr-body:v1 --> comment with the implementation
-          # summary, AC table, and static-analysis verdict. Strip the marker line;
-          # fall back to a minimal body if the comment is absent.
+          # Read the PR body authored by the compliance-verify skill (posted as a
+          # <!-- pr-body:v1 --> comment on the CP feature issue). Strip the marker
+          # line; fall back to a minimal cross-repo "Closes" body if absent.
           PR_BODY_RAW=$(gh issue view "${ISSUE_NUMBER}" \
-            --repo "${REPO}" \
+            --repo "${CP}" \
             --json comments \
             --jq '[.comments[] | select(.body | startswith("<!-- pr-body:v1 -->"))] | last | .body // ""')
           if [ -n "${PR_BODY_RAW}" ]; then
             BODY=$(printf "%s" "${PR_BODY_RAW}" | tail -n +3)
           else
-            BODY=$(printf "Closes #%s\n\n🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)" "${ISSUE_NUMBER}")
+            BODY=$(printf "Closes %s#%s\n\n🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)" "${CP}" "${ISSUE_NUMBER}")
           fi
           gh pr create \
+            --repo "${TARGET}" \
             --title "feat: ${ISSUE_TITLE}" \
             --body "${BODY}" \
             --base main \
             --head "${BRANCH}"
           echo "opened=true" >> $GITHUB_OUTPUT
-          echo "✓ PR opened for ${BRANCH}."
+          echo "✓ PR opened for ${BRANCH} in ${TARGET}."
 
       # Safety net: if the recipe exited on the FAIL path without completing
       # the label swap (e.g. context exhaustion mid-step), the issue is stuck
@@ -723,13 +831,28 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - name: Checkout repository
+      # CP-rooted project layout (#873). The PR + its branch live in the TARGET
+      # repo (the code); the control plane (this repo) is the knowledge root. The
+      # target is resolved from the feature number embedded in the PR branch
+      # (feature/<N>-*) via the Target-repo field (#872). For a single-topology
+      # project the target resolves to the CP repo itself — identical layout.
+      #
+      # NOTE — federated trigger gap (surfaced by #873): the `pull_request_review`
+      # event fires in the repo that hosts the PR (the pure-code target repo, which
+      # carries no workflow), so it cannot auto-trigger this CP-hosted job. For a
+      # federation, drive this job via workflow_dispatch (pr_number + branch_name)
+      # or a target-repo event forwarder. The `pull_request_review` trigger remains
+      # valid for single-topology (CP == target). See the feature for the open
+      # decision on a CP-side PR-review trigger.
+      - name: Checkout knowledge root (control plane)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ inputs.branch_name || github.event.inputs.branch_name || github.event.pull_request.head.ref }}
+          repository: ${{ github.repository }}
+          ref: main
+          path: .
           fetch-depth: 0
           submodules: recursive
-          token: ${{ github.token }}
+          token: ${{ secrets.PIPELINE_PAT }}
 
       - name: Setup Goose environment
         uses: ./.agents/.github/actions/setup-goose-env
@@ -742,10 +865,48 @@ jobs:
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
 
+      # gh is available now. Resolve the TARGET repo from the feature number
+      # embedded in the PR branch (feature/<N>-*) via the Target-repo field (#872).
+      - name: Resolve target repo
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
+          GH_REPO: ${{ github.repository }}
+          AGENTIC_VERSION: ${{ vars.AGENTIC_FRAMEWORK_VERSION }}
+          BRANCH: ${{ inputs.branch_name || github.event.inputs.branch_name || github.event.pull_request.head.ref }}
+        run: |
+          gh extension install eddiecarpenter/gh-agentic --pin "${AGENTIC_VERSION}" --force
+          FEATURE_N=$(printf '%s' "${BRANCH}" | sed -E 's|^feature/([0-9]+)-.*|\1|')
+          if printf '%s' "${FEATURE_N}" | grep -qE '^[0-9]+$'; then
+            TARGET="$(gh agentic feature target "${FEATURE_N}" --raw || true)"
+          fi
+          if [ -z "${TARGET:-}" ]; then
+            echo "Could not resolve target from feature #${FEATURE_N:-?} — defaulting to ${GH_REPO} (single topology)."
+            TARGET="${GH_REPO}"
+          fi
+          echo "repo=${TARGET}" >> "$GITHUB_OUTPUT"
+          echo "✓ PR review targets ${TARGET}, branch ${BRANCH}."
+
+      - name: Checkout project (code)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ steps.resolve.outputs.repo }}
+          ref: ${{ inputs.branch_name || github.event.inputs.branch_name || github.event.pull_request.head.ref }}
+          path: project
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+
+      - name: Isolate project and export anchors
+        run: |
+          [ -d .git ] && echo '/project/' >> .git/info/exclude
+          echo "AGENTIC_CP_ROOT=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
+          echo "AGENTIC_PROJECT_DIR=${GITHUB_WORKSPACE}/project" >> "$GITHUB_ENV"
+
       # PIPELINE_PAT: go-gh inside Goose needs to read Actions variables
-      # (AGENTIC_PROJECT_ID). github.token does not propagate reliably through
-      # Goose's subprocess environment.
+      # (AGENTIC_PROJECT_ID). cwd = ./project (the target code + PR); the recipe
+      # path is absolute into the knowledge root's mount.
       - name: Run PR review recipe
+        working-directory: project
         env:
           PR_NUMBER: ${{ inputs.pr_number || github.event.inputs.pr_number || github.event.pull_request.number }}
           GOOSE_PATH_ROOT: ${{ github.workspace }}/.agents/.goose
@@ -756,14 +917,16 @@ jobs:
           GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
         run: |
           goose run \
-            --recipe .agents/.goose/recipes/pr-review-session.yaml \
+            --recipe ${{ github.workspace }}/.agents/.goose/recipes/pr-review-session.yaml \
             --params pr_number=${PR_NUMBER}
 
-      # github.token is sufficient for a git push (contents: write declared).
+      # PIPELINE_PAT: the push targets the (cross-repo) target repo; the ./project
+      # checkout is already authenticated with it. Pushes only inside ./project.
       - name: Push fixes
         if: success()
+        working-directory: project
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
           BRANCH: ${{ inputs.branch_name || github.event.inputs.branch_name || github.event.pull_request.head.ref }}
         run: |
           LOCAL=$(git rev-parse HEAD)

--- a/.goose/recipes/compliance-verify.yaml
+++ b/.goose/recipes/compliance-verify.yaml
@@ -23,6 +23,9 @@ instructions: |
   You are an automated agent in this project's agentic delivery pipeline.
 
 prompt: |
-  Load `AGENTS.md` (the project rulebook). Then execute the
+  Load `AGENTS.md` (the project rulebook) from the control-plane
+  knowledge root — the directory named by the `AGENTIC_CP_ROOT`
+  environment variable, or the current directory when it is unset.
+  Then execute the
   `compliance-verify` skill for Feature {{ feature_number }}. The
   skill is the authoritative playbook; do not improvise.

--- a/.goose/recipes/dev-session.yaml
+++ b/.goose/recipes/dev-session.yaml
@@ -23,6 +23,9 @@ instructions: |
   You are an automated agent in this project's agentic delivery pipeline.
 
 prompt: |
-  Load `AGENTS.md` (the project rulebook). Then execute the
+  Load `AGENTS.md` (the project rulebook) from the control-plane
+  knowledge root — the directory named by the `AGENTIC_CP_ROOT`
+  environment variable, or the current directory when it is unset.
+  Then execute the
   `dev-session` skill for Feature {{ feature_number }}. The
   skill is the authoritative playbook; do not improvise.

--- a/.goose/recipes/feature-design.yaml
+++ b/.goose/recipes/feature-design.yaml
@@ -23,6 +23,9 @@ instructions: |
   You are an automated agent in this project's agentic delivery pipeline.
 
 prompt: |
-  Load `AGENTS.md` (the project rulebook). Then execute the
+  Load `AGENTS.md` (the project rulebook) from the control-plane
+  knowledge root — the directory named by the `AGENTIC_CP_ROOT`
+  environment variable, or the current directory when it is unset.
+  Then execute the
   `feature-design` skill for Feature {{ feature_number }}. The
   skill is the authoritative playbook; do not improvise.

--- a/.goose/recipes/pr-review-session.yaml
+++ b/.goose/recipes/pr-review-session.yaml
@@ -23,6 +23,9 @@ instructions: |
   You are an automated agent in this project's agentic delivery pipeline.
 
 prompt: |
-  Load `AGENTS.md` (the project rulebook). Then execute the
+  Load `AGENTS.md` (the project rulebook) from the control-plane
+  knowledge root — the directory named by the `AGENTIC_CP_ROOT`
+  environment variable, or the current directory when it is unset.
+  Then execute the
   `pr-review-session` skill for PR {{ pr_number }}. The skill is
   the authoritative playbook; do not improvise.

--- a/internal/cli/feature.go
+++ b/internal/cli/feature.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/eddiecarpenter/gh-agentic/internal/projectstatus"
+)
+
+// newFeatureCmd constructs the `gh agentic feature` command group.
+func newFeatureCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "feature",
+		Short: "Feature-level queries for the agentic pipeline",
+		Long: `Feature-level helpers used by the pipeline and by humans.
+
+Currently exposes 'target', which resolves the implementation repo a
+control-plane Feature targets (its "Target repo" field), with a
+single-topology fallback to the current repository.`,
+		RunE: func(cmd *cobra.Command, args []string) error { return cmd.Help() },
+	}
+	cmd.AddCommand(newFeatureTargetCmd())
+	return cmd
+}
+
+// newFeatureTargetCmd constructs `gh agentic feature target <N>` with
+// production dependencies.
+func newFeatureTargetCmd() *cobra.Command {
+	return newFeatureTargetCmdWithDeps(defaultStatusDeps())
+}
+
+// newFeatureTargetCmdWithDeps builds the command with an explicit statusDeps
+// for testing.
+func newFeatureTargetCmdWithDeps(deps statusDeps) *cobra.Command {
+	var raw bool
+	cmd := &cobra.Command{
+		Use:   "target <number>",
+		Short: "Print the implementation repo a Feature targets",
+		Long: `Resolve the implementation repository a Feature targets.
+
+In a federation, a control-plane Feature records its target repo in the
+"Target repo" ProjectV2 field; this command prints it as 'owner/repo' (the
+owner is always the control-plane owner). When the field is unset — a
+single-topology project — it resolves to the current repository.
+
+The pipeline reads this (with --raw) to know which repo to clone into ./project.`,
+		Example: `  # Human-readable
+  gh agentic feature target 873
+
+  # Scripting/CI — owner/repo only
+  gh agentic feature target 873 --raw`,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			n, err := parseIssueNumberArg(args[0])
+			if err != nil {
+				return err
+			}
+			if err := runFeatureTarget(cmd.OutOrStdout(), cmd.ErrOrStderr(), n, raw, deps); err != nil {
+				return renderStatusError(cmd, err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&raw, "raw", false, "print only owner/repo on stdout (for scripting/CI)")
+	return cmd
+}
+
+// runFeatureTarget resolves and prints a Feature's target repo.
+func runFeatureTarget(w io.Writer, stderr io.Writer, number int, raw bool, deps statusDeps) error {
+	currentRepo, err := deps.currentRepo()
+	if err != nil {
+		return fmt.Errorf("resolving current repository: %w", err)
+	}
+	projectID, err := deps.resolveProjectID(currentRepo)
+	if err != nil {
+		return fmt.Errorf("reading AGENTIC_PROJECT_ID for %s: %w", currentRepo, err)
+	}
+	if projectID == "" {
+		return projectstatus.ErrProjectNotConfigured
+	}
+
+	var feature *projectstatus.Feature
+	err = deps.busy(stderr, fmt.Sprintf("Resolving target for feature #%d…", number), func() error {
+		var fetchErr error
+		feature, fetchErr = projectstatus.FetchFeature(deps.psDeps, projectID, number)
+		return fetchErr
+	})
+	if err != nil {
+		return annotateDetailError(err, number, currentRepo)
+	}
+
+	target := resolveFeatureTarget(feature.TargetRepo, currentRepo)
+	if raw {
+		fmt.Fprintln(w, target)
+	} else {
+		fmt.Fprintf(w, "Feature #%d targets: %s\n", number, target)
+	}
+	return nil
+}
+
+// resolveFeatureTarget composes the target owner/repo for a Feature. When the
+// "Target repo" field is set it holds the bare repo name and the owner is the
+// current (control-plane) repo's owner — the single-owner federation rule.
+// When unset — single topology — the target is the current repo itself. A
+// field value that already carries an owner is used verbatim (defensive).
+func resolveFeatureTarget(targetRepoField, currentRepo string) string {
+	field := strings.TrimSpace(targetRepoField)
+	if field == "" {
+		return currentRepo
+	}
+	if strings.Contains(field, "/") {
+		return field
+	}
+	owner := currentRepo
+	if i := strings.IndexByte(currentRepo, '/'); i >= 0 {
+		owner = currentRepo[:i]
+	}
+	return owner + "/" + field
+}

--- a/internal/cli/feature_test.go
+++ b/internal/cli/feature_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eddiecarpenter/gh-agentic/internal/projectstatus"
+)
+
+func TestResolveFeatureTarget(t *testing.T) {
+	cases := []struct {
+		name        string
+		field       string
+		currentRepo string
+		want        string
+	}{
+		{"field set — prepend CP owner", "charging-rating", "openbss/openbss", "openbss/charging-rating"},
+		{"unset — single topology falls back to current repo", "", "acme/widgets", "acme/widgets"},
+		{"blank field treated as unset", "   ", "acme/widgets", "acme/widgets"},
+		{"field already owner/repo — used verbatim", "other/repo", "acme/cp", "other/repo"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resolveFeatureTarget(c.field, c.currentRepo); got != c.want {
+				t.Errorf("resolveFeatureTarget(%q, %q) = %q, want %q", c.field, c.currentRepo, got, c.want)
+			}
+		})
+	}
+}
+
+// TestRunFeatureTarget_Raw exercises the command end-to-end against an injected
+// feature with the Target repo field set, and one without (single topology).
+func TestRunFeatureTarget_Raw(t *testing.T) {
+	now := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{"federated", "charging-rating", "eddiecarpenter/charging-rating\n"},
+		{"single topology", "", "eddiecarpenter/gh-agentic\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := []projectstatus.ProjectIssue{
+				{Number: 873, Title: "feat: x", Body: "b", Stage: projectstatus.StageInDevelopment, Type: "feature", State: "open", OwningRepo: "eddiecarpenter/gh-agentic", TargetRepo: tc.target, CreatedAt: now, LastTransitionedAt: now},
+			}
+			sd := featureDetailFixture(issues, nil, nil, nil, nil)
+
+			buf := &bytes.Buffer{}
+			if err := runFeatureTarget(buf, io.Discard, 873, true, sd); err != nil {
+				t.Fatalf("runFeatureTarget: %v", err)
+			}
+			if buf.String() != tc.want {
+				t.Errorf("--raw output = %q, want %q", buf.String(), tc.want)
+			}
+		})
+	}
+}
+
+// TestRunFeatureTarget_HumanForm verifies the non-raw output names the feature
+// and its target.
+func TestRunFeatureTarget_HumanForm(t *testing.T) {
+	now := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
+	issues := []projectstatus.ProjectIssue{
+		{Number: 873, Title: "feat: x", Body: "b", Stage: projectstatus.StageInDevelopment, Type: "feature", State: "open", OwningRepo: "eddiecarpenter/gh-agentic", TargetRepo: "charging-rating", CreatedAt: now, LastTransitionedAt: now},
+	}
+	sd := featureDetailFixture(issues, nil, nil, nil, nil)
+
+	buf := &bytes.Buffer{}
+	if err := runFeatureTarget(buf, io.Discard, 873, false, sd); err != nil {
+		t.Fatalf("runFeatureTarget: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "873") || !strings.Contains(out, "eddiecarpenter/charging-rating") {
+		t.Errorf("human output should name the feature and target, got: %q", out)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -84,6 +84,7 @@ Run 'gh agentic <command> --help' on any command for detailed usage.`,
 	root.AddCommand(newInfoCmd(version, date))
 	root.AddCommand(newAuthCmd())
 	root.AddCommand(newStatusCmd())
+	root.AddCommand(newFeatureCmd())
 
 	return root
 }

--- a/internal/mount/pipeline_scripts_exec_test.go
+++ b/internal/mount/pipeline_scripts_exec_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -189,84 +190,69 @@ func TestExtractFeatureIssueNumber(t *testing.T) {
 }
 
 // -------------------------------------------------------------------
-// Test: dev-session "Resolve feature branch"
+// Test: dev-session "Resolve target repo and feature branch" (#873)
 //
-// Calls curl against the GitHub API and parses the JSON branch list
-// with jq. Mock curl to return a fixed JSON payload; verify the script
-// extracts the right branch name.
+// Resolves the TARGET repo via `gh agentic feature target <N> --raw`,
+// then the feature branch within it via `gh api .../branches --paginate
+// --jq .[].name`. Mock gh: `extension install` is a no-op, `agentic`
+// returns the target, `api` emits one branch name per line (emulating
+// the --jq projection). Verify repo + branch outputs.
 // -------------------------------------------------------------------
 
+// ghResolveStub returns a `gh` stub script: extension install → no-op,
+// `gh agentic ...` → the given target repo, `gh api ...` → the given
+// newline-separated branch names (the gh --jq projection).
+func ghResolveStub(target string, branches ...string) string {
+	body := "if [ \"$1\" = \"extension\" ]; then exit 0; fi\n"
+	body += "if [ \"$1\" = \"agentic\" ]; then echo \"" + target + "\"; exit 0; fi\n"
+	body += "if [ \"$1\" = \"api\" ]; then\n"
+	for _, b := range branches {
+		body += "  echo \"" + b + "\"\n"
+	}
+	body += "  exit 0\nfi\n"
+	return body
+}
+
+func resolveEnv(issue, ghOut string) map[string]string {
+	return map[string]string{
+		"GH_TOKEN":        "stub-token",
+		"GH_REPO":         "owner/cp-repo",
+		"AGENTIC_VERSION": "v9.9.9",
+		"ISSUE":           issue,
+		"GITHUB_OUTPUT":   ghOut,
+	}
+}
+
 func TestResolveFeatureBranch_HappyPath(t *testing.T) {
-	script := scriptByName(t, "dev-session", "Resolve feature branch")
+	script := scriptByName(t, "dev-session", "Resolve target repo and feature branch")
 
 	stubDir, ghOut := makeStubDir(t)
-	// curl stub returns a JSON branch list when page=1; empty page=2.
-	writeStub(t, stubDir, "curl", `
-# Last arg is the URL. Extract the page query parameter.
-URL="${@: -1}"
-case "$URL" in
-  *\&page=1)
-    cat <<'JSON'
-[
-  {"name": "main"},
-  {"name": "feature/41-other-thing"},
-  {"name": "feature/42-add-login"},
-  {"name": "develop"}
-]
-JSON
-    ;;
-  *\&page=2)
-    echo '[]'
-    ;;
-esac
-`)
-	// jq is real (universal command).
+	writeStub(t, stubDir, "gh", ghResolveStub(
+		"owner/target-repo",
+		"main", "feature/41-other-thing", "feature/42-add-login", "develop"))
 
-	env := map[string]string{
-		"GH_TOKEN":      "stub-token",
-		"REPO":          "owner/repo",
-		"ISSUE":         "42",
-		"GITHUB_OUTPUT": ghOut,
-	}
-	stdout, stderr, code := runScript(t, script, stubDir, env)
+	stdout, stderr, code := runScript(t, script, stubDir, resolveEnv("42", ghOut))
 	if code != 0 {
 		t.Fatalf("script exited %d: stdout=%s stderr=%s", code, stdout, stderr)
 	}
 	out := readOutput(t, ghOut)
+	if got, want := out["repo"], "owner/target-repo"; got != want {
+		t.Errorf("repo = %q, want %q (stdout=%q)", got, want, stdout)
+	}
 	if got, want := out["name"], "feature/42-add-login"; got != want {
 		t.Errorf("name = %q, want %q (stdout=%q)", got, want, stdout)
 	}
 }
 
 func TestResolveFeatureBranch_NoMatch(t *testing.T) {
-	script := scriptByName(t, "dev-session", "Resolve feature branch")
+	script := scriptByName(t, "dev-session", "Resolve target repo and feature branch")
 
 	stubDir, ghOut := makeStubDir(t)
-	writeStub(t, stubDir, "curl", `
-URL="${@: -1}"
-case "$URL" in
-  *\&page=1)
-    cat <<'JSON'
-[
-  {"name": "main"},
-  {"name": "feature/41-other-thing"},
-  {"name": "develop"}
-]
-JSON
-    ;;
-  *\&page=2)
-    echo '[]'
-    ;;
-esac
-`)
+	writeStub(t, stubDir, "gh", ghResolveStub(
+		"owner/target-repo",
+		"main", "feature/41-other-thing", "develop"))
 
-	env := map[string]string{
-		"GH_TOKEN":      "stub-token",
-		"REPO":          "owner/repo",
-		"ISSUE":         "999", // no branch matches
-		"GITHUB_OUTPUT": ghOut,
-	}
-	stdout, stderr, code := runScript(t, script, stubDir, env)
+	stdout, stderr, code := runScript(t, script, stubDir, resolveEnv("999", ghOut))
 	if code == 0 {
 		t.Errorf("expected non-zero exit when no branch found, got 0")
 	}
@@ -276,36 +262,19 @@ esac
 	}
 }
 
-// Verifies the paginated loop: branch found on page 2 of 2.
+// Verifies branch extraction when many non-matching branches precede the hit.
 func TestResolveFeatureBranch_PaginatedHit(t *testing.T) {
-	script := scriptByName(t, "dev-session", "Resolve feature branch")
+	script := scriptByName(t, "dev-session", "Resolve target repo and feature branch")
 
 	stubDir, ghOut := makeStubDir(t)
-	writeStub(t, stubDir, "curl", `
-URL="${@: -1}"
-case "$URL" in
-  *\&page=1)
-    # 100 branches, none matching → triggers pagination.
-    echo -n '['
-    for i in $(seq 1 99); do
-      printf '{"name":"feat-%s"},' "$i"
-    done
-    printf '{"name":"feat-100"}'
-    echo ']'
-    ;;
-  *\&page=2)
-    echo '[{"name":"feature/77-found-it"}]'
-    ;;
-esac
-`)
-
-	env := map[string]string{
-		"GH_TOKEN":      "stub-token",
-		"REPO":          "owner/repo",
-		"ISSUE":         "77",
-		"GITHUB_OUTPUT": ghOut,
+	branches := make([]string, 0, 101)
+	for i := 1; i <= 100; i++ {
+		branches = append(branches, "feat-"+strconv.Itoa(i))
 	}
-	stdout, stderr, code := runScript(t, script, stubDir, env)
+	branches = append(branches, "feature/77-found-it")
+	writeStub(t, stubDir, "gh", ghResolveStub("owner/target-repo", branches...))
+
+	stdout, stderr, code := runScript(t, script, stubDir, resolveEnv("77", ghOut))
 	if code != 0 {
 		t.Fatalf("script exited %d: stdout=%s stderr=%s", code, stdout, stderr)
 	}
@@ -446,6 +415,7 @@ exit 99
 	env := map[string]string{
 		"GH_TOKEN":      "stub-token",
 		"GITHUB_OUTPUT": ghOut,
+		"CP_REPO":       "owner/cp-repo",
 	}
 	// substitute ${{ github.event.issue.number }} → 42
 	sub := substituteExpr(script, map[string]string{
@@ -480,6 +450,7 @@ if [ "$1" = "rev-list" ]; then echo 3; fi
 	env := map[string]string{
 		"GH_TOKEN":      "stub-token",
 		"GITHUB_OUTPUT": ghOut,
+		"CP_REPO":       "owner/cp-repo",
 	}
 	sub := substituteExpr(script, map[string]string{
 		"github.event.issue.number": "42",

--- a/skills/compliance-verify/SKILL.md
+++ b/skills/compliance-verify/SKILL.md
@@ -5,6 +5,7 @@ triggers: automated
 user-invocable: false
 loads:
   - skills/definitions/error-handling.md
+  - skills/definitions/cp-execution-context.md
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
   - skills/gh-agentic/SKILL.md
@@ -118,6 +119,14 @@ A return value at exit:
 
 ## Definitions
 
+- `skills/definitions/cp-execution-context.md` — the control-plane
+  execution context (#873): cwd is the project code
+  (`$AGENTIC_PROJECT_DIR`) where the diff and branch live; docs, the
+  rulebook, and the Feature issue live on the control plane
+  (`$AGENTIC_CP_ROOT`). Read docs/standards from `$AGENTIC_CP_ROOT`;
+  route Feature label / comment / report operations to the control
+  plane; the PR lives in the project repo; never write to the
+  control-plane checkout.
 - `skills/definitions/error-handling.md` — severity taxonomy for
   `INVALID_VERIFY_STATE`, `BRANCH_MISSING`, `REPORT_FAILED`.
 - `skills/definitions/verification-procedure.md` — evidence must be

--- a/skills/definitions/cp-execution-context.md
+++ b/skills/definitions/cp-execution-context.md
@@ -1,0 +1,129 @@
+# cp-execution-context.md — Control-plane execution context for pipeline phases
+
+This document defines the runtime context every **execution phase**
+(feature-design, dev-session, compliance-verify, pr-review-session)
+operates in under the control-plane-centralized model (#870, #873).
+
+It is the authoritative contract referenced by those skills. It makes
+concrete the read-only doc-consumer rule (carried from #855) and the
+"feature issues live on the control plane" keystone (#872) for the
+agent at execution time.
+
+---
+
+## The two anchors
+
+The pipeline runs **on the control plane**. Each execution phase checks
+the control plane out as the workspace root (the knowledge layer) and
+clones the feature's **target repo** into `./project` (the code). Two
+environment variables anchor the layout — both are exported by the
+pipeline before the recipe runs:
+
+| Anchor | Points at | Holds |
+|---|---|---|
+| `AGENTIC_CP_ROOT` | the workspace root | the framework mount (`.agents`), all project docs, `AGENTS.md` / `RULEBOOK.md` / `LOCALRULES.md`, `FEDERATION.md` — and is the repo where **issues live** |
+| `AGENTIC_PROJECT_DIR` | `./project` | the **code** — the target repo at the feature/PR branch. This is the agent's **current working directory** |
+
+In a single-topology project the target *is* the control plane, so both
+anchors resolve to the same repo checked out twice — the rules below
+still hold unchanged.
+
+**Legacy fallback.** When neither anchor is set (a pre-#873 single-repo
+checkout), the working directory is both the code and the knowledge
+root; every "`$AGENTIC_CP_ROOT/...`" path below falls back to the
+current directory, and "the control plane repo" falls back to the
+current repo. A skill MUST check for the anchor and fall back rather
+than assume it is set.
+
+---
+
+## Where each operation goes
+
+The agent's cwd is the **code** (`./project`), but the knowledge and the
+issues live on the **control plane**. Route every operation accordingly:
+
+| Operation | Target | How |
+|---|---|---|
+| Read a doc / brief / architecture | Control plane | read under `$AGENTIC_CP_ROOT/docs` (see *Reading docs*) |
+| Read the rulebook / skills / standards | Control plane | `$AGENTIC_CP_ROOT/.agents` (the recipe loads `$AGENTIC_CP_ROOT/AGENTS.md`) |
+| Feature / Requirement / Task issue read or write (view, label, comment, sub-issue, status) | Control plane | `gh ... --repo <CP>` where `<CP>` is the `owner/repo` of `$AGENTIC_CP_ROOT` |
+| Code edits, branches, commits, `git push` | Project | operate in cwd (`./project` / `$AGENTIC_PROJECT_DIR`) |
+| Pull-request create / read / comment / review | Project | `gh pr ... --repo <target>` (the PR lives where the code lives) |
+
+Resolve the two `owner/repo` strings once, at the top of the phase:
+
+```bash
+CP_REPO=$(git -C "${AGENTIC_CP_ROOT:-.}" remote get-url origin \
+  | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
+TARGET_REPO=$(git -C "${AGENTIC_PROJECT_DIR:-.}" remote get-url origin \
+  | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
+```
+
+Then pass `--repo "${CP_REPO}"` to every `gh issue` operation on the
+Feature, and `--repo "${TARGET_REPO}"` to every `gh pr` operation.
+
+> A cross-repo "Closes" reference (`Closes <CP>#<N>`) is required when a
+> PR in the target repo implements a Feature issue on the control plane;
+> GitHub's same-repo auto-close does not fire across repos. The
+> `feature-complete` pipeline stage closes the Feature explicitly, so the
+> reference is for human traceability, not automation.
+
+---
+
+## Reading docs — two tiers, control-plane-homed
+
+All project documentation lives on the control plane (#871). Resolve doc
+reads against `$AGENTIC_CP_ROOT/docs`, never against the project code
+(which carries no docs):
+
+- **System tier** — `$AGENTIC_CP_ROOT/docs/SYSTEM_BRIEF.md` and
+  `$AGENTIC_CP_ROOT/docs/SYSTEM_ARCHITECTURE.md` (federation only).
+- **Domain tier** — `$AGENTIC_CP_ROOT/docs/domains/<domain>/BRIEF.md`
+  and `.../ARCHITECTURE.md`, where `<domain>` is the target repo's
+  domain from `$AGENTIC_CP_ROOT/FEDERATION.md`.
+- **Single topology** — `$AGENTIC_CP_ROOT/docs/BRIEF.md` and
+  `.../ARCHITECTURE.md` (the unqualified pair; the repo *is* the project).
+
+See `concepts/knowledge-plane.md` for the full naming model.
+
+---
+
+## Read-only on the control plane
+
+The control-plane checkout is a **read-only knowledge root**, pinned at
+`main`. An execution phase **MUST NOT write to it**:
+
+- No commits to `$AGENTIC_CP_ROOT`. No `docs/new/` write-back to the
+  control plane — the per-feature architecture-integration write-back is
+  **not** performed by the pipeline. Architecture updates to the control
+  plane are separate human-driven PRs (`concepts/knowledge-plane.md`).
+- All file writes the phase makes — code, tests, design products under
+  `docs/design/feature-<N>/` — land in `$AGENTIC_PROJECT_DIR` (the
+  project repo), never in the control-plane root.
+
+The only durable effects an execution phase has on the control plane are
+**GitHub issue operations** (labels, comments, status, sub-issues) via
+`gh ... --repo <CP>` — never filesystem writes.
+
+---
+
+## Headless doc-insufficiency → halt and signal
+
+When an execution phase runs **headless** (no human in the loop) and
+finds the control-plane documentation insufficient to proceed correctly
+— missing architecture for the area being changed, an unscoped
+dependency, a contradiction it cannot resolve — it **halts** rather than
+guessing:
+
+1. Make **no** code commit and **no** control-plane commit.
+2. Apply the kickback label on the Feature issue (`--repo <CP>`):
+   `needs-scoping` when the gap is a scoping/requirements gap;
+   `needs-human-review` when the work cannot continue without a human
+   decision. Remove the current in-flight phase label.
+3. Post a comment on the Feature naming the gap precisely — which
+   document, which fact was missing, what decision is needed.
+4. Exit. A red/halted phase is the visible signal; a silent guess is the
+   failure mode this rule exists to prevent.
+
+In an **interactive** phase the agent surfaces the same gap to the human
+and waits, rather than applying a kickback label.

--- a/skills/definitions/recipe-pattern.md
+++ b/skills/definitions/recipe-pattern.md
@@ -122,14 +122,19 @@ set. Custom parameter names fail the lint.
 Extending the vocabulary requires updating this document
 explicitly. Do NOT add ad-hoc parameter names to recipes.
 
-**Note on the active repo.** Recipes do NOT pass `repo` — Goose
-runs in the workflow's checkout, so the working directory IS the
-active repo. Skills resolve it via
-`gh repo view --json nameWithOwner -q .nameWithOwner` when they
-need the `owner/name` string explicitly. If a future cross-repo
-use case arises (e.g., federated workflows acting on a repo other
-than the workspace), `repo` can be reintroduced as an optional
-parameter at that point.
+**Note on the active repo (control-plane execution).** Recipes do
+NOT pass `repo`. Under the control-plane-centralized model (#873) the
+pipeline exports two anchors instead: `AGENTIC_CP_ROOT` (the
+workspace root — the control plane, where docs and Feature issues
+live) and `AGENTIC_PROJECT_DIR` (`./project` — the target code, which
+is the agent's working directory). The recipe loads `AGENTS.md` from
+`$AGENTIC_CP_ROOT`; the skill routes operations per
+`skills/definitions/cp-execution-context.md` — issue/label/comment
+operations to the control plane, code/PR/git operations to the
+project. In a single-topology project both anchors resolve to the
+same repo, so the distinction is transparent. This is the cross-repo
+case the earlier note anticipated; it is handled by the anchors, not
+by a `repo` parameter.
 
 ## Recipes wrap automated / hybrid skills only
 

--- a/skills/dev-session/SKILL.md
+++ b/skills/dev-session/SKILL.md
@@ -5,6 +5,7 @@ triggers: automated
 user-invocable: false
 loads:
   - skills/definitions/error-handling.md
+  - skills/definitions/cp-execution-context.md
   - skills/definitions/concurrency-beacon.md
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
@@ -81,6 +82,14 @@ clears.
 
 ## Definitions
 
+- `skills/definitions/cp-execution-context.md` — the control-plane
+  execution context (#873): cwd is the project code
+  (`$AGENTIC_PROJECT_DIR`) where code, commits, and the feature branch
+  live; docs, the rulebook, and the Feature / Task issues live on the
+  control plane (`$AGENTIC_CP_ROOT`). Read docs from
+  `$AGENTIC_CP_ROOT/docs`; route Task / label / comment operations to
+  the control plane; commit and push only inside the project; never
+  write to the control-plane checkout.
 - `skills/definitions/error-handling.md` — severity taxonomy applied
   to `INVALID_DEV_STATE`, `BRANCH_MISSING`, `TASK_BLOCKED`,
   `TEST_FAILED_PERSISTENT`, `BUILD_FAILED_PERSISTENT`.

--- a/skills/feature-design/SKILL.md
+++ b/skills/feature-design/SKILL.md
@@ -5,6 +5,7 @@ triggers: hybrid
 user-invocable: true
 loads:
   - skills/definitions/error-handling.md
+  - skills/definitions/cp-execution-context.md
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
   - skills/definitions/state-model-pattern.md
@@ -116,6 +117,13 @@ the work.
 
 ## Definitions
 
+- `skills/definitions/cp-execution-context.md` — the control-plane
+  execution context (#873): cwd is the project code
+  (`$AGENTIC_PROJECT_DIR`); docs, the rulebook, and Feature issues live
+  on the control plane (`$AGENTIC_CP_ROOT`). Read architecture context
+  from `$AGENTIC_CP_ROOT/docs`; route Feature / Task / label / comment
+  operations to the control plane; never write to the control-plane
+  checkout; headless doc-insufficiency halts and signals.
 - `skills/definitions/error-handling.md` — severity taxonomy for
   `INVALID_DESIGN_STATE`, `RATIONALE_POST_FAILED`,
   `BRANCH_CREATION_FAILED`, `TASK_CREATION_FAILED`,
@@ -368,18 +376,38 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
    release the beacon (see step 18 happy-path and the slot-release
    rule in Error Handling).
 
-5. **Architecture context.** Read `docs/ARCHITECTURE.md` if it
-   exists; hold its contents as Slice SA context for the rationale.
-   If missing, surface a warning to the response stream:
+5. **Architecture context.** Read the architecture docs **from the
+   control plane** per `skills/definitions/cp-execution-context.md` —
+   the framework and docs live at `$AGENTIC_CP_ROOT`, not in the
+   project code (cwd). Resolve, in order:
 
-   ```
-   Note: docs/ARCHITECTURE.md is missing. Design will proceed
-   without architectural baseline. Slice SA mapping in the rationale
-   will be limited.
-   ```
+   - **Federation** — `$AGENTIC_CP_ROOT/docs/SYSTEM_ARCHITECTURE.md`
+     plus the target repo's domain architecture under
+     `$AGENTIC_CP_ROOT/docs/domains/<domain>/ARCHITECTURE.md`
+     (`<domain>` from `$AGENTIC_CP_ROOT/FEDERATION.md`).
+   - **Single topology** — `$AGENTIC_CP_ROOT/docs/ARCHITECTURE.md`.
+   - **Legacy (no anchor set)** — fall back to `docs/ARCHITECTURE.md`
+     in the current directory.
 
-   Continue. The hard gate for ARCHITECTURE.md lives at
-   requirements-session, not here.
+   Hold the contents as Slice SA context for the rationale.
+
+   If the relevant architecture doc is missing:
+
+   - **Interactive mode** — surface a warning and continue; the human
+     can supply context. The hard gate for ARCHITECTURE.md lives at
+     requirements-session, not here.
+
+     ```
+     Note: architecture doc not found on the control plane. Design will
+     proceed without architectural baseline. Slice SA mapping in the
+     rationale will be limited.
+     ```
+
+   - **Headless mode** — apply the doc-insufficiency halt from
+     `cp-execution-context.md`: make no commit, apply `needs-scoping`
+     on the Feature (`--repo <CP>`), comment naming the missing
+     document, release the beacon, and exit. A headless design phase
+     with no architectural baseline must not guess.
 
 ---
 
@@ -393,8 +421,8 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
 
    Wait for the human's reply. Continue the conversation until the
    human signals readiness (free-form, no prompt-user). Surface
-   architectural assessment from `docs/ARCHITECTURE.md` inline as
-   relevant.
+   architectural assessment from the architecture context loaded in
+   step 5 (the control-plane docs) inline as relevant.
 
 7. **Capture design products if produced. (interactive only)**
    During the conversation the human may share Figma URLs, sketch
@@ -444,8 +472,8 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
    ## Architectural Assessment
 
    <Slice SA mapping: linear addition / extension / novel.
-    What in docs/ARCHITECTURE.md does this touch or extend?
-    What new patterns are introduced, if any?>
+    What in the control-plane architecture docs (step 5) does this
+    touch or extend? What new patterns are introduced, if any?>
 
    ## Technical Approach
 

--- a/skills/gh-agentic/SKILL.md
+++ b/skills/gh-agentic/SKILL.md
@@ -274,6 +274,19 @@ Subcommands and flags:
   - `--vertical` — force vertical layout (no-op under `--raw`).
   - `--include-done`, `--this-repo`, `--raw`, `--verbose`.
 
+### `gh agentic feature` (group)
+
+Feature-level helpers used by the pipeline.
+
+Subcommands and flags:
+
+- `gh agentic feature target <number>` — resolve the implementation repo a
+  control-plane Feature targets (its "Target repo" ProjectV2 field). Prints
+  `owner/repo`; the owner is always the control-plane owner. When the field is
+  unset (single topology) it resolves to the current repo. The pipeline reads
+  this to know which repo to clone into `./project`.
+  - `--raw` — print only `owner/repo` on stdout (for scripting/CI).
+
 ---
 
 ## `--raw` Contract

--- a/skills/pr-review-session/SKILL.md
+++ b/skills/pr-review-session/SKILL.md
@@ -5,6 +5,7 @@ triggers: automated
 user-invocable: false
 loads:
   - skills/definitions/error-handling.md
+  - skills/definitions/cp-execution-context.md
   - skills/definitions/verification-procedure.md
   - skills/definitions/step-skip-rule.md
   - skills/definitions/commit-discipline.md
@@ -93,6 +94,13 @@ addressed.
 
 ## Definitions
 
+- `skills/definitions/cp-execution-context.md` — the control-plane
+  execution context (#873): cwd is the project code
+  (`$AGENTIC_PROJECT_DIR`) where the PR branch lives; the PR and its
+  review threads live in the project repo, while docs and the rulebook
+  live on the control plane (`$AGENTIC_CP_ROOT`). Read docs from
+  `$AGENTIC_CP_ROOT/docs`; commit and push fixes only inside the
+  project; never write to the control-plane checkout.
 - `skills/definitions/error-handling.md` — severity taxonomy for
   `INVALID_REVIEW_STATE`, `BRANCH_MISSING`, `REPLY_FAILED`,
   `COMMIT_DISCIPLINE_FAILED`, `CHANGE_BLOCKED`.


### PR DESCRIPTION
Closes #873, closes #887, closes #888, closes #889

Inverts the pipeline topology to the control-plane-centralized model (requirement #870): the pipeline runs **on the control plane**, which checks itself out as the read-only knowledge root and clones the feature's **target** repo into `./project`.

## Task 1 (#887) — `gh agentic feature target` (already merged-in on branch)
`gh agentic feature target <N> [--raw]` resolves a feature's target repo from the #872 Target-repo field (set → `<owner>/<bare>`; unset → current repo). Pure `resolveFeatureTarget` helper, unit-tested; SKILL.md updated (skill-sync passes).

## Task 2 (#888) — workflow rewrite
All four execution jobs (feature-design, dev-session, compliance-verify, pr-review-session) now use the CP-rooted / `./project` layout:
- **Knowledge root** = this repo (the CP) @ `main` at the workspace root (`.agents` + docs = `$AGENTIC_CP_ROOT`).
- **Target** resolved via `gh agentic feature target <N> --raw`; **code** cloned into `./project` (`$AGENTIC_PROJECT_DIR`) at the per-job ref.
- `/project/` isolated via `.git/info/exclude`; recipe + git ops run `working-directory: project` with an absolute recipe path into the CP mount.
- **CP vs target split**: Feature issue / label / comment / status → control plane (`--repo`); the PR is opened in and reviewed against the **target** repo; commits/push land only in `./project`.
- **Ordering**: respects the enforced no-`gh`-before-`setup-goose-env` rule (self-hosted runners lack `gh` until `install-ai-tools`): knowledge-root checkout → setup-goose-env → resolve → project checkout → anchors → recipe.
- **Single topology** resolves the target to the CP itself → identical layout.

## Task 3 (#889) — execution skills as read-only CP doc consumers
- New `skills/definitions/cp-execution-context.md`: the contract — two anchors, CP-vs-project routing, two-tier control-plane-homed doc reads, **read-only on the CP** (no commits, no `docs/new/` write-back), and the **headless doc-insufficiency halt** (no commit → kickback label → comment → exit).
- Wired into the four execution skills; `feature-design` step 5 now reads architecture from `$AGENTIC_CP_ROOT/docs` (system + domain tiers) and halts headlessly when the baseline is missing.
- Execution recipes load `AGENTS.md` from `$AGENTIC_CP_ROOT` (cwd is now the pure-code project); recipe-pattern note refreshed.

## Verification
- `go build ./...` clean; `go test ./...` green (step-ordering + `pipeline_scripts_exec` unit tests updated for the new resolve step and CP-targeted label edit); `gofmt`/`go vet` clean; `actionlint` shows no new issues.

## ⚠️ Pending live validation + open decisions
Per the design, the workflow + skill changes are **live-validation-only** — they can only be proven end-to-end against a real CP. Before merge/rollout:
- **Blocked on OpenBSS testbed migration** (grouped `FEDERATION.md` + a registered target repo) to validate a full feature run through the rewritten pipeline.
- **Federated PR-event trigger gap** (surfaced here): `pull_request_review` and the `feature-complete` PR-merge event fire in the **pure-code target repo**, which has no workflow — so they cannot auto-trigger the CP-hosted jobs for a federation. A CP-side PR-event trigger / forwarder is an open decision (flagged inline in the workflow). `pull_request_review` remains valid for single-topology (CP == target).
- **`issue-session` (Stage 4c)** is outside #873's four-phase scope and keeps the single-checkout model.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)