### PR TITLE
test: Layer 2 CP-root layout structure check (#873)

### DIFF
--- a/internal/mount/pipeline_layout_test.go
+++ b/internal/mount/pipeline_layout_test.go
@@ -1,0 +1,35 @@
+package mount
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestCPLayoutStructure runs the Layer 2 structure check
+// (scripts/test-cp-layout.sh) that reproduces the agentic-pipeline's
+// CP-rooted / ./project layout with real local clones and asserts every
+// filesystem invariant the recipe + execution skills depend on (#873).
+//
+// It is the regression gate for the control-plane-centralized layout: it
+// fails if the recipe/AGENTS.md/docs stop resolving from $AGENTIC_CP_ROOT,
+// if the project stops landing at ./project, or if the control-plane
+// checkout stops staying clean (the read-only-CP invariant).
+//
+// The check needs bash + git; it is skipped where either is unavailable.
+func TestCPLayoutStructure(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available — skipping CP layout structure check")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available — skipping CP layout structure check")
+	}
+
+	script := repoRelativePath(t, "scripts", "test-cp-layout.sh")
+
+	out, err := exec.Command(bash, script).CombinedOutput()
+	if err != nil {
+		t.Fatalf("CP layout structure check failed (%v):\n%s", err, out)
+	}
+	t.Logf("CP layout structure check passed:\n%s", out)
+}

