### PR TITLE
fix: grant actions: read in the pipeline wrapper template

### DIFF
--- a/internal/mount/templates/agentic-pipeline.yml.tmpl
+++ b/internal/mount/templates/agentic-pipeline.yml.tmpl
@@ -27,7 +27,13 @@ jobs:
       pr_number: ${{ inputs.pr_number || '' }}
       branch_name: ${{ inputs.branch_name || '' }}
     secrets: inherit
+    # The caller must grant at least the union of every nested job's permissions;
+    # a called job cannot request more than the caller grants. The execution jobs
+    # request actions: read (e.g. to read workflow run state), so it is required
+    # here — without it the reusable-workflow call fails to load (startup_failure:
+    # "is requesting 'actions: read', but is only allowed 'actions: none'").
     permissions:
       contents: write
       issues: write
       pull-requests: write
+      actions: read

--- a/internal/mount/wrapper_permissions_test.go
+++ b/internal/mount/wrapper_permissions_test.go
@@ -1,0 +1,74 @@
+package mount
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// permRank orders GitHub Actions permission levels: none < read < write.
+var permRank = map[string]int{"none": 0, "read": 1, "write": 2, "": 0}
+
+type permWorkflow struct {
+	Jobs map[string]struct {
+		Permissions map[string]string `yaml:"permissions"`
+	} `yaml:"jobs"`
+}
+
+// TestWrapperTemplateGrantsNestedJobPermissions guards the bug that caused the
+// OpenBSS federation pipeline to fail with startup_failure: the generated
+// caller wrapper (templates/agentic-pipeline.yml.tmpl) must grant at least the
+// union of every nested job's permissions in the reusable workflow. A called
+// reusable-workflow job cannot request more than the caller grants, so a
+// missing scope (historically `actions: read`) makes the whole call fail to
+// load before any job runs.
+func TestWrapperTemplateGrantsNestedJobPermissions(t *testing.T) {
+	// Required = the max level each scope is requested at across all nested jobs.
+	reusable, err := os.ReadFile(reusableWorkflowPath(t))
+	if err != nil {
+		t.Fatalf("read reusable workflow: %v", err)
+	}
+	var rw permWorkflow
+	if err := yaml.Unmarshal(reusable, &rw); err != nil {
+		t.Fatalf("parse reusable workflow: %v", err)
+	}
+	required := map[string]string{}
+	for jobID, job := range rw.Jobs {
+		for scope, level := range job.Permissions {
+			if _, ok := permRank[level]; !ok {
+				t.Fatalf("job %s: unknown permission level %q for %q", jobID, level, scope)
+			}
+			if permRank[level] > permRank[required[scope]] {
+				required[scope] = level
+			}
+		}
+	}
+	if len(required) == 0 {
+		t.Fatal("no job-level permissions parsed from reusable workflow — test is a no-op")
+	}
+
+	// Granted = the caller wrapper's permissions block.
+	tmpl, err := os.ReadFile(repoRelativePath(t, "internal", "mount", "templates", "agentic-pipeline.yml.tmpl"))
+	if err != nil {
+		t.Fatalf("read wrapper template: %v", err)
+	}
+	var cw permWorkflow
+	if err := yaml.Unmarshal(tmpl, &cw); err != nil {
+		t.Fatalf("parse wrapper template (the {{.Version}} / ${{ }} scalars must stay valid YAML): %v", err)
+	}
+	caller, ok := cw.Jobs["pipeline"]
+	if !ok {
+		t.Fatal("wrapper template has no 'pipeline' job")
+	}
+
+	for scope, need := range required {
+		got := caller.Permissions[scope]
+		if permRank[got] < permRank[need] {
+			t.Errorf("wrapper template grants %q=%q but a nested job requires %q=%q — "+
+				"the reusable-workflow call will fail to load (startup_failure). "+
+				"Add `%s: %s` to the template's permissions block.",
+				scope, got, scope, need, scope, need)
+		}
+	}
+}


### PR DESCRIPTION
## The bug
Every run of a generated pipeline wrapper fails with **`startup_failure`** before any job runs:

> The nested job 'feature-design' is requesting 'actions: read', but is only allowed 'actions: none'.

The reusable workflow's execution jobs (feature-design, dev-session, compliance-verify, pr-review-session, issue-session, feature-complete) all declare `actions: read`. A **called reusable-workflow job cannot request more than the caller grants** — and the wrapper template (`internal/mount/templates/agentic-pipeline.yml.tmpl`) granted only `contents` / `issues` / `pull-requests`, never `actions`. So the call failed to load.

This broke the **OpenBSS federation pipeline (25/25 startup_failure)** — it had never successfully started.

## The fix
Add `actions: read` to the wrapper template's `permissions:` block (the caller must grant the union of every nested job's permissions).

## Regression guard
`TestWrapperTemplateGrantsNestedJobPermissions` parses the reusable workflow's per-job permissions and asserts the template grants at least that union. Verified it fails without the fix and passes with it.

## Verification
`go build`/`go vet`/`gofmt`/`go test ./...` all clean.

## Rollout note
Domain repos pick this up by regenerating their wrapper on `gh agentic upgrade` / `gh agentic repair`. **Existing** wrappers (e.g. OpenBSS) need the one-line `actions: read` grant added and pushed **with human credentials** — GitHub blocks workflow-file edits from runner tokens. Worth a patch release (`v3.0.1`) so `repair` regenerates correct wrappers.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)