### PR TITLE
fix: upgrade reconciles stale workflow refs; check flags workflow @version behind the pin

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -212,10 +212,12 @@ Run 'gh agentic repair' to auto-fix any issues that can be fixed automatically.`
 				ctx, _ := project.Resolve(projectDeps)
 				projectID := ""
 				topology := ""
+				frameworkVersion := ""
 				projectIDReadFailed := false
 				if ctx != nil {
 					projectID = ctx.ProjectID
 					topology = ctx.Topology
+					frameworkVersion = ctx.FrameworkVersion
 					projectIDReadFailed = ctx.ProjectIDReadFailed
 				}
 
@@ -227,6 +229,7 @@ Run 'gh agentic repair' to auto-fix any issues that can be fixed automatically.`
 					OwnerType:                info.OwnerType,
 					Topology:                 topology,
 					ProjectID:                projectID,
+					FrameworkVersion:         frameworkVersion,
 					ProjectIDReadFailed:      projectIDReadFailed,
 					Run:                      deps.run,
 					ReadCreds:                deps.readCreds,

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -191,10 +191,12 @@ func buildPipelineCheckDeps(pdeps project.Deps) (doctor.CheckDeps, error) {
 	ctx, _ := project.Resolve(pdeps)
 	projectID := ""
 	topology := ""
+	frameworkVersion := ""
 	projectIDReadFailed := false
 	if ctx != nil {
 		projectID = ctx.ProjectID
 		topology = ctx.Topology
+		frameworkVersion = ctx.FrameworkVersion
 		projectIDReadFailed = ctx.ProjectIDReadFailed
 	}
 
@@ -206,6 +208,7 @@ func buildPipelineCheckDeps(pdeps project.Deps) (doctor.CheckDeps, error) {
 		OwnerType:           ownerType,
 		Topology:            topology,
 		ProjectID:           projectID,
+		FrameworkVersion:    frameworkVersion,
 		ProjectIDReadFailed: projectIDReadFailed,
 		Run:                 run,
 		ReadCreds: func(r auth.RunCommandFunc) ([]byte, error) {

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -56,6 +56,13 @@ type CheckDeps struct {
 	// checks (variables, secrets, workflows, project reachability) run as
 	// normal. See feature #619 §E.
 	FrameworkSource bool
+	// FrameworkVersion is the authoritative AGENTIC_FRAMEWORK_VERSION the project
+	// is pinned to (from project.Resolve). checkWorkflows compares the wrapper
+	// workflow @version against this — not the local .agents/ mount — so a CP
+	// whose mount AND workflow are stale-but-consistent (both behind the pin) is
+	// still flagged. Empty when no pin is published; the check then falls back to
+	// the mounted version.
+	FrameworkVersion string
 }
 
 // checkGroupStep pairs a spinner label with a check function.
@@ -545,7 +552,16 @@ func checkAgentFiles(deps CheckDeps) Group {
 func checkWorkflows(deps CheckDeps) Group {
 	g := Group{Name: "Workflows"}
 
-	version, _ := mount.ReadAIVersionFromGit(deps.Root)
+	// Reference version: the authoritative AGENTIC_FRAMEWORK_VERSION pin when
+	// published, else the local .agents/ mount version. Comparing against the
+	// pin (not just the mount) catches a CP whose mount and workflow are both
+	// stale-but-consistent — the case `gh agentic upgrade` could silently leave.
+	version := deps.FrameworkVersion
+	versionSource := "pinned framework version"
+	if version == "" {
+		version, _ = mount.ReadAIVersionFromGit(deps.Root)
+		versionSource = "mounted framework version"
+	}
 	workflowsDir := filepath.Join(deps.Root, ".github", "workflows")
 
 	workflows := []string{"agentic-pipeline.yml", "release.yml"}
@@ -586,7 +602,7 @@ func checkWorkflows(deps CheckDeps) Group {
 		default:
 			g.Results = append(g.Results, CheckResult{
 				Name: wf, Status: Fail,
-				Message:     fmt.Sprintf("%s — version tag mismatch (expected @%s)", wf, mount.TrimVPrefix(version)),
+				Message:     fmt.Sprintf("%s — version tag mismatch (expected @%s, the %s)", wf, mount.TrimVPrefix(version), versionSource),
 				Remediation: "Run 'gh agentic repair' to update workflow versions",
 			})
 		}

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1903,3 +1903,57 @@ func TestCheckFederationProjectSync_DomainRepoUnlisted_Warns(t *testing.T) {
 		t.Errorf("expected acme/extra (linked, not in manifest) flagged unlisted, got: %+v", g.Results)
 	}
 }
+
+// TestCheckWorkflows_StaleVsPin_Fails guards the gap where the OpenBSS CP passed
+// `check` while its wrapper was behind the pinned framework version: when the
+// mounted .agents/ AND the workflow are stale-but-consistent (both at the old
+// version), checkWorkflows used to compare workflow-vs-mount and pass. It now
+// compares the workflow @version against the authoritative AGENTIC_FRAMEWORK_VERSION
+// pin (CheckDeps.FrameworkVersion), so a globally-behind CP is flagged.
+func TestCheckWorkflows_StaleVsPin_Fails(t *testing.T) {
+	root := t.TempDir()
+	// Mount and workflow agree at the OLD version...
+	setupAIGitRepo(t, filepath.Join(root, ".agents"), "v2.9.0")
+	wfDir := filepath.Join(root, ".github", "workflows")
+	_ = os.MkdirAll(wfDir, 0o755)
+	_ = os.WriteFile(filepath.Join(wfDir, "agentic-pipeline.yml"),
+		[]byte("uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.9.0"), 0o644)
+
+	// ...but the project is pinned to a NEWER version.
+	deps := CheckDeps{Root: root, FrameworkVersion: "v3.0.0"}
+
+	g := checkWorkflows(deps)
+
+	found := false
+	for _, r := range g.Results {
+		if r.Name == "agentic-pipeline.yml" && r.Status == Fail && strings.Contains(r.Message, "mismatch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected agentic-pipeline.yml to FAIL against the pin (v3.0.0); got: %+v", g.Results)
+	}
+}
+
+// TestCheckWorkflows_MatchesPin_Passes verifies the pin is the reference: when
+// the workflow @version equals the pin, it passes even if the local mount
+// reports a different (e.g. not-yet-updated) version.
+func TestCheckWorkflows_MatchesPin_Passes(t *testing.T) {
+	root := t.TempDir()
+	setupAIGitRepo(t, filepath.Join(root, ".agents"), "v2.9.0")
+	wfDir := filepath.Join(root, ".github", "workflows")
+	_ = os.MkdirAll(wfDir, 0o755)
+	_ = os.WriteFile(filepath.Join(wfDir, "agentic-pipeline.yml"),
+		[]byte("uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v3.0.0"), 0o644)
+	_ = os.WriteFile(filepath.Join(wfDir, "release.yml"),
+		[]byte("uses: eddiecarpenter/gh-agentic/.github/workflows/release.yml@v3.0.0"), 0o644)
+
+	deps := CheckDeps{Root: root, FrameworkVersion: "v3.0.0"}
+
+	g := checkWorkflows(deps)
+	for _, r := range g.Results {
+		if r.Status == Fail {
+			t.Errorf("expected pass against the pin, but %s failed: %s", r.Name, r.Message)
+		}
+	}
+}

--- a/internal/project/switch.go
+++ b/internal/project/switch.go
@@ -103,6 +103,21 @@ func SwitchVersion(w io.Writer, deps Deps, version string, pre SwitchVersionPref
 
 	if pre.CurrentVersion == version {
 		fmt.Fprintf(w, "  %s  Framework is already at %s\n", ui.StatusOK.Render("✓"), version)
+		// Reconcile wrapper workflow refs even when the mounted .agents/ already
+		// matches the target. They can drift from the mount — e.g. a prior
+		// upgrade's workflow-file edit was rejected (GitHub blocks workflow
+		// pushes from runner tokens), or only the submodule pointer moved. The
+		// mount-version short-circuit would otherwise leave a stale @version in
+		// the workflow forever, since RunSwitch (the only other caller of
+		// UpdateWorkflowVersions) runs only on an actual version change.
+		// Idempotent: a no-op when the refs already point at `version`.
+		n, err := mount.UpdateWorkflowVersionsCount(deps.Root, version)
+		if err != nil {
+			return fmt.Errorf("reconciling workflow versions: %w", err)
+		}
+		if n > 0 {
+			fmt.Fprintf(w, "  %s  Reconciled %d wrapper workflow(s) to @%s\n", ui.StatusOK.Render("✓"), n, version)
+		}
 		return writeVariable()
 	}
 

--- a/internal/project/switch_test.go
+++ b/internal/project/switch_test.go
@@ -388,3 +388,43 @@ func TestSwitchVersion_SkipsVariableWrite_WhenAlreadyCorrect(t *testing.T) {
 // out by a future refactor and the test would silently stop covering
 // the SwitchVersion → RunSwitch path.
 var _ = mount.FrameworkRepo
+
+// TestSwitchVersion_ReconcilesStaleWorkflowWhenMountMatches guards the gap that
+// left the OpenBSS CP wrapper pinned at the old version: when the mounted
+// .agents/ already equals the target, SwitchVersion used to short-circuit to
+// only writing the variable — never reconciling a stale workflow @version. Now
+// it reconciles workflow refs on that path too (idempotent).
+func TestSwitchVersion_ReconcilesStaleWorkflowWhenMountMatches(t *testing.T) {
+	root := t.TempDir()
+	wfDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(wfDir, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	wfPath := filepath.Join(wfDir, "agentic-pipeline.yml")
+	stale := "jobs:\n  pipeline:\n    uses: eddiecarpenter/gh-agentic/.github/workflows/agentic-pipeline.yml@v2.9.0\n"
+	if err := os.WriteFile(wfPath, []byte(stale), 0o644); err != nil {
+		t.Fatalf("seed workflow: %v", err)
+	}
+
+	writes := map[string]string{}
+	deps := Deps{
+		Root: root, Owner: "o", RepoName: "r", RepoFullName: "o/r",
+		GetRepoVariable: func(_, _, _ string) (string, error) { return "", nil },
+		SetRepoVariable: func(_, _, name, value string) error { writes[name] = value; return nil },
+	}
+	// Mount already at the target — the short-circuit path.
+	pre := SwitchVersionPreflight{CurrentVersion: "v3.0.0", IsFederatedCP: false}
+
+	var buf bytes.Buffer
+	if err := SwitchVersion(&buf, deps, "v3.0.0", pre, nil); err != nil {
+		t.Fatalf("SwitchVersion: %v", err)
+	}
+
+	got, _ := os.ReadFile(wfPath)
+	if strings.Contains(string(got), "@v2.9.0") || !strings.Contains(string(got), "@v3.0.0") {
+		t.Errorf("workflow @version not reconciled on the already-at-version path:\n%s", got)
+	}
+	if writes[FrameworkVersionVarName] != "v3.0.0" {
+		t.Errorf("expected %s=v3.0.0 written, got %q", FrameworkVersionVarName, writes[FrameworkVersionVarName])
+	}
+}


### PR DESCRIPTION
Two real gaps that let the OpenBSS CP run the **v2.9.0** pipeline while believing it was on **v3.0.0** — both found while diagnosing its `startup_failure`.

## Gap A — `gh agentic upgrade` doesn't reconcile a stale workflow `@version`
`project.SwitchVersion` short-circuits to *only* writing `AGENTIC_FRAMEWORK_VERSION` when the mounted `.agents/` already equals the target — skipping `mount.RunSwitch`, the **only** caller of `UpdateWorkflowVersions`. So a CP whose mount matches but whose workflow file is stale (e.g. a prior upgrade's workflow edit was rejected — GitHub blocks workflow pushes from runner tokens) can **never** be reconciled by `upgrade`.

**Fix:** reconcile workflow refs on the already-at-version path too (idempotent), reporting how many were rewritten.

## Gap B — `gh agentic check` doesn't flag the stale `@version`
`checkWorkflows` compared the workflow `@version` against the local `.agents/` **mount** (`ReadAIVersionFromGit`). So when the mount **and** the workflow are stale-but-consistent (both behind the pin), it passed ✓ — exactly the OpenBSS case.

**Fix:** compare against the authoritative **`AGENTIC_FRAMEWORK_VERSION`** pin (plumbed via `CheckDeps.FrameworkVersion` from `project.Resolve`), falling back to the mounted version only when no pin is published. The mismatch message now names which reference it used.

## Tests
- `TestSwitchVersion_ReconcilesStaleWorkflowWhenMountMatches` — reconciles on the already-at-version path.
- `TestCheckWorkflows_StaleVsPin_Fails` / `_MatchesPin_Passes` — check fails a workflow behind the pin, passes one matching it.

`go build`/`vet`/`gofmt`/`go test ./...` all clean. Pairs with #905 (the `actions: read` template fix). Worth folding into the `v3.0.1` patch.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)