### PR TITLE
feat: rename federation manifest to FEDERATION.yaml (back-compat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Most projects are **single-topology**: requirements, features, and code all live
 
 Federation is a **scoping-time concern, not a runtime one** — the *only* difference from single-topology is *where a feature issue gets created*. Everything downstream of scoping (design, dev-session, compliance verify, PR review) runs inside a single repo, unchanged.
 
-A repo becomes a federation requirements repo by adding a **`FEDERATION.md`** manifest at its root — a small YAML file listing the federation's implementation repos and what each is for:
+A repo becomes a federation requirements repo by adding a **`FEDERATION.yaml`** manifest at its root — a small YAML file listing the federation's implementation repos and what each is for:
 
 ```yaml
 repos:
@@ -151,9 +151,9 @@ The manifest's presence is the *sole* signal — no topology variable, no contro
 
 - **Scoping targets the right repo.** When you scope a requirement, the agent proposes a target repo for each feature from the manifest's purposes; you confirm or override. A feature must fit one repo — one spanning two is split at the decomposition checkpoint.
 - **Cross-repo sub-issues keep it coherent.** Each feature is created in its target repo and wired as a sub-issue of its requirement, so the requirement's progress is visible natively no matter where its features live (GitHub sub-issues work across repos within one owner).
-- **One project spans the federation.** `gh agentic status` answers "where is everything" across all linked repos, and a requirement closes only when all of its cross-repo features are done. `gh agentic check` keeps `FEDERATION.md` and the project's linked repos in sync.
+- **One project spans the federation.** `gh agentic status` answers "where is everything" across all linked repos, and a requirement closes only when all of its cross-repo features are done. `gh agentic check` keeps `FEDERATION.yaml` and the project's linked repos in sync.
 
-Implementation repos stay plain single-topology repos — no federation-specific config. A repo without `FEDERATION.md` behaves exactly as before.
+Implementation repos stay plain single-topology repos — no federation-specific config. A repo without `FEDERATION.yaml` behaves exactly as before.
 
 ### The workbench
 

--- a/concepts/knowledge-plane.md
+++ b/concepts/knowledge-plane.md
@@ -52,14 +52,14 @@ plane (see the domain documentation tier below).
 
 ### Federation topology
 
-The control plane declares its domains and their repos via `FEDERATION.md` at the
+The control plane declares its domains and their repos via `FEDERATION.yaml` at the
 repo root, and owns all knowledge for the federation; domain repos hold only code.
 
 **Control plane:**
 ```
 control-plane-repo/
 ├── .agents/                          # framework mount, read-only
-├── FEDERATION.md                     # declares all domains + their repos
+├── FEDERATION.yaml                     # declares all domains + their repos
 └── docs/
     ├── SYSTEM_BRIEF.md               # system orientation
     ├── SYSTEM_ARCHITECTURE.md        # seams between repos
@@ -78,7 +78,7 @@ plane outward, not from domain repos inward.
 
 #### Domain documentation tier (#871)
 
-Under the domain-grouped `FEDERATION.md` schema, a *domain* is one or more
+Under the domain-grouped `FEDERATION.yaml` schema, a *domain* is one or more
 repos, and a domain's documentation lives centrally on the control plane —
 not scattered across its member repos. The knowledge plane has exactly two
 tiers, both homed on the control plane:
@@ -87,7 +87,7 @@ tiers, both homed on the control plane:
   control-plane `docs/` root (e.g. `SYSTEM_BRIEF.md`, `SYSTEM_ARCHITECTURE.md`).
   Never decentralised into domain repos.
 - **Domain tier** — each domain's documentation under `docs/domains/<domain>/`,
-  where `<domain>` is the domain's slug from `FEDERATION.md`. A domain spanning
+  where `<domain>` is the domain's slug from `FEDERATION.yaml`. A domain spanning
   several repos therefore has a single documentation home.
 
 There is no separate per-service documentation tier: member repos carry code,
@@ -134,12 +134,12 @@ describe seams owned by another repo.
 ## Membership
 
 In federation topology, **every member repo is linked to the GitHub Project**.
-The control plane repo is identified by `FEDERATION.md` at its root — no
+The control plane repo is identified by `FEDERATION.yaml` at its root — no
 marker variable is required.
 
 Discovery:
 1. Query the Project's linked repositories — returns all N members
-2. Find the repo whose root contains `FEDERATION.md` — that is the control plane
+2. Find the repo whose root contains `FEDERATION.yaml` — that is the control plane
 3. The rest are pure-code domain repos (no `.agents`, no docs)
 
 The GitHub Project is the single source of truth for membership. A deleted
@@ -308,7 +308,7 @@ mechanism mirrors the `.agents/` mount used by the framework itself.
 
 For every session, session-init:
 
-1. Detects topology from `FEDERATION.md` presence (single or federation).
+1. Detects topology from `FEDERATION.yaml` presence (single or federation).
 2. Loads `docs/BRIEF.md` and `docs/ARCHITECTURE.md` from the local repo
    (single topology — the repo is its own control plane).
 3. For federation topology: loads `docs/SYSTEM_BRIEF.md` and
@@ -406,7 +406,7 @@ No `docs/decisions/` directory exists in either the CP or domain repos.
 Three artefacts from the framework's previous federation model have been removed:
 
 - **`docs/federation.yaml`** — replaced by GitHub Project linkage and later by
-  `FEDERATION.md`. Membership is now declared in `FEDERATION.md` at the control
+  `FEDERATION.yaml`. Membership is now declared in `FEDERATION.yaml` at the control
   plane repo root.
 - **`docs/requirements/`** — replaced by GitHub Issues. Requirements are
   Issues; there is no parallel filesystem artefact.

--- a/concepts/project-command.md
+++ b/concepts/project-command.md
@@ -10,23 +10,23 @@ and the `docs/` pattern), see `knowledge-plane.md`.
 
 ## Topology Model
 
-Topology is **derived from FEDERATION.md presence**, not from runtime variables.
+Topology is **derived from FEDERATION.yaml presence**, not from runtime variables.
 
 The rule is simple and binary:
 
-| `FEDERATION.md` at repo root | Topology |
+| `FEDERATION.yaml` at repo root | Topology |
 |---|---|
 | Present (valid YAML, domain-grouped `domains` list — may be empty) | **Federation** — this repo is the control plane |
 | Absent | **Single** — standalone repo (its own control plane), or a pure-code domain repo |
 
 `gh agentic` calls `project.IsFederationRepo(root)` — a single `os.Stat` check on
-`FEDERATION.md` — to classify any repo. No variable reads, no GraphQL queries, and
+`FEDERATION.yaml` — to classify any repo. No variable reads, no GraphQL queries, and
 no runtime environment are required. The topology is deterministic from the working tree.
 
-### FEDERATION.md format
+### FEDERATION.yaml format
 
 The control plane declares its domains — and the repos that implement them — in
