### PR TITLE
fix: dev-session remediates compliance feedback when all tasks are closed

### DIFF
--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -745,6 +745,20 @@ jobs:
             echo "in-verification already removed by skill — no safety-net action needed."
             exit 0
           fi
+          # Deliberate terminal block (compliance-verify Output D / Output F):
+          # the skill posts a <!-- compliance-blocked:v1 --> comment and
+          # INTENTIONALLY keeps the Feature at in-verification WITHOUT counting
+          # a cycle (e.g. STACK_GATE_UNDEFINED, toolchain absent on the runner).
+          # This is a human-actionable block, not a mid-FAIL abort — do NOT
+          # cycle it back to in-development or fail the run, or the feature
+          # ping-pongs in-development ↔ in-verification forever.
+          BLOCKED_COUNT=$(gh issue view "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --json comments \
+            --jq '[.comments[] | select(.body | startswith("<!-- compliance-blocked:v1 -->"))] | length')
+          if [ "${BLOCKED_COUNT}" -gt 0 ]; then
+            echo "::notice::compliance-verify posted a compliance-blocked:v1 comment — Feature #${ISSUE_NUMBER} stays at in-verification awaiting human action (environment/toolchain block, not counted toward the cycle cap). Safety net taking no action."
+            exit 0
+          fi
           # Post a minimal feedback comment if the skill did not post one, so
           # the next dev session has context about what failed.
           FEEDBACK_COUNT=$(gh issue view "${ISSUE_NUMBER}" --repo "${REPO}" \

--- a/internal/mount/pipeline_safety_net_test.go
+++ b/internal/mount/pipeline_safety_net_test.go
@@ -1,0 +1,94 @@
+package mount
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestSafetyNetHonoursComplianceBlockedMarker — the compliance-verify
+// safety-net step force-swaps a stuck `in-verification` Feature back to
+// `in-development` when it suspects the skill aborted mid-FAIL. But
+// compliance-verify Output D / Output F (e.g. STACK_GATE_UNDEFINED,
+// toolchain absent) are DELIBERATE terminal blocks: the skill posts a
+// `<!-- compliance-blocked:v1 -->` comment and intentionally keeps the
+// Feature at in-verification without counting a cycle. The safety net
+// must detect that marker and take no action — otherwise a re-firing
+// dev-session produces an infinite in-development ↔ in-verification loop
+// (observed live: OpenBSS/openbss run 27793325499).
+//
+// This test pins that the marker check exists and runs BEFORE the
+// destructive cycle/exit-1 logic.
+func TestSafetyNetHonoursComplianceBlockedMarker(t *testing.T) {
+	wfPath := reusableWorkflowPath(t)
+	data, err := os.ReadFile(wfPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", wfPath, err)
+	}
+	var wf map[string]any
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("parse workflow: %v", err)
+	}
+
+	run := safetyNetRunScript(t, wf)
+
+	// 1. The marker must be referenced at all.
+	const marker = "compliance-blocked:v1"
+	if !strings.Contains(run, marker) {
+		t.Fatalf("safety-net step does not reference %q — deliberate blocks would be misclassified as aborts.\nScript:\n%s", marker, run)
+	}
+
+	// 2. The marker check must guard an early exit 0 that happens BEFORE
+	//    the destructive `--add-label "in-development"` cycle.
+	markerIdx := strings.Index(run, marker)
+	cycleIdx := strings.Index(run, `--add-label "in-development"`)
+	if cycleIdx < 0 {
+		t.Fatalf("safety-net step no longer adds in-development — test assumptions are stale, review manually.\nScript:\n%s", run)
+	}
+	if markerIdx > cycleIdx {
+		t.Errorf("compliance-blocked:v1 check appears AFTER the in-development cycle (marker@%d, cycle@%d) — the block guard must run first.\nScript:\n%s", markerIdx, cycleIdx, run)
+	}
+
+	// 3. There must be an early `exit 0` between the marker check and the
+	//    cycle, so a blocked Feature is not force-swapped.
+	between := run[markerIdx:cycleIdx]
+	if !strings.Contains(between, "exit 0") {
+		t.Errorf("no `exit 0` between the compliance-blocked:v1 check and the in-development cycle — a deliberate block would still be cycled.\nSegment:\n%s", between)
+	}
+}
+
+// safetyNetRunScript locates the compliance-verify safety-net step and
+// returns its `run:` script body.
+func safetyNetRunScript(t *testing.T, wf map[string]any) string {
+	t.Helper()
+	jobs, ok := wf["jobs"].(map[string]any)
+	if !ok {
+		t.Fatalf("workflow has no jobs map")
+	}
+	job, ok := jobs["compliance-verify"].(map[string]any)
+	if !ok {
+		t.Fatalf("compliance-verify job missing")
+	}
+	steps, ok := job["steps"].([]any)
+	if !ok {
+		t.Fatalf("compliance-verify job has no steps")
+	}
+	for _, s := range steps {
+		step, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := step["name"].(string)
+		if strings.Contains(name, "Safety net") && strings.Contains(name, "in-verification") {
+			run, _ := step["run"].(string)
+			if run == "" {
+				t.Fatalf("safety-net step %q has empty run:", name)
+			}
+			return run
+		}
+	}
+	t.Fatalf("safety-net step not found in compliance-verify job")
+	return ""
+}

--- a/skills/dev-session/SKILL.md
+++ b/skills/dev-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-session
-description: Implements a Feature's tasks in order — reading the rationale comment and the ordered Task sub-issues, then walking each open task (read body, implement with reuse discipline, run tests, commit with the prescribed message format, push, close the task issue) until all tasks are done. On exit, the surrounding GitHub Actions workflow opens the PR and transitions the Feature to in-review. Use when workflow automation fires on in-development label apply against a Feature whose feature-design phase has produced a rationale, ordered tasks, and a feature branch. Headless only; humans running implementation interactively use this skill as a guide.
+description: Implements a Feature's tasks in order — reading the rationale comment and the ordered Task sub-issues, then walking each open task (read body, implement with reuse discipline, run tests, commit with the prescribed message format, push, close the task issue) until all tasks are done. On exit, the surrounding GitHub Actions workflow opens the PR and transitions the Feature to in-review. On a fix run — the Feature is kicked back to in-development with compliance-feedback while all tasks are already closed — it implements the failed acceptance criteria directly on the branch rather than no-opping. Use when workflow automation fires on in-development label apply against a Feature whose feature-design phase has produced a rationale, ordered tasks, and a feature branch. Headless only; humans running implementation interactively use this skill as a guide.
 triggers: automated
 user-invocable: false
 loads:
@@ -49,17 +49,21 @@ A return value at exit summarising the run:
 ```
 { repo: <string>, feature: <int>, branch: <string>,
   tasks_total: <int>, tasks_completed_this_run: <int>,
-  exit_state: "completed" | "no-op" | "blocked" }
+  exit_state: "completed" | "remediated" | "no-op" | "blocked" }
 ```
 
 `exit_state`:
 - `completed` — all tasks closed by end of session.
-- `no-op` — entered with all tasks already closed (re-run case).
+- `remediated` — a fix run entered with all tasks already closed but
+  outstanding compliance feedback; the failed acceptance criteria were
+  implemented directly on the branch (step 7b).
+- `no-op` — entered with all tasks already closed AND no outstanding
+  compliance feedback (a genuine re-run, nothing to do).
 - `blocked` — the agent could not complete a task (build/test
   refused to pass, ambiguous task body, missing dependency); the
   Feature stays at `in-development` and the human takes over.
 
-The skill's four valid terminal outputs:
+The skill's five valid terminal outputs:
 
 **A. Completed.** Walked through K open tasks, all committed,
 pushed, closed. Feature still at `in-development`; the workflow's
@@ -69,9 +73,18 @@ post-agent steps will push (no-op) and open the PR.
 entry (a prior run committed them); walked the remaining open ones
 and finished. Same exit shape as A.
 
-**C. Re-run no-op.** Entered with zero open tasks. Nothing to do;
-exit cleanly. The workflow's PR-creation step is idempotent (`gh pr
-create` no-ops when a PR already exists for the branch).
+**C. Re-run no-op.** Entered with zero open tasks **and no
+outstanding compliance feedback**. Nothing to do; exit cleanly. The
+workflow's PR-creation step is idempotent (`gh pr create` no-ops when
+a PR already exists for the branch). Output C is a bug when
+compliance feedback is outstanding — see E.
+
+**E. Feedback-remediated.** Entered a *fix run* (compliance kicked
+the Feature back with `compliance-feedback:v1`) with all tasks
+already closed. The failed acceptance criteria were implemented
+directly on the branch (step 7b) and committed; the work list came
+from the feedback, not from open task issues. Same downstream
+handoff as A/B: the workflow pushes and re-runs compliance.
 
 **D. Blocked.** The agent could not finish one of the tasks. Surface
 the failure clearly in the exit block (which task, what failed,
@@ -336,9 +349,55 @@ discipline at task granularity:
    preserving order. The recovery probe (step 6a) trims tasks
    already completed by a prior run.
 
-   - **`<open-tasks>` empty** → all tasks already closed. Skip the
-     walk; emit Output C in step 18.
-   - **Non-empty** → walk through.
+   - **`<open-tasks>` empty AND `<compliance-feedback>` (step 6b) is
+     null** → all tasks closed and no outstanding feedback. A genuine
+     re-run no-op: skip the walk; emit Output C in step 18.
+   - **`<open-tasks>` empty AND `<compliance-feedback>` present** →
+     this is a *fix run* whose failed work lives inside one or more
+     already-closed tasks (a task was closed before its acceptance
+     criteria were truly met). It is **not** a no-op — emitting
+     Output C here is the bug that produces the endless
+     `in-development ↔ in-review` cycle (the task cursor is blind to
+     work that a *closed* task failed to deliver, so every re-run
+     no-ops until the cycle cap, and clearing the count cannot help
+     because the tasks stay closed). Go to step 7b.
+   - **Non-empty** → walk through (step 8). If `<compliance-feedback>`
+     is also present, the remediation obligation in step 7b applies
+     to the closed-task ACs *in addition to* completing the open tasks.
+
+7b. **Feedback-remediation flow (fix run with no open task to carry
+    the work).** Entered from step 7 when `<compliance-feedback>` is
+    present. Because the responsible task issue is already closed, the
+    compliance feedback **is** the work list.
+
+    - Read the latest `<!-- compliance-feedback:v1 -->` comment and the
+      `<!-- compliance-report:v1 -->` it references (both on the Feature
+      issue, on the control plane). Extract every acceptance criterion
+      marked **FAIL** or **PARTIAL**, with the report's stated reason.
+    - For each failed / partial AC, implement the fix **directly on the
+      feature branch**. There is no open task issue to close — the
+      branch is the work surface. Apply the same discipline as the
+      per-task walk: the reuse outcome (recorded in the commit
+      trailer), narrow scope (touch only what the AC requires), and the
+      verification gate (tests + build must pass before the commit).
+    - Commit with a body naming the AC(s) addressed, e.g.
+      `fix: satisfy AC-<n> (<short>) — compliance remediation (#<N>)`,
+      carrying the mandatory `Co-Authored-By` and `Reuse:` trailers.
+      Push.
+    - Re-run the verification gate (step 15pre's commands) over the
+      whole branch before exit.
+    - If a failed AC genuinely cannot be satisfied (the feedback is
+      wrong, or the work is truly blocked), raise `TASK_BLOCKED`
+      (`WARN`) and emit Output D naming the AC — do **not** silently
+      no-op. That is a real human-review event.
+    - On success, jump to step 16 (verify), step 17 (release slot),
+      and emit **Output E** in step 18. Do not run the task walk
+      (steps 8–15) when `<open-tasks>` was empty — every task is
+      already closed.
+
+    This is what makes the cycle self-healing: each fix run now does
+    real work, so the 3-cycle cap means "the agent tried three times
+    and could not satisfy the ACs," not "the agent no-op'd three times."
 
 8. **Per-task — read.** For the next open task `T_K` (where K is
    its position in `<tasks>` and M is `len(<tasks>)`):
@@ -698,11 +757,37 @@ discipline at task granularity:
     ```
     === Dev Session — No-op ===
 
-    Entered with zero open tasks. All <M> tasks for #<N> were
-    already closed.
+    Entered with zero open tasks and no outstanding compliance
+    feedback. All <M> tasks for #<N> were already closed.
 
     Next: workflow applies in-verification, triggering compliance-verify.
     ```
+
+    Output C is valid ONLY when step 6b found no
+    `compliance-feedback:v1` comment. Emitting Output C while feedback
+    is outstanding is a protocol violation: it guarantees an identical
+    compliance failure and an endless cycle. In that case the correct
+    output is E (work done) or D (fix impossible).
+
+    **Output E — Feedback-remediated:**
+    ```
+    === Dev Session — Completed (feedback remediation) ===
+
+    Fix run: entered with all <M> tasks already closed and outstanding
+    compliance feedback. The feedback carried the work list.
+
+    Produced:
+      - <K> remediation commit(s) on feature/<N>-<slug>
+      - Acceptance criteria addressed: AC-<a>, AC-<b>, ...
+
+    Verification gate: PASS (stacks: <stack-1>[, <stack-2>...])
+      - <stack-1>: <command-1> ✓ ; <command-2> ✓ ; ...
+
+    Next: workflow applies in-verification, triggering compliance-verify.
+    ```
+
+    The "Verification gate" line is mandatory in Output E for the same
+    reason as A/B.
 
     **Output D — Blocked:**
     ```


### PR DESCRIPTION
## Problem

Recurring failure in OpenBSS (confirmed on feature **#100**): the dev-session doesn't fully satisfy a Feature's acceptance criteria, compliance kicks it back to `in-development`, but re-running the dev-session does **nothing** — this repeats to the 3-cycle cap and escalates to `needs-human-review`. Clearing the count and re-triggering doesn't help either.

**#100 evidence:** all four tasks (#101–#104) CLOSED; timeline shows design-plan → 3× `compliance-feedback:v1` (~12 min apart) → `compliance-escalation` (cycle cap) → `needs-human-review`.

## Root cause

In `dev-session/SKILL.md`, **step 6b** detects the feedback and declares *"this is a fix run,"* but **step 7** computes the work cursor purely from **open task issues**. With every task closed, `<open-tasks>` is empty → step 7 short-circuits to **Output C (re-run no-op)** before any remediation can run. The task walk is the only thing that produces commits, and it only walks open tasks — so the cursor is permanently blind to work that a *closed* task failed to deliver. Every cycle no-ops; the cap is reached without the agent ever attempting the fix. That's why clearing the count changes nothing: the tasks stay closed.

## Fix

- **Gate the no-op:** step 7's empty-`<open-tasks>` branch now checks `<compliance-feedback>`. Empty + no feedback = genuine no-op (Output C). Empty + feedback = **fix run → step 7b**.
- **New step 7b (feedback-remediation flow):** read the latest `compliance-feedback:v1` + `compliance-report:v1`, extract FAIL/PARTIAL ACs, implement the fixes **directly on the feature branch** with full commit discipline (reuse trailer, narrow scope, verification gate), push, exit via steps 16/17 with new **Output E**. If an AC genuinely can't be satisfied → `TASK_BLOCKED` + Output D, never a silent no-op.
- **Tighten Output C:** valid only when no `compliance-feedback:v1` is outstanding; emitting it with feedback present is a protocol violation that guarantees the endless cycle.
- Add `exit_state "remediated"` + terminal Output E; description covers fix runs.

Net effect: the cycle becomes self-healing — each fix run does real work, so the 3-cycle cap means "tried three times and couldn't," not "no-op'd three times."

## Notes

- Skill change made interactively per the Skill Editing Authority rule.
- Feature #100 left as-is for now (separate remediation); this PR fixes the framework so #100 and future features stop looping once the framework is upgraded on OpenBSS.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)