--- a/scripts/test-cp-layout.sh
+++ b/scripts/test-cp-layout.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# test-cp-layout.sh — Layer 2 structure check for the control-plane-centralized
+# pipeline (#873).
+#
+# Reproduces the agentic-pipeline's CP-rooted / ./project layout with real LOCAL
+# clones — no network, no GitHub writes, no goose/agent — then asserts every
+# filesystem invariant the recipe and execution skills depend on. This is the
+# check that catches layout regressions (e.g. .agents resolving to the wrong
+# root) without a full end-to-end pipeline run.
+#
+# It mirrors the workflow's execution-job steps:
+#   1. Checkout knowledge root (CP @ main)   -> local clone of this repo
+#   2. Resolve target repo                    -> single: the CP itself
+#                                                federated: a scratch pure-code repo
+#   3. Checkout project (code) into ./project -> clone of the target
+#   4. Isolate project + export anchors       -> the REAL run-block, verbatim
+# then checks the resulting tree.
+#
+# Usage:  scripts/test-cp-layout.sh
+# Exit:   0 = all invariants hold; non-zero = a layout invariant failed.
+set -u
+
+# Repo root = the git toplevel containing this script.
+SRC="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "${SRC}" ] || [ ! -e "${SRC}/.github/workflows/agentic-pipeline.yml" ]; then
+  echo "::error::could not locate the gh-agentic repo root from $(dirname "$0")"
+  exit 2
+fi
+
+PASS=0; FAIL=0
+ok()  { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad() { printf '  \033[31m✗ %s\033[0m\n' "$1"; FAIL=$((FAIL+1)); }
+chk() { if eval "$2"; then ok "$1"; else bad "$1  [cmd: $2]"; fi; }
+
+# The exact "Isolate project and export anchors" run-block from agentic-pipeline.yml.
+# Kept verbatim so this check fails if the workflow's anchor contract drifts.
+isolate_and_anchors() {
+  local WS="$1" ENVFILE="$2"
+  ( cd "$WS" || exit 1
+    GITHUB_WORKSPACE="$WS"
+    GITHUB_ENV="$ENVFILE"
+    [ -d .git ] && echo '/project/' >> .git/info/exclude
+    echo "AGENTIC_CP_ROOT=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
+    echo "AGENTIC_PROJECT_DIR=${GITHUB_WORKSPACE}/project" >> "$GITHUB_ENV"
+  )
+}
+
+run_case() {
+  local NAME="$1" TARGET_SRC="$2" REF="$3"
+  echo ""
+  echo "=== Case: ${NAME} ==="
+  local ROOT; ROOT="$(mktemp -d)"
+  local WS="${ROOT}/ws"
+
+  # Step 1 — Checkout knowledge root (CP @ main) at the workspace root.
+  git clone --quiet "file://${SRC}" "${WS}" 2>/dev/null
+  git -C "${WS}" checkout --quiet main 2>/dev/null || true
+
+  # Step 3 — Checkout project (code) into ./project at the per-job ref.
+  git clone --quiet "file://${TARGET_SRC}" "${WS}/project" 2>/dev/null
+  [ -n "${REF}" ] && git -C "${WS}/project" checkout --quiet "${REF}" 2>/dev/null || true
+
+  # Step 4 — Isolate + export anchors (the real run-block).
+  local ENVFILE="${ROOT}/gh_env"; : > "${ENVFILE}"
+  isolate_and_anchors "${WS}" "${ENVFILE}"
+
+  # Load the exported anchors as the recipe step would see them.
+  # shellcheck disable=SC1090
+  set -a; . "${ENVFILE}"; set +a
+  echo "  AGENTIC_CP_ROOT=${AGENTIC_CP_ROOT}"
+  echo "  AGENTIC_PROJECT_DIR=${AGENTIC_PROJECT_DIR}"
+
+  # --- Invariants the recipe + skills depend on ---
+  chk "recipe resolves: \$AGENTIC_CP_ROOT/.agents/.goose/recipes/feature-design.yaml" \
+      "[ -f \"${AGENTIC_CP_ROOT}/.agents/.goose/recipes/feature-design.yaml\" ]"
+  chk "rulebook resolves: \$AGENTIC_CP_ROOT/AGENTS.md" \
+      "[ -f \"${AGENTIC_CP_ROOT}/AGENTS.md\" ]"
+  chk "docs resolve: \$AGENTIC_CP_ROOT/docs/ARCHITECTURE.md" \
+      "[ -f \"${AGENTIC_CP_ROOT}/docs/ARCHITECTURE.md\" ]"
+  chk "code present at \$AGENTIC_PROJECT_DIR (.git)" \
+      "[ -d \"${AGENTIC_PROJECT_DIR}/.git\" ]"
+  chk "/project/ in CP .git/info/exclude" \
+      "grep -qx '/project/' \"${AGENTIC_CP_ROOT}/.git/info/exclude\""
+  chk "CP working tree clean (./project invisible to it)" \
+      "[ -z \"\$(git -C \"${AGENTIC_CP_ROOT}\" status --porcelain)\" ]"
+  chk "composite action resolves: \$AGENTIC_CP_ROOT/.agents/.github/actions/setup-goose-env" \
+      "[ -d \"${AGENTIC_CP_ROOT}/.agents/.github/actions/setup-goose-env\" ]"
+
+  rm -rf "${ROOT}"
+}
+
+# --- Build a scratch pure-code domain repo as a federated target ---
+SCRATCH_PARENT="$(mktemp -d)"
+SCRATCH="${SCRATCH_PARENT}/domain-repo"
+mkdir -p "${SCRATCH}"
+git -C "${SCRATCH}" init --quiet
+git -C "${SCRATCH}" checkout --quiet -b main
+printf 'package main\nfunc main(){}\n' > "${SCRATCH}/main.go"
+git -C "${SCRATCH}" -c user.email=t@t -c user.name=t add -A
+git -C "${SCRATCH}" -c user.email=t@t -c user.name=t commit --quiet -m "code"
+git -C "${SCRATCH}" checkout --quiet -b feature/42-add-login
+printf '// feature work\n' >> "${SCRATCH}/main.go"
+git -C "${SCRATCH}" -c user.email=t@t -c user.name=t commit --quiet -am "wip"
+
+echo "=== scratch domain repo (must be pure code) ==="
+chk "domain repo has NO .agents" "[ ! -e \"${SCRATCH}/.agents\" ]"
+chk "domain repo has NO docs/"   "[ ! -e \"${SCRATCH}/docs\" ]"
+
+# Case 1: single-topology — target == CP (feature-design checks out the target @ main).
+run_case "single-topology (target = CP itself)" "${SRC}" "main"
+
+# Case 2: federated — target is a pure-code domain repo @ the feature branch.
+run_case "federated (target = pure-code domain repo @ feature branch)" "${SCRATCH}" "feature/42-add-login"
+
+rm -rf "${SCRATCH_PARENT}"
+
+echo ""
+echo "=================================================="
+printf "Layer 2 structure check: \033[32m%d passed\033[0m, " "${PASS}"
+if [ "${FAIL}" -gt 0 ]; then printf "\033[31m%d FAILED\033[0m\n" "${FAIL}"; else printf "%d failed\n" "${FAIL}"; fi
+echo "=================================================="
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
Persists the Layer 2 structure harness used to validate the #873 pipeline-on-control-plane pivot ([#901](https://github.com/eddiecarpenter/gh-agentic/pull/901)) as a repeatable regression gate.

## What it does
`scripts/test-cp-layout.sh` reproduces the agentic-pipeline's CP-rooted / `./project` layout with **real local clones** — no network, no GitHub writes, no goose/agent — then asserts every filesystem invariant the recipe and execution skills depend on:

- recipe (`feature-design.yaml`), `AGENTS.md`, `docs/`, and the `setup-goose-env` composite action all resolve from `$AGENTIC_CP_ROOT`
- the code lands at `$AGENTIC_PROJECT_DIR` (`./project`)
- `/project/` is written to the CP's `.git/info/exclude`
- the control-plane checkout stays **clean** (the read-only-CP invariant)

It runs both **single-topology** (target = the CP itself) and **federated** (target = a pure-code domain repo @ a feature branch, verified to carry no `.agents`/`docs`).

`TestCPLayoutStructure` (in `internal/mount`) runs the script under `go test`, so it executes in CI; it skips where bash or git is unavailable.

## Why
This is the layer that catches CP-layout drift — e.g. `.agents` resolving to the wrong root, the exact bug the #867 prototype hit — without needing a full end-to-end pipeline run. It complements the existing `pipeline_steps_test` (ordering) and `pipeline_scripts_exec_test` (per-step script execution) gates.

## Verification
`go test ./...` green (`TestCPLayoutStructure` passes in ~2s); `gofmt`/`go vet` clean. 16 invariants pass across both topologies.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)