-`FEDERATION.md` at the repo root. The file is valid YAML, **domain-grouped**
+`FEDERATION.yaml` at the repo root. The file is valid YAML, **domain-grouped**
 (#871): a list of domains, each with a purpose and the repos under it.
 
 ```yaml
@@ -47,10 +47,10 @@ Validation rules (enforced by `project.ReadFederation`):
 - Duplicate repo names are rejected
 - The flat `repos:` schema is no longer accepted (hard cut in #871)
 
-Domain repos (listed in `FEDERATION.md`) are **pure code** — no `.agents` mount,
+Domain repos (listed in `FEDERATION.yaml`) are **pure code** — no `.agents` mount,
 no docs, no pipeline workflow. They carry only an `AGENTIC_PROJECT_ID` repo
 variable, set when registered. The federation — including which domain each repo
-belongs to — is declared entirely from the control plane's `FEDERATION.md`; no
+belongs to — is declared entirely from the control plane's `FEDERATION.yaml`; no
 per-repo marker or domain variable is required.
 
 ---
@@ -108,7 +108,7 @@ plane** (#874), not in the domain repo:
 gh agentic project join <owner/repo> --domain <name> [--purpose <text>] [--domain-purpose <text>]
 ```
 
-It adds the target repo to the control plane's `FEDERATION.md` under the named
+It adds the target repo to the control plane's `FEDERATION.yaml` under the named
 domain (lazy-creating the domain if it does not exist yet), links the repo to the
 GitHub Project, and sets the target repo's `AGENTIC_PROJECT_ID`. It does **not**
 mount the framework into the target repo — domain repos stay pure code.
@@ -117,17 +117,17 @@ mount the framework into the target repo — domain repos stay pure code.
 
 | Current state | Behaviour |
 |---|---|
-| Not run on a control plane (no local `FEDERATION.md`) | **Block** — join is a control-plane operation |
+| Not run on a control plane (no local `FEDERATION.yaml`) | **Block** — join is a control-plane operation |
 | Target repo already a member of a different project | Warn + confirm (re-affiliation) |
 | Target repo already registered in this federation | Info only — no change |
 | Otherwise | Proceed |
 
 **Actions:**
-- Add the target repo to `FEDERATION.md` under `--domain` (via `AddRepo` + `WriteFederation`)
+- Add the target repo to `FEDERATION.yaml` under `--domain` (via `AddRepo` + `WriteFederation`)
 - Link the target repo to the GitHub Project
 - Set `AGENTIC_PROJECT_ID` on the target repo (no framework mount)
 
-The domain a repo belongs to is read from the control plane's `FEDERATION.md` —
+The domain a repo belongs to is read from the control plane's `FEDERATION.yaml` —
 no per-repo domain variable. Agents in a domain repo read system-level knowledge
 from the control plane via the GitHub API on demand.
 
@@ -158,7 +158,7 @@ Verifies project health. Reports:
 - `AGENTIC_PROJECT_ID` present and configured
 - Project exists and is accessible
 - Framework mounted and at expected version
-- FEDERATION.md valid (when present)
+- FEDERATION.yaml valid (when present)
 - Legacy federation config present (warns when pre-Feature-#824 topology variables or directory layout are still present)
 - Required variables and secrets present
 - Runner registered and reachable
@@ -179,8 +179,8 @@ before applying.
 
 Displays current project state:
 - Project name and ID
-- Topology (Single / Federation — derived from `FEDERATION.md` presence)
-- All domains and their repos (when `FEDERATION.md` is present)
+- Topology (Single / Federation — derived from `FEDERATION.yaml` presence)
+- All domains and their repos (when `FEDERATION.yaml` is present)
 - Framework version
 - Runner label
 
@@ -193,7 +193,7 @@ The content of `docs/` is defined by the knowledge plane. In brief:
 | Topology | Location | Writeable |
 |---|---|---|
 | Single (standalone repo, its own control plane) | Local `docs/` — holds both system-level and repo-level knowledge | Yes |
-| Federation (control plane) | Local `docs/` (system-level + `docs/domains/<domain>/`) + `FEDERATION.md` | Yes |
+| Federation (control plane) | Local `docs/` (system-level + `docs/domains/<domain>/`) + `FEDERATION.yaml` | Yes |
 
 In a federation, all knowledge — system-level and per-domain — lives on the
 control plane: system docs at the root (`SYSTEM_BRIEF.md`,
@@ -213,7 +213,7 @@ a federated project is:
 
 1. Create a new control plane repo with `gh agentic init` → federated (or
    `project create` with federated topology), which scaffolds an empty
-   `FEDERATION.md` plus the federated-tier system docs (#875).
+   `FEDERATION.yaml` plus the federated-tier system docs (#875).
 2. Migrate system-level content from the original repo's `docs/` into the new
    control plane's `docs/` as `SYSTEM_BRIEF.md` and `SYSTEM_ARCHITECTURE.md`.
 3. On the control plane, run `gh agentic project join <owner/repo> --domain <name>`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,7 +111,7 @@ operation and domain repos cannot drift.
 control-plane-repo/
 ├── .agents/                 ← tracked submodule → eddiecarpenter/gh-agentic@vX.Y.Z
 │   ├── RULEBOOK.md / skills/ / standards/ / concepts/ / recipes/
-├── FEDERATION.md            ← domain-grouped manifest (domains → repos)
+├── FEDERATION.yaml            ← domain-grouped manifest (domains → repos)
 ├── docs/                    ← SYSTEM_BRIEF, SYSTEM_ARCHITECTURE, docs/domains/<domain>/
 ├── CLAUDE.md / AGENTS.md / LOCALRULES.md   ← committed agent entry files
 └── .github/workflows/
@@ -122,7 +122,7 @@ control-plane-repo/
 
 A domain repo is **pure code** — no `.agents`, no docs, no pipeline workflow.
 It is registered with the control plane (added to the GitHub Project and
-`FEDERATION.md`, and given an `AGENTIC_PROJECT_ID` variable) via
+`FEDERATION.yaml`, and given an `AGENTIC_PROJECT_ID` variable) via
 `gh agentic project join` run on the control plane (#874), but nothing agentic is
 installed into it.
 
@@ -146,9 +146,9 @@ cannot drift.
 > are pure code. Migrating an existing federation is documented in
 > `docs/migration-cp-centralized.md`.
 
-### `FEDERATION.md` manifest
+### `FEDERATION.yaml` manifest
 
-The presence of `FEDERATION.md` at a repo's root signals that the repo is a
+The presence of `FEDERATION.yaml` at a repo's root signals that the repo is a
 federation control plane (`project.IsFederationRepo` is a stat-only check; a repo
 without it is single topology). The manifest is **domain-grouped** (#871) —
 domains, each with a purpose and the repos that implement it (a domain may span
@@ -174,10 +174,10 @@ info` lists the domains and their repos.
 
 - **Create a control plane** — `gh agentic init` → federated (or `gh agentic
   project create`) establishes the GitHub Project, scaffolds an empty
-  `FEDERATION.md` plus the federated-tier system docs (`docs/SYSTEM_BRIEF.md`,
+  `FEDERATION.yaml` plus the federated-tier system docs (`docs/SYSTEM_BRIEF.md`,
   `docs/SYSTEM_ARCHITECTURE.md`), and mounts the framework (#875).
 - **Register a domain repo** — `gh agentic project join <owner/repo> --domain
-  <name>`, run on the control plane, adds the repo to `FEDERATION.md` under the
+  <name>`, run on the control plane, adds the repo to `FEDERATION.yaml` under the
   named domain (lazy-creating the domain), links it to the Project, and sets its
   `AGENTIC_PROJECT_ID` — with **no framework mount** (#874).
 - **Feature issues live on the control plane**, each carrying a "Target repo"
@@ -189,7 +189,7 @@ info` lists the domains and their repos.
   `$AGENTIC_PROJECT_DIR`). Execution phases are read-only documentation consumers
   (#873, designed).
 - **One GitHub Project** spans the whole federation; `gh agentic status` answers
-  "where is everything", and `gh agentic check` / `repair` keep `FEDERATION.md`
+  "where is everything", and `gh agentic check` / `repair` keep `FEDERATION.yaml`
   and the Project's linked repos in sync.
 
 The two-tier knowledge plane (carried into #870) keeps system-level docs at the

--- a/docs/migration-cp-centralized.md
+++ b/docs/migration-cp-centralized.md
@@ -12,7 +12,7 @@ repos no longer have one).
 
 > **No-op for new federations.** A federation created on the current framework is
 > already CP-centralized — `gh agentic init` → federated scaffolds the
-> domain-grouped `FEDERATION.md` and federated-tier docs, `gh agentic project join`
+> domain-grouped `FEDERATION.yaml` and federated-tier docs, `gh agentic project join`
 > registers pure-code domain repos, and features are created on the control plane
 > from the start. There is nothing to migrate. See *No-op path* below.
 
@@ -25,7 +25,7 @@ repos no longer have one).
 | Where features live | In their target domain repo | On the **control plane** |
 | Feature → requirement link | **Cross-repo** sub-issues (#825) | **Same-repo** sub-issues on the CP (#872) |
 | Which repo a feature targets | Implied by the repo it lives in | A **"Target repo"** ProjectV2 field (#872) |
-| `FEDERATION.md` schema | Flat `repos:` | Domain-grouped `domains:` (#871) |
+| `FEDERATION.yaml` schema | Flat `repos:` | Domain-grouped `domains:` (#871) |
 | Domain registration | `project join` run in the domain repo, with a mount | `gh agentic project join <owner/repo> --domain <name>` run on the **CP**, no mount (#874) |
 
 The headline win: only the control plane carries anything agentic. Federation
@@ -36,22 +36,27 @@ maintenance collapses from N repos to one, and domain repos cannot drift.
 Run these on the control plane and confirm each before making changes:
 
 - [ ] **You are on the control plane.** `gh agentic info` reports Federation
-      topology and a local `FEDERATION.md` exists at the repo root.
-- [ ] **The manifest is on the domain-grouped schema.** `FEDERATION.md` uses
-      `domains:` (not the flat `repos:`). If it still uses `repos:`, convert it
-      first — group the existing repos under one or more `domains:` entries, each
-      with a `name` and `purpose`. `gh agentic check` validates the result.
-- [ ] **`FEDERATION.md` is a *pure YAML* file — not a markdown document.**
+      topology and a local federation manifest exists at the repo root —
+      `FEDERATION.yaml` (canonical) or the legacy `FEDERATION.md`.
+- [ ] **The manifest file is named `FEDERATION.yaml`.** The content was always
+      YAML; the `.yaml` extension makes that honest and lets editors/tooling treat
+      it as YAML. The framework still **reads** a legacy `FEDERATION.md` for
+      backward compatibility and migrates it to `FEDERATION.yaml` on the next
+      write (e.g. `gh agentic project join`). To migrate eagerly, just rename it:
+      `git mv FEDERATION.md FEDERATION.yaml`.
+- [ ] **The manifest is on the domain-grouped schema.** It uses `domains:` (not
+      the flat `repos:`). If it still uses `repos:`, convert it first — group the
+      existing repos under one or more `domains:` entries, each with a `name` and
+      `purpose`. `gh agentic check` validates the result.
+- [ ] **The manifest is a *pure YAML* file — not a markdown document.**
       `project.ReadFederation` (`internal/project/federation.go`) runs
-      `yaml.Unmarshal` over the **entire file**, so the file may contain *only*
-      YAML. A markdown manifest — architecture prose plus a fenced
-      ` ```yaml ` block — fails: the prose lines parse as YAML scalars and
-      `gh agentic info` / `check` abort with
-      `cannot unmarshal !!str into project.Federation`. If your `FEDERATION.md`
-      is a markdown doc, convert it: remove all prose and code-fence markers,
-      leaving the bare `domains:` mapping. Move any architecture narrative to
-      `docs/SYSTEM_ARCHITECTURE.md`, or keep short notes inline as YAML `#`
-      comments.
+      `yaml.Unmarshal` over the **entire file**, so it may contain *only* YAML.
+      A markdown manifest — architecture prose plus a fenced ` ```yaml ` block —
+      fails: the prose lines parse as YAML scalars and `gh agentic info` / `check`
+      abort with `cannot unmarshal !!str into project.Federation`. Remove all
+      prose and code-fence markers, leaving the bare `domains:` mapping. Move any
+      architecture narrative to `docs/SYSTEM_ARCHITECTURE.md`, or keep short notes
+      inline as YAML `#` comments.
 - [ ] **The control plane is at (or ahead of) the version that ships #870.** The
       "Target repo" field machinery (#872) and CP-side `join` (#874) must be
       available. `gh agentic check` confirms the field exists; `gh agentic repair`
@@ -66,7 +71,7 @@ If no features have been created in any domain repo (a federation that scoped
 requirements but never started feature work, or a brand-new federation), there is
 **nothing to relocate**. Complete only these steps:
 
-1. Confirm `FEDERATION.md` is domain-grouped and `gh agentic check` is clean.
+1. Confirm `FEDERATION.yaml` is domain-grouped and `gh agentic check` is clean.
 2. Run the **stale-`.agents` cleanup** (below) for each domain repo, in case any
    carried a mount under the old model.
 3. Done. New features will be created on the control plane with the "Target repo"
@@ -130,7 +135,7 @@ deleted.
 
 Under the old model each domain repo mounted the framework at `.agents/`. Under
 the CP-centralized model domain repos are **pure code** — the mount is stale and
-must be removed. For **each repo listed in the control plane's `FEDERATION.md`**:
+must be removed. For **each repo listed in the control plane's `FEDERATION.yaml`**:
 
 1. **Confirm it is a manifest domain repo**, not the control plane itself. The
    control plane keeps its `.agents/` mount; only domain repos shed it.
@@ -147,14 +152,14 @@ must be removed. For **each repo listed in the control plane's `FEDERATION.md`**
    domain repo reports it as *not under agentic control* — which is correct: the
    control plane is under control, the domain repo is just code. Running
    `gh agentic check` on the control plane confirms the repo is still a linked
-   Project member and present in `FEDERATION.md`.
+   Project member and present in `FEDERATION.yaml`.
 
 This is the re-scoped [#874] AC-3 (stale-`.agents` cleanup), homed here because it
-is a CP-side migration step performed where `FEDERATION.md` is local.
+is a CP-side migration step performed where `FEDERATION.yaml` is local.
 
 ## After migration
 
-- `FEDERATION.md` is domain-grouped, and every registered domain repo is pure code.
+- `FEDERATION.yaml` is domain-grouped, and every registered domain repo is pure code.
 - Every feature lives on the control plane with its "Target repo" field set and a
   same-repo sub-issue link to its requirement.
 - The pipeline runs only on the control plane; domain repos have no workflow.

--- a/docs/status-verification.md
+++ b/docs/status-verification.md
@@ -15,7 +15,7 @@ release.
 
 1. Point a shell at a gh-agentic repo that has an
    `AGENTIC_PROJECT_ID` variable set (for the federated checks, a
-   federation requirements repo — one carrying a `FEDERATION.md` manifest).
+   federation requirements repo — one carrying a `FEDERATION.yaml` manifest).
 2. Confirm `gh auth status` reports a logged-in user with access to the
    project board.
 3. Install the `gh-agentic` extension built from this branch.

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -306,7 +306,7 @@ func printInfo(w io.Writer, data *infoData) {
 		fmt.Fprintln(w, "  "+ui.SectionHeading.Render("Federation"))
 		fmt.Fprintln(w, "  "+ui.Divider(48))
 		if data.federationError != "" {
-			fmt.Fprintf(w, "  %s\n", ui.StatusWarning.Render("⚠ FEDERATION.md present but could not be parsed: "+data.federationError))
+			fmt.Fprintf(w, "  %s\n", ui.StatusWarning.Render("⚠ federation manifest present but could not be parsed: "+data.federationError))
 		} else {
 			fmt.Fprintf(w, "  This is a federation requirements repository.\n")
 			for _, d := range data.federationDomains {

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -61,14 +61,14 @@ func TestPrintInfo_FederationError_ShowsWarning(t *testing.T) {
 		version:         "v2.0.0",
 		repoLabel:       "acme/cp",
 		topology:        "Federation",
-		federationError: "FEDERATION.md: repos list is empty",
+		federationError: "FEDERATION.yaml: repos list is empty",
 	}
 	out := printInfoToString(data)
 	if !strings.Contains(out, "Federation") {
 		t.Errorf("expected 'Federation' section heading even on error, got:\n%s", out)
 	}
-	if !strings.Contains(out, "FEDERATION.md present but could not be parsed") {
-		t.Errorf("expected warning phrase 'FEDERATION.md present but could not be parsed', got:\n%s", out)
+	if !strings.Contains(out, "federation manifest present but could not be parsed") {
+		t.Errorf("expected warning phrase 'federation manifest present but could not be parsed', got:\n%s", out)
 	}
 	if !strings.Contains(out, "repos list is empty") {
 		t.Errorf("expected error text 'repos list is empty' in output, got:\n%s", out)

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -41,7 +41,7 @@ type CheckDeps struct {
 	CreateProjectField project.CreateProjectFieldFunc
 	// FetchLinkedRepos, FetchOwnerAndRepoIDs, and LinkRepoToProject are used
 	// by checkFederationProjectSync (check) and RepairPipeline (repair) to
-	// detect and fix drift between FEDERATION.md and the GitHub Project's
+	// detect and fix drift between FEDERATION.yaml and the GitHub Project's
 	// linked-repo graph. Tests substitute fakes; production wires the
 	// project.Default* implementations. LinkRepoToProject is repair-only; the
 	// check command leaves it nil.
@@ -236,7 +236,7 @@ func checksForTopologyWithLabels(deps CheckDeps) []checkGroupStep {
 	}
 
 	// Feature #874: a pure-code domain repo carries AGENTIC_PROJECT_ID but no
-	// .agents mount and no FEDERATION.md — the control plane holds the framework.
+	// .agents mount and no FEDERATION.yaml — the control plane holds the framework.
 	// It runs only the minimal checks: it is registered code, not a framework
 	// consumer, so mount/content/label/workflow checks do not apply.
 	if isPureCodeDomainRepo(deps) {
@@ -270,12 +270,12 @@ func checksForTopologyWithLabels(deps CheckDeps) []checkGroupStep {
 		// Target-repo field: required on federation control-plane projects (#872);
 		// skipped for single topology.
 		{"Checking project target-repo field...", checkProjectTargetRepoField},
-		// Federation manifest: validates FEDERATION.md when present; passes silently
+		// Federation manifest: validates FEDERATION.yaml when present; passes silently
 		// when absent (single topology).
 		{"Checking federation manifest...", checkFederationManifest},
 		// Federation project sync: checks that every manifest repo is linked to the
 		// federation's GitHub Project, and flags project-linked repos not in the
-		// manifest. Guard: skipped when FEDERATION.md is absent.
+		// manifest. Guard: skipped when FEDERATION.yaml is absent.
 		{"Checking federation project sync...", checkFederationProjectSync},
 		// Legacy federation config: warns when pre-#824 topology variables or .cp/
 		// directory are still present so operators know to clean them up.
@@ -302,7 +302,7 @@ func checkDomainRepo(deps CheckDeps) Group {
 // isPureCodeDomainRepo reports whether deps describes a registered pure-code
 // domain repo (#874): it carries AGENTIC_PROJECT_ID but has no .agents mount,
 // is not the framework source, and is not a federation requirements repo (no
-// FEDERATION.md). Such a repo is validated as code, not as a framework consumer.
+// FEDERATION.yaml). Such a repo is validated as code, not as a framework consumer.
 //
 // Detection is absence-based: a domain repo carrying a stale .agents from the
 // pre-pivot model is NOT distinguishable here from a single-topology repo, and
@@ -833,7 +833,7 @@ func checkProjectTargetRepoField(deps CheckDeps) Group {
 	return g
 }
 
-// checkFederationManifest validates the FEDERATION.md manifest when it is
+// checkFederationManifest validates the FEDERATION.yaml manifest when it is
 // present at deps.Root. When absent, the repo is single-topology and the
 // check passes unconditionally. When present but invalid, each error from
 // project.ReadFederation is surfaced as a Fail result with the exact error
@@ -845,7 +845,7 @@ func checkFederationManifest(deps CheckDeps) Group {
 		g.Results = append(g.Results, CheckResult{
 			Name:    "federation-manifest",
 			Status:  Pass,
-			Message: "FEDERATION.md not present (single topology)",
+			Message: "federation manifest not present (single topology)",
 		})
 		return g
 	}
@@ -863,7 +863,7 @@ func checkFederationManifest(deps CheckDeps) Group {
 	g.Results = append(g.Results, CheckResult{
 		Name:    "federation-manifest",
 		Status:  Pass,
-		Message: "FEDERATION.md is valid",
+		Message: "federation manifest is valid",
 	})
 
 	// Soft check (#871): each domain's documentation lives at
@@ -885,9 +885,9 @@ func checkFederationManifest(deps CheckDeps) Group {
 	return g
 }
 
-// checkFederationProjectSync validates that every repo listed in FEDERATION.md
+// checkFederationProjectSync validates that every repo listed in FEDERATION.yaml
 // is linked to the federation's GitHub Project, and flags project-linked repos
-// that are absent from the manifest. It is active only when FEDERATION.md is
+// that are absent from the manifest. It is active only when FEDERATION.yaml is
 // present; single-topology repos receive a single Pass result (guard AC-4).
 //
 // Result name conventions:
@@ -902,12 +902,12 @@ func checkFederationManifest(deps CheckDeps) Group {
 func checkFederationProjectSync(deps CheckDeps) Group {
 	g := Group{Name: "Federation project sync"}
 
-	// Guard AC-4: no FEDERATION.md → skip silently (single topology).
+	// Guard AC-4: no FEDERATION.yaml → skip silently (single topology).
 	if !project.IsFederationRepo(deps.Root) {
 		g.Results = append(g.Results, CheckResult{
 			Name:    "federation-sync",
 			Status:  Pass,
-			Message: "FEDERATION.md not present — federation sync check skipped",
+			Message: "federation manifest not present — federation sync check skipped",
 		})
 		return g
 	}
@@ -1014,7 +1014,7 @@ func checkFederationProjectSync(deps CheckDeps) Group {
 			g.Results = append(g.Results, CheckResult{
 				Name:    fmt.Sprintf("federation-sync:unlisted:%s", r.NameWithOwner),
 				Status:  Warning,
-				Message: fmt.Sprintf("project-linked repo %s is not in FEDERATION.md — add it to the manifest or unlink it from the project", r.NameWithOwner),
+				Message: fmt.Sprintf("project-linked repo %s is not in the federation manifest — add it to the manifest or unlink it from the project", r.NameWithOwner),
 			})
 		}
 	}
@@ -1025,20 +1025,20 @@ func checkFederationProjectSync(deps CheckDeps) Group {
 // checkLegacyFederationConfig detects remnants of the pre-#824 topology model.
 // It runs unconditionally regardless of topology so repos that still carry
 // the old variables or directory layout are flagged even when they have
-// already adopted FEDERATION.md. Each legacy artefact becomes a Warning with
+// already adopted FEDERATION.yaml. Each legacy artefact becomes a Warning with
 // a remediation command.
 func checkLegacyFederationConfig(deps CheckDeps) Group {
 	g := Group{Name: "Legacy federation config"}
 	found := 0
 
 	// AGENTIC_TOPOLOGY variable — was the old topology marker; replaced by
-	// FEDERATION.md presence detection in Feature #824.
+	// FEDERATION.yaml presence detection in Feature #824.
 	if deps.Run != nil {
 		if hit, _, _ := getRepoVariable(deps, "AGENTIC_TOPOLOGY"); hit {
 			g.Results = append(g.Results, CheckResult{
 				Name:        "legacy-topology",
 				Status:      Warning,
-				Message:     "AGENTIC_TOPOLOGY is set — no longer used; topology is now inferred from FEDERATION.md presence",
+				Message:     "AGENTIC_TOPOLOGY is set — no longer used; topology is now inferred from FEDERATION.yaml presence",
 				Remediation: "gh variable delete AGENTIC_TOPOLOGY --repo " + deps.RepoFullName,
 			})
 			found++
@@ -1046,7 +1046,7 @@ func checkLegacyFederationConfig(deps CheckDeps) Group {
 	}
 
 	// AGENTIC_CONTROL_PLANE variable — was written by the old federated init
-	// flow; the FEDERATION.md manifest supersedes it.
+	// flow; the FEDERATION.yaml manifest supersedes it.
 	if deps.Run != nil {
 		if hit, _, _ := getRepoVariable(deps, "AGENTIC_CONTROL_PLANE"); hit {
 			g.Results = append(g.Results, CheckResult{

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1291,8 +1291,8 @@ func TestCheckFederationManifest_MalformedYAML_Fail(t *testing.T) {
 	if r.Status != Fail {
 		t.Errorf("status: got %v, want Fail", r.Status)
 	}
-	if !strings.Contains(r.Message, "FEDERATION.md") {
-		t.Errorf("message: got %q, expected 'FEDERATION.md' prefix", r.Message)
+	if !strings.Contains(r.Message, "FEDERATION.yaml") {
+		t.Errorf("message: got %q, expected 'FEDERATION.yaml' prefix", r.Message)
 	}
 }
 
@@ -1743,8 +1743,8 @@ func TestCheckFederationProjectSync_ProjectLinkedRepoNotInManifest_Warns(t *test
 	if warnResult.Name != "federation-sync:unlisted:acme/extra" {
 		t.Errorf("name: got %q, want federation-sync:unlisted:acme/extra", warnResult.Name)
 	}
-	if !strings.Contains(warnResult.Message, "FEDERATION.md") {
-		t.Errorf("message: got %q, want FEDERATION.md mention", warnResult.Message)
+	if !strings.Contains(warnResult.Message, "federation manifest") {
+		t.Errorf("message: got %q, want federation manifest mention", warnResult.Message)
 	}
 }
 

--- a/internal/init/wizard.go
+++ b/internal/init/wizard.go
@@ -97,7 +97,7 @@ func Run(w io.Writer, root string, force bool, deps Deps) error {
 //
 // All variables and secrets are written at --repo scope. The org-scope
 // routing that existed under the old federated topology has been removed
-// as part of Feature #824 — topology is now determined by FEDERATION.md
+// as part of Feature #824 — topology is now determined by FEDERATION.yaml
 // presence, not by variable-level scoping.
 func ConfigureRepo(w io.Writer, cfg *InitConfig, run RunCommandFunc) error {
 	repo := cfg.RepoFullName

--- a/internal/project/federation.go
+++ b/internal/project/federation.go
@@ -31,7 +31,7 @@ type FederationDomain struct {
 	Repos []FederationRepo `yaml:"repos"`
 }
 
-// Federation holds the parsed contents of a FEDERATION.md manifest file.
+// Federation holds the parsed contents of a federation manifest file (FEDERATION.yaml).
 type Federation struct {
 	// Domains groups the federation's repos under the domains they implement.
 	Domains []FederationDomain `yaml:"domains"`
@@ -43,8 +43,30 @@ type flatFederation struct {
 	Repos []FederationRepo `yaml:"repos"`
 }
 
-// federationFileName is the canonical name of the federation manifest file.
-const federationFileName = "FEDERATION.md"
+// federationFileName is the canonical name of the federation manifest file. Its
+// content is YAML, so it carries a .yaml extension. The legacy .md name is still
+// read for backward compatibility (see manifestReadPath) and migrated to .yaml
+// on the next write (see WriteFederation).
+const federationFileName = "FEDERATION.yaml"
+
+// legacyFederationFileName is the pre-v3.0.1 manifest name. The file was always
+// YAML; the .md extension was a historical mislabel. Still read, never written.
+const legacyFederationFileName = "FEDERATION.md"
+
+// manifestReadPath returns the manifest path to read at root: the canonical
+// FEDERATION.yaml when present, else the legacy FEDERATION.md, else the canonical
+// path (so a not-found error names the file callers should create).
+func manifestReadPath(root string) string {
+	canonical := filepath.Join(root, federationFileName)
+	if _, err := os.Stat(canonical); err == nil {
+		return canonical
+	}
+	legacy := filepath.Join(root, legacyFederationFileName)
+	if _, err := os.Stat(legacy); err == nil {
+		return legacy
+	}
+	return canonical
+}
 
 // domainNamePattern validates a domain name as a filesystem-safe slug, since
 // each domain maps to a docs/domains/<name>/ folder.
@@ -61,44 +83,48 @@ func (f *Federation) AllRepos() []FederationRepo {
 	return repos
 }
 
-// IsFederationRepo returns true when a FEDERATION.md file exists at root.
-// It uses os.Stat only — no YAML decode — so it is fast and has no side effects.
-// A false return means the repo is single topology; no further federation config
-// is required.
+// IsFederationRepo returns true when a federation manifest exists at root —
+// FEDERATION.yaml (canonical) or the legacy FEDERATION.md. It uses os.Stat only —
+// no YAML decode — so it is fast and has no side effects. A false return means
+// the repo is single topology; no further federation config is required.
 func IsFederationRepo(root string) bool {
-	_, err := os.Stat(filepath.Join(root, federationFileName))
+	if _, err := os.Stat(filepath.Join(root, federationFileName)); err == nil {
+		return true
+	}
+	_, err := os.Stat(filepath.Join(root, legacyFederationFileName))
 	return err == nil
 }
 
-// ReadFederation reads and validates the domain-grouped FEDERATION.md manifest
-// at root. It returns the first validation error found:
-//   - file present but empty → "FEDERATION.md: file is empty"
-//   - YAML parse error → "FEDERATION.md: YAML parse error: <detail>"
-//   - legacy flat `repos:` schema → "FEDERATION.md: flat `repos:` schema is no longer supported — group repos under `domains:`"
-//   - domains list absent or empty → "FEDERATION.md: domains list is empty"
-//   - domain missing name → "FEDERATION.md: domain N: name is required"
-//   - domain name not a slug → "FEDERATION.md: domain <name>: name must be a lowercase slug ([a-z0-9-])"
-//   - domain missing/blank purpose → "FEDERATION.md: domain <name>: purpose is required"
-//   - duplicate domain → "FEDERATION.md: duplicate domain <name>"
-//   - domain with no repos → "FEDERATION.md: domain <name>: repos list is empty"
-//   - repo missing name → "FEDERATION.md: domain <name>: repo N: name is required"
-//   - repo missing/blank purpose → "FEDERATION.md: domain <name>: repo <name>: purpose is required"
-//   - repo name not owner/repo → "FEDERATION.md: domain <name>: repo <name>: name must be in owner/repo format"
-//   - duplicate repo across the manifest → "FEDERATION.md: duplicate repo <name>"
+// ReadFederation reads and validates the domain-grouped FEDERATION.yaml manifest
+// at root (falling back to the legacy FEDERATION.md). It returns the first
+// validation error found:
+//   - file present but empty → "FEDERATION.yaml: file is empty"
+//   - YAML parse error → "FEDERATION.yaml: YAML parse error: <detail>"
+//   - legacy flat `repos:` schema → "FEDERATION.yaml: flat `repos:` schema is no longer supported — group repos under `domains:`"
+//   - domains list absent or empty → "FEDERATION.yaml: domains list is empty"
+//   - domain missing name → "FEDERATION.yaml: domain N: name is required"
+//   - domain name not a slug → "FEDERATION.yaml: domain <name>: name must be a lowercase slug ([a-z0-9-])"
+//   - domain missing/blank purpose → "FEDERATION.yaml: domain <name>: purpose is required"
+//   - duplicate domain → "FEDERATION.yaml: duplicate domain <name>"
+//   - domain with no repos → "FEDERATION.yaml: domain <name>: repos list is empty"
+//   - repo missing name → "FEDERATION.yaml: domain <name>: repo N: name is required"
+//   - repo missing/blank purpose → "FEDERATION.yaml: domain <name>: repo <name>: purpose is required"
+//   - repo name not owner/repo → "FEDERATION.yaml: domain <name>: repo <name>: name must be in owner/repo format"
+//   - duplicate repo across the manifest → "FEDERATION.yaml: duplicate repo <name>"
 func ReadFederation(root string) (*Federation, error) {
-	path := filepath.Join(root, federationFileName)
+	path := manifestReadPath(root)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("FEDERATION.md: %w", err)
+		return nil, fmt.Errorf("FEDERATION.yaml: %w", err)
 	}
 
 	if len(strings.TrimSpace(string(data))) == 0 {
-		return nil, fmt.Errorf("FEDERATION.md: file is empty")
+		return nil, fmt.Errorf("FEDERATION.yaml: file is empty")
 	}
 
 	var fed Federation
 	if err := yaml.Unmarshal(data, &fed); err != nil {
-		return nil, fmt.Errorf("FEDERATION.md: YAML parse error: %s", err.Error())
+		return nil, fmt.Errorf("FEDERATION.yaml: YAML parse error: %s", err.Error())
 	}
 
 	if len(fed.Domains) == 0 {
@@ -107,7 +133,7 @@ func ReadFederation(root string) (*Federation, error) {
 		// domains registered yet (domains are added later via `project join`).
 		var flat flatFederation
 		if yaml.Unmarshal(data, &flat) == nil && len(flat.Repos) > 0 {
-			return nil, fmt.Errorf("FEDERATION.md: flat `repos:` schema is no longer supported — group repos under `domains:`")
+			return nil, fmt.Errorf("FEDERATION.yaml: flat `repos:` schema is no longer supported — group repos under `domains:`")
 		}
 		return &fed, nil
 	}
@@ -129,37 +155,37 @@ func validateFederation(fed *Federation) error {
 	for di, d := range fed.Domains {
 		domainNo := di + 1
 		if d.Name == "" {
-			return fmt.Errorf("FEDERATION.md: domain %d: name is required", domainNo)
+			return fmt.Errorf("FEDERATION.yaml: domain %d: name is required", domainNo)
 		}
 		if !domainNamePattern.MatchString(d.Name) {
-			return fmt.Errorf("FEDERATION.md: domain %q: name must be a lowercase slug ([a-z0-9-])", d.Name)
+			return fmt.Errorf("FEDERATION.yaml: domain %q: name must be a lowercase slug ([a-z0-9-])", d.Name)
 		}
 		if strings.TrimSpace(d.Purpose) == "" {
-			return fmt.Errorf("FEDERATION.md: domain %q: purpose is required", d.Name)
+			return fmt.Errorf("FEDERATION.yaml: domain %q: purpose is required", d.Name)
 		}
 		domainKey := strings.ToLower(d.Name)
 		if seenDomain[domainKey] {
-			return fmt.Errorf("FEDERATION.md: duplicate domain %q", d.Name)
+			return fmt.Errorf("FEDERATION.yaml: duplicate domain %q", d.Name)
 		}
 		seenDomain[domainKey] = true
 
 		if len(d.Repos) == 0 {
-			return fmt.Errorf("FEDERATION.md: domain %q: repos list is empty", d.Name)
+			return fmt.Errorf("FEDERATION.yaml: domain %q: repos list is empty", d.Name)
 		}
 		for ri, repo := range d.Repos {
 			repoNo := ri + 1
 			if repo.Name == "" {
-				return fmt.Errorf("FEDERATION.md: domain %q: repo %d: name is required", d.Name, repoNo)
+				return fmt.Errorf("FEDERATION.yaml: domain %q: repo %d: name is required", d.Name, repoNo)
 			}
 			if strings.TrimSpace(repo.Purpose) == "" {
-				return fmt.Errorf("FEDERATION.md: domain %q: repo %q: purpose is required", d.Name, repo.Name)
+				return fmt.Errorf("FEDERATION.yaml: domain %q: repo %q: purpose is required", d.Name, repo.Name)
 			}
 			if !isValidOwnerRepo(repo.Name) {
-				return fmt.Errorf("FEDERATION.md: domain %q: repo %q: name must be in owner/repo format", d.Name, repo.Name)
+				return fmt.Errorf("FEDERATION.yaml: domain %q: repo %q: name must be in owner/repo format", d.Name, repo.Name)
 			}
 			repoKey := strings.ToLower(repo.Name)
 			if seenRepo[repoKey] {
-				return fmt.Errorf("FEDERATION.md: duplicate repo %q", repo.Name)
+				return fmt.Errorf("FEDERATION.yaml: duplicate repo %q", repo.Name)
 			}
 			seenRepo[repoKey] = true
 		}
@@ -201,7 +227,7 @@ func (f *Federation) AddRepo(domain, domainPurpose, repoName, repoPurpose string
 	return true, nil
 }
 
-// WriteFederation writes the domain-grouped manifest to FEDERATION.md at root,
+// WriteFederation writes the domain-grouped manifest to FEDERATION.yaml at root,
 // round-tripping the schema ReadFederation parses. The manifest is validated
 // before writing so a malformed in-memory Federation never reaches disk.
 func WriteFederation(root string, fed *Federation) error {
@@ -210,10 +236,16 @@ func WriteFederation(root string, fed *Federation) error {
 	}
 	data, err := yaml.Marshal(fed)
 	if err != nil {
-		return fmt.Errorf("FEDERATION.md: marshalling: %w", err)
+		return fmt.Errorf("FEDERATION.yaml: marshalling: %w", err)
 	}
 	if err := os.WriteFile(filepath.Join(root, federationFileName), data, 0644); err != nil {
-		return fmt.Errorf("FEDERATION.md: %w", err)
+		return fmt.Errorf("FEDERATION.yaml: %w", err)
+	}
+	// Migrate a legacy FEDERATION.md to the canonical name: now that the .yaml
+	// manifest is written, the old .md would be a stale duplicate. Best-effort.
+	legacy := filepath.Join(root, legacyFederationFileName)
+	if _, err := os.Stat(legacy); err == nil {
+		_ = os.Remove(legacy)
 	}
 	return nil
 }

--- a/internal/project/federation_test.go
+++ b/internal/project/federation_test.go
@@ -420,3 +420,67 @@ func TestFederation_AddRepo_RejectsDuplicate(t *testing.T) {
 		t.Fatal("expected a duplicate-repo error (case-insensitive) across domains")
 	}
 }
+
+// --- Backward compatibility: legacy FEDERATION.md (v3.0.1 rename) ---
+
+func TestIsFederationRepo_LegacyMdOnly_ReturnsTrue(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, legacyFederationFileName), []byte(validManifest), 0644); err != nil {
+		t.Fatalf("writing legacy manifest: %v", err)
+	}
+	if !IsFederationRepo(dir) {
+		t.Error("IsFederationRepo: expected true when only the legacy FEDERATION.md exists")
+	}
+}
+
+func TestReadFederation_LegacyMdOnly_Parsed(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, legacyFederationFileName), []byte(validManifest), 0644); err != nil {
+		t.Fatalf("writing legacy manifest: %v", err)
+	}
+	fed, err := ReadFederation(dir)
+	if err != nil {
+		t.Fatalf("ReadFederation (legacy .md): %v", err)
+	}
+	if len(fed.Domains) != 2 {
+		t.Errorf("expected 2 domains from legacy manifest, got %d", len(fed.Domains))
+	}
+}
+
+func TestReadFederation_PrefersYamlOverLegacyMd(t *testing.T) {
+	dir := t.TempDir()
+	// Legacy .md has one domain; canonical .yaml has the two-domain validManifest.
+	legacy := "domains:\n  - name: legacy\n    purpose: old\n    repos:\n      - name: o/r\n        purpose: p\n"
+	if err := os.WriteFile(filepath.Join(dir, legacyFederationFileName), []byte(legacy), 0644); err != nil {
+		t.Fatalf("writing legacy manifest: %v", err)
+	}
+	writeManifest(t, dir, validManifest) // writes FEDERATION.yaml
+	fed, err := ReadFederation(dir)
+	if err != nil {
+		t.Fatalf("ReadFederation: %v", err)
+	}
+	if len(fed.Domains) != 2 || fed.Domains[0].Name == "legacy" {
+		t.Errorf("expected canonical FEDERATION.yaml to win, got domains %+v", fed.Domains)
+	}
+}
+
+func TestWriteFederation_WritesYamlAndMigratesLegacyMd(t *testing.T) {
+	dir := t.TempDir()
+	// Start from a legacy-only manifest.
+	if err := os.WriteFile(filepath.Join(dir, legacyFederationFileName), []byte(validManifest), 0644); err != nil {
+		t.Fatalf("writing legacy manifest: %v", err)
+	}
+	fed, err := ReadFederation(dir)
+	if err != nil {
+		t.Fatalf("ReadFederation: %v", err)
+	}
+	if err := WriteFederation(dir, fed); err != nil {
+		t.Fatalf("WriteFederation: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, federationFileName)); err != nil {
+		t.Errorf("expected FEDERATION.yaml to be written, stat err: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, legacyFederationFileName)); !os.IsNotExist(err) {
+		t.Errorf("expected legacy FEDERATION.md to be removed after write, stat err: %v", err)
+	}
+}

--- a/internal/project/scaffold_federation.go
+++ b/internal/project/scaffold_federation.go
@@ -25,9 +25,9 @@ var systemDocTemplates = map[string]string{
 func ScaffoldFederation(w io.Writer, root string) error {
 	if !IsFederationRepo(root) {
 		if err := WriteFederation(root, &Federation{}); err != nil {
-			return fmt.Errorf("scaffolding FEDERATION.md: %w", err)
+			return fmt.Errorf("scaffolding FEDERATION.yaml: %w", err)
 		}
-		fmt.Fprintf(w, "  %s  FEDERATION.md scaffolded (no domains registered yet)\n", ui.StatusOK.Render("✓"))
+		fmt.Fprintf(w, "  %s  FEDERATION.yaml scaffolded (no domains registered yet)\n", ui.StatusOK.Render("✓"))
 	}
 
 	for path, tmpl := range systemDocTemplates {

--- a/skills/definitions/cp-execution-context.md
+++ b/skills/definitions/cp-execution-context.md
@@ -21,7 +21,7 @@ pipeline before the recipe runs:
 
 | Anchor | Points at | Holds |
 |---|---|---|
-| `AGENTIC_CP_ROOT` | the workspace root | the framework mount (`.agents`), all project docs, `AGENTS.md` / `RULEBOOK.md` / `LOCALRULES.md`, `FEDERATION.md` — and is the repo where **issues live** |
+| `AGENTIC_CP_ROOT` | the workspace root | the framework mount (`.agents`), all project docs, `AGENTS.md` / `RULEBOOK.md` / `LOCALRULES.md`, `FEDERATION.yaml` — and is the repo where **issues live** |
 | `AGENTIC_PROJECT_DIR` | `./project` | the **code** — the target repo at the feature/PR branch. This is the agent's **current working directory** |
 
 In a single-topology project the target *is* the control plane, so both
@@ -80,7 +80,7 @@ reads against `$AGENTIC_CP_ROOT/docs`, never against the project code
   `$AGENTIC_CP_ROOT/docs/SYSTEM_ARCHITECTURE.md` (federation only).
 - **Domain tier** — `$AGENTIC_CP_ROOT/docs/domains/<domain>/BRIEF.md`
   and `.../ARCHITECTURE.md`, where `<domain>` is the target repo's
-  domain from `$AGENTIC_CP_ROOT/FEDERATION.md`.
+  domain from `$AGENTIC_CP_ROOT/FEDERATION.yaml`.
 - **Single topology** — `$AGENTIC_CP_ROOT/docs/BRIEF.md` and
   `.../ARCHITECTURE.md` (the unqualified pair; the repo *is* the project).
 

--- a/skills/feature-design/SKILL.md
+++ b/skills/feature-design/SKILL.md
@@ -384,7 +384,7 @@ human-driven recovery via `gh agentic repair` plus manual finishing.
    - **Federation** — `$AGENTIC_CP_ROOT/docs/SYSTEM_ARCHITECTURE.md`
      plus the target repo's domain architecture under
      `$AGENTIC_CP_ROOT/docs/domains/<domain>/ARCHITECTURE.md`
-     (`<domain>` from `$AGENTIC_CP_ROOT/FEDERATION.md`).
+     (`<domain>` from `$AGENTIC_CP_ROOT/FEDERATION.yaml`).
    - **Single topology** — `$AGENTIC_CP_ROOT/docs/ARCHITECTURE.md`.
    - **Legacy (no anchor set)** — fall back to `docs/ARCHITECTURE.md`
      in the current directory.

--- a/skills/gh-agentic/SKILL.md
+++ b/skills/gh-agentic/SKILL.md
@@ -235,7 +235,7 @@ Subcommands and flags:
   - `--version` — framework version to mount (default: latest).
   - `--interactive` (`-i`) — collect title + version via form.
 - `gh agentic project join <owner/repo>` — CP-side: register a domain repo with
-  this control plane (writes `FEDERATION.md`, links the Project, sets the target
+  this control plane (writes `FEDERATION.yaml`, links the Project, sets the target
   repo's `AGENTIC_PROJECT_ID`; **no framework mount** — domain repos are pure code).
   - `--domain` — domain the repo belongs to (required; lazy-created if new).
   - `--purpose` — the repo's purpose within its domain.

--- a/skills/requirement-scoping/SKILL.md
+++ b/skills/requirement-scoping/SKILL.md
@@ -305,7 +305,7 @@ on it:
    verbatim into Feature bodies (they're context, not source).
 
    **Federation manifest detection.** Check whether the active repo
-   is a federation requirements repo by testing for `FEDERATION.md`
+   is a federation requirements repo by testing for `FEDERATION.yaml`
    at the repo root:
 
    - **Present** → read it with the `Read` tool (NOT shell parsing)


### PR DESCRIPTION
The federation manifest's content is YAML, but the file was named **`FEDERATION.md`** — which lied to humans and tooling: editors apply Markdown highlighting/linting, and YAML language servers / schema validation don't recognise it by extension. The file even carried a comment explaining *"this WHOLE file is parsed as YAML."* That explanatory comment existing at all was the tell.

This renames the canonical manifest to **`FEDERATION.yaml`**, so the extension matches the content.

## Backward-compatible — non-breaking
- `ReadFederation` / `IsFederationRepo` resolve `FEDERATION.yaml` first, then fall back to a legacy `FEDERATION.md` (new `manifestReadPath` helper).
- `WriteFederation` always writes `FEDERATION.yaml` and removes a legacy `FEDERATION.md`, so the next write (e.g. `gh agentic project join`) **auto-migrates** a repo. Existing federations keep working untouched until then.

No decision issue / hard-cut migration needed precisely *because* nothing existing breaks.

## Also in this PR
- Error / doctor / info messages say `FEDERATION.yaml` or the generic "federation manifest".
- `ScaffoldFederation` writes `FEDERATION.yaml`.
- Docs / skills / concepts / `README` updated; the migration runbook gains an eager `git mv FEDERATION.md FEDERATION.yaml` step and a back-compat note.
- New tests: legacy-`.md` read, `.yaml`-preferred-over-`.md`, and write-migrates-`.md`.

## Verification
`go build ./...`, `go vet`, `gofmt`, `go test ./...` all clean. No CLI surface change (no new command/flag) → no skill-sync impact.

## Follow-up (separate, not in this PR)
Live control planes (e.g. `OpenBSS/openbss`) can `git mv FEDERATION.md FEDERATION.yaml` at leisure — back-compat means they keep working until they do. Worth a patch release (`v3.0.1`) to ship.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)