### PR TITLE
fix: define the Verification Gate section in the Java standard

### DIFF
--- a/internal/cli/standards_gate_section_test.go
+++ b/internal/cli/standards_gate_section_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// gateSectionHeading is the exact heading that compliance-verify's Section
+// A.0 (the mandatory build+test gate) parses out of each detected stack's
+// standards file. The verifier reads the commands under this heading to run
+// the gate; a standards file that lacks it raises STACK_GATE_UNDEFINED and
+// the verifier blocks — a framework-level gap, not a code FAIL.
+//
+// See skills/compliance-verify/SKILL.md Section A.0 outcome #5.
+const gateSectionHeading = "## Verification Gate (build + test)"
+
+// languageStandardsRequiringGate is the set of per-language standards files
+// that describe an executable build+test toolchain and therefore MUST define
+// the Verification Gate section. These are the stacks a Feature's diff can be
+// detected as touching; compliance-verify needs a gate contract for each.
+//
+// Non-language standards files (e.g. a generic "documentation.md" if one is
+// added) are intentionally excluded — they have no build+test gate to run.
+var languageStandardsRequiringGate = []string{
+	"go.md",
+	"java.md",
+	"typescript.md",
+	"react.md",
+}
+
+// TestStandardsFilesDefineVerificationGate is the build-time guard for the
+// framework gap that left Feature #8 (OpenBSS Branding) stuck: standards/java.md
+// shipped without a `## Verification Gate (build + test)` section, so
+// compliance-verify raised STACK_GATE_UNDEFINED on every Java-touching Feature
+// and the workflow safety-net cycled the issue between in-verification and
+// in-development indefinitely.
+//
+// Every language standards file that defines an executable toolchain must carry
+// the gate heading. This test reads the real standards/*.md files at the repo
+// root (../.. from this package, mirroring TestNoLegacyAuthRefsInWorkflows) and
+// fails — listing every offender — if any is missing the section.
+func TestStandardsFilesDefineVerificationGate(t *testing.T) {
+	standardsDir := filepath.Join(repoRootFromCli, "standards")
+
+	var missing []string
+	for _, name := range languageStandardsRequiringGate {
+		path := filepath.Join(standardsDir, name)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %q: %v — a language standards file required to define the "+
+				"Verification Gate is absent or unreadable", path, err)
+		}
+		if !strings.Contains(string(content), gateSectionHeading) {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) == 0 {
+		return
+	}
+
+	sort.Strings(missing)
+	var msg strings.Builder
+	msg.WriteString("\n")
+	msg.WriteString("Language standards file(s) missing the Verification Gate section.\n\n")
+	msg.WriteString("compliance-verify Section A.0 parses the build+test commands out of the\n")
+	msg.WriteString("heading:\n\n")
+	msg.WriteString("    " + gateSectionHeading + "\n\n")
+	msg.WriteString("A detected stack whose standards file lacks this heading raises\n")
+	msg.WriteString("STACK_GATE_UNDEFINED and the verifier blocks — leaving the Feature stuck.\n\n")
+	msg.WriteString("Offending files (under standards/):\n")
+	for _, m := range missing {
+		msg.WriteString("  " + m + "\n")
+	}
+	msg.WriteString("\nRemediation: add a `" + gateSectionHeading + "` section mirroring the\n")
+	msg.WriteString("one in standards/go.md (commands, manifest pre-check, dev/compliance\n")
+	msg.WriteString("hooks, and the toolchain-absent → SKIPPED-with-WARN softening).\n")
+	t.Errorf("%s", msg.String())
+}

--- a/standards/java.md
+++ b/standards/java.md
@@ -45,6 +45,120 @@ Never claim an implementation is complete without the build passing cleanly.
 
 ---
 
