### PR TITLE
fix: safety-net honours compliance-blocked:v1 instead of cycling deliberate blocks

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -745,6 +745,20 @@ jobs:
             echo "in-verification already removed by skill — no safety-net action needed."
             exit 0
           fi
+          # Deliberate terminal block (compliance-verify Output D / Output F):
+          # the skill posts a <!-- compliance-blocked:v1 --> comment and
+          # INTENTIONALLY keeps the Feature at in-verification WITHOUT counting
+          # a cycle (e.g. STACK_GATE_UNDEFINED, toolchain absent on the runner).
+          # This is a human-actionable block, not a mid-FAIL abort — do NOT
+          # cycle it back to in-development or fail the run, or the feature
+          # ping-pongs in-development ↔ in-verification forever.
+          BLOCKED_COUNT=$(gh issue view "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --json comments \
+            --jq '[.comments[] | select(.body | startswith("<!-- compliance-blocked:v1 -->"))] | length')
+          if [ "${BLOCKED_COUNT}" -gt 0 ]; then
+            echo "::notice::compliance-verify posted a compliance-blocked:v1 comment — Feature #${ISSUE_NUMBER} stays at in-verification awaiting human action (environment/toolchain block, not counted toward the cycle cap). Safety net taking no action."
+            exit 0
+          fi
           # Post a minimal feedback comment if the skill did not post one, so
           # the next dev session has context about what failed.
           FEEDBACK_COUNT=$(gh issue view "${ISSUE_NUMBER}" --repo "${REPO}" \

--- a/internal/mount/pipeline_safety_net_test.go
+++ b/internal/mount/pipeline_safety_net_test.go
@@ -1,0 +1,94 @@
+package mount
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestSafetyNetHonoursComplianceBlockedMarker — the compliance-verify
+// safety-net step force-swaps a stuck `in-verification` Feature back to
+// `in-development` when it suspects the skill aborted mid-FAIL. But
+// compliance-verify Output D / Output F (e.g. STACK_GATE_UNDEFINED,
+// toolchain absent) are DELIBERATE terminal blocks: the skill posts a
+// `<!-- compliance-blocked:v1 -->` comment and intentionally keeps the
+// Feature at in-verification without counting a cycle. The safety net
+// must detect that marker and take no action — otherwise a re-firing
+// dev-session produces an infinite in-development ↔ in-verification loop
+// (observed live: OpenBSS/openbss run 27793325499).
+//
+// This test pins that the marker check exists and runs BEFORE the
+// destructive cycle/exit-1 logic.
+func TestSafetyNetHonoursComplianceBlockedMarker(t *testing.T) {
+	wfPath := reusableWorkflowPath(t)
+	data, err := os.ReadFile(wfPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", wfPath, err)
+	}
+	var wf map[string]any
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("parse workflow: %v", err)
+	}
+
+	run := safetyNetRunScript(t, wf)
+
+	// 1. The marker must be referenced at all.
+	const marker = "compliance-blocked:v1"
+	if !strings.Contains(run, marker) {
+		t.Fatalf("safety-net step does not reference %q — deliberate blocks would be misclassified as aborts.\nScript:\n%s", marker, run)
+	}
+
+	// 2. The marker check must guard an early exit 0 that happens BEFORE
+	//    the destructive `--add-label "in-development"` cycle.
+	markerIdx := strings.Index(run, marker)
+	cycleIdx := strings.Index(run, `--add-label "in-development"`)
+	if cycleIdx < 0 {
+		t.Fatalf("safety-net step no longer adds in-development — test assumptions are stale, review manually.\nScript:\n%s", run)
+	}
+	if markerIdx > cycleIdx {
+		t.Errorf("compliance-blocked:v1 check appears AFTER the in-development cycle (marker@%d, cycle@%d) — the block guard must run first.\nScript:\n%s", markerIdx, cycleIdx, run)
+	}
+
+	// 3. There must be an early `exit 0` between the marker check and the
+	//    cycle, so a blocked Feature is not force-swapped.
+	between := run[markerIdx:cycleIdx]
+	if !strings.Contains(between, "exit 0") {
+		t.Errorf("no `exit 0` between the compliance-blocked:v1 check and the in-development cycle — a deliberate block would still be cycled.\nSegment:\n%s", between)
+	}
+}
+
+// safetyNetRunScript locates the compliance-verify safety-net step and
+// returns its `run:` script body.
+func safetyNetRunScript(t *testing.T, wf map[string]any) string {
+	t.Helper()
+	jobs, ok := wf["jobs"].(map[string]any)
+	if !ok {
+		t.Fatalf("workflow has no jobs map")
+	}
+	job, ok := jobs["compliance-verify"].(map[string]any)
+	if !ok {
+		t.Fatalf("compliance-verify job missing")
+	}
+	steps, ok := job["steps"].([]any)
+	if !ok {
+		t.Fatalf("compliance-verify job has no steps")
+	}
+	for _, s := range steps {
+		step, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := step["name"].(string)
+		if strings.Contains(name, "Safety net") && strings.Contains(name, "in-verification") {
+			run, _ := step["run"].(string)
+			if run == "" {
+				t.Fatalf("safety-net step %q has empty run:", name)
+			}
+			return run
+		}
+	}
+	t.Fatalf("safety-net step not found in compliance-verify job")
+	return ""
+}


### PR DESCRIPTION
## Problem

The compliance-verify safety-net step (`.github/workflows/agentic-pipeline.yml`, "Safety net — swap in-verification on skill abort") force-swapped any still-`in-verification` Feature back to `in-development` and `exit 1`d, assuming the skill aborted mid-FAIL.

But compliance-verify **Output D** (`STACK_GATE_UNDEFINED` and other catastrophic blocks) and **Output F** (toolchain absent) are *deliberate terminal states*. The skill posts a `<!-- compliance-blocked:v1 -->` comment and intentionally keeps the Feature at `in-verification` **without counting a cycle** (see `skills/compliance-verify/SKILL.md` Section A.0 outcome #5 and the Output D / Output F blocks). The safety-net never checked for this marker, so it misclassified legitimate blocks as aborts — cycling the Feature back to `in-development` and failing the run. With a re-firing dev-session this becomes an infinite `in-development` ↔ `in-verification` loop.

**Live evidence:** OpenBSS/openbss run `27793325499` (Compliance Verify Stage 5) — the agent blocked on `STACK_GATE_UNDEFINED` and the safety-net cycled #8 back to `in-development` with `exit 1`.

## Fix

Before the cycle/`exit 1` logic, the safety-net now checks whether a `<!-- compliance-blocked:v1 -->` comment exists on the issue. If it does, it is treated as a legitimate human-actionable block:

- leaves the Feature at `in-verification` (no label swap),
- logs a `::notice::` explaining a human-actionable block is posted,
- `exit 0` (no fallback `compliance-feedback:v1` comment, no `exit 1`).

Only when no `compliance-blocked:v1` marker is present does the existing abort-recovery (swap to `in-development`) run.

## Test

Adds `TestSafetyNetHonoursComplianceBlockedMarker` (`internal/mount/pipeline_safety_net_test.go`) — a structural guard asserting the safety-net step references the `compliance-blocked:v1` marker and that the check (with an early `exit 0`) runs **before** the destructive `--add-label "in-development"` cycle.

## Scope note

This is the safety-net hardening only. The root cause of the original block (missing Java verification gate) was fixed separately in #908.

Per `LOCALRULES.md`, this workflow-file change was made in an interactive session and pushed with human credentials.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)