+## Verification Gate (build + test)
+
+The build+test pass is the **mandatory gate** at two specific
+points in the pipeline. The same command runs in both places.
+
+**Maven:**
+```bash
+mvn clean verify
+```
+
+**Gradle:**
+```bash
+./gradlew build
+```
+
+`mvn clean verify` compiles, runs unit tests, and runs the
+verify-phase checks (integration tests, coverage gates) in one
+pass; `./gradlew build` does the equivalent for Gradle projects.
+The command must exit zero. Any non-zero exit — compilation
+failure, failing test, coverage-gate breach surfaced through
+`verify`, etc. — **fails** the gate.
+
+### Stack-eligibility pre-check (manifest presence)
+
+The Java gate only applies to a repository when its **build
+manifest is present**:
+
+```bash
+test -f pom.xml || test -f build.gradle || test -f build.gradle.kts
+```
+
+If no Java build manifest is present at the repo root (i.e. this
+isn't a Maven/Gradle project), the Java gate is **not eligible**
+for this repository. Compliance and the dev session SKIP the gate
+with a WARN ("Java manifest `pom.xml`/`build.gradle` not present —
+Java gate not applicable to this repo"); the verdict is **not a
+fail**.
+
+This handles the legitimate case where a multi-stack repo (e.g.
+Java + TypeScript) gets a Feature whose diff touches only files in
+a directory that is NOT a Java module — those files are not
+verifiable as a Java project and the gate should not pretend
+otherwise.
+
+### Dev Session — last step before exit
+
+After the final task commit and before the workflow applies
+`in-verification`, the dev session **MUST** run the gate when
+eligible (manifest present). On gate failure the dev session does
+NOT exit cleanly — it loops back to fix the breakage and re-runs
+the gate until it passes. Pushing a broken build or a failing test
+suite and signalling completion is forbidden.
+
+The dev session's exit block must state, for each touched stack,
+whether the gate ran and what its result was (PASS / FAIL / SKIPPED).
+An exit block that omits the gate result is itself a protocol
+violation.
+
+### Compliance Verify — first step before any other check
+
+The compliance verifier **MUST** run the gate (when eligible)
+before evaluating acceptance criteria, static analysis, or any
+other check. On gate failure the verifier emits an immediate FAIL
+verdict and short-circuits — ACs cannot be PASS while the build is
+broken or the tests fail, regardless of what code inspection
+suggests.
+
+The gate's run-and-result is the first item in the compliance
+report. Subsequent sections (static analysis, AC table) appear only
+when the gate passed or was skipped per the rules below.
+
+### When the toolchain is unavailable
+
+If a Java build manifest IS present but the toolchain is **not** on
+the runner's PATH (`mvn` for a Maven project, or a usable JDK / the
+`./gradlew` wrapper for a Gradle project), the gate is treated as
+**SKIPPED with a WARN** — not as PASS, not as FAIL, not as BLOCKED.
+The recipe records:
+
+- a `compliance-warn:v1` comment noting that the Java gate was
+  skipped because the toolchain isn't installed on the runner, with
+  the exact `which mvn` / `java -version` probe output
+- a recommendation to install the JDK + build tool on the runner
+  image (via `actions/setup-java@v4` plus Maven/Gradle, or a runner
+  image that bundles them) so the gate can actually run on the next
+  cycle
+- AC verdicts for build / test fields are marked **WARN — skipped**
+  rather than PASS or FAIL
+
+Compliance still produces an overall verdict, runs the static
+analysis section, and evaluates the AC table. The PR is permitted
+to open. CI (`build-and-test.yml` or equivalent) is the
+authoritative backstop for actually running the tests once the PR
+is open.
+
+This mirrors the Go and TypeScript gates: toolchain absence is a
+runner-image problem, not a reason to leave a real Feature in a
+permanent stuck-state. The intent is preserved by the "WARN, never
+PASS by inspection" rule below.
+
+### What is still forbidden
+
+- **PASS-by-inspection is still forbidden.** Compliance MUST NOT
+  emit a PASS verdict for the gate based on diff inspection alone.
+  The gate is either PASS (commands ran and exited zero), FAIL
+  (commands ran and exited non-zero), or SKIPPED-with-WARN
+  (commands could not run). No fourth state.
+- **FAIL-by-inspection is still forbidden.** Compliance MUST NOT
+  emit FAIL based on a CI run from a closed PR, sibling branch, or
+  any commit other than the current branch HEAD. Same trap, opposite
+  direction.
+
+---
+
 ## Coding Standards
 
 - **Dependency injection** — use constructor injection for all collaborators. Field injection (`@Autowired` on fields) is prohibited. All dependencies must be injectable for testing.


### PR DESCRIPTION
## Problem

The OpenBSS **Branding** feature (#8, Java/Quarkus backend + TS/React frontend) was stuck in an infinite `in-development ↔ in-verification` loop. Root cause, diagnosed from the live compliance-verify run:

`standards/java.md` was the **only** language standard missing the `## Verification Gate (build + test)` section. compliance-verify Section A.0 parses that section for **every** detected stack; a stack without it raises `STACK_GATE_UNDEFINED` and the verifier correctly blocks (Output D) rather than improvising a gate. `go.md`, `typescript.md`, and `react.md` all have the section — `java.md` had only `## Build Verification`.

## Fix

- Add `## Verification Gate (build + test)` to `standards/java.md`, mirroring `standards/go.md`: Maven/Gradle commands, manifest-presence eligibility pre-check, dev-session + compliance-verify hook points, and the **toolchain-absent → SKIPPED-with-WARN** softening. The softening means a runner without a JDK/Maven (OpenBSS's current state) WARNs and lets the PR open with CI as the backstop, instead of blocking a real Feature forever.
- Add `TestStandardsFilesDefineVerificationGate` — a build-time guard asserting every language standards file carries the gate heading, so this gap can't recur silently.

## Note — a second, latent gap (not in this PR)

The workflow safety-net (`agentic-pipeline.yml` "Safety net — swap in-verification on skill abort") misclassifies a *deliberate* `compliance-blocked:v1` exit as a mid-FAIL abort and cycles the issue back to `in-development` + `exit 1`. That is what turned the block into a destructive loop. This PR fixes the root cause (so #8 no longer blocks); the safety-net hardening is a separate workflow change to be handled interactively.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)