### PR TITLE
fix: compliance cycle cap is progress-aware (resets when branch advances)

### DIFF
--- a/skills/compliance-verify/SKILL.md
+++ b/skills/compliance-verify/SKILL.md
@@ -188,20 +188,46 @@ and reuse as `<active-repo>`.
      already past compliance verification; this run is a no-op or a
      workflow bug.
 
-3b. **Check the feedback cycle count.** Count how many
-    `<!-- compliance-feedback:v1 -->` comments already exist on the
-    Feature issue:
+3b. **Check the feedback cycle count (progress-aware).** The cap
+    counts only *unaddressed* feedback — FAIL cycles the branch has
+    not responded to yet. A `<!-- compliance-feedback:v1 -->` comment
+    **older than the branch's current HEAD commit** has been
+    superseded by later work and does **not** count. Counting all
+    feedback comments cumulatively is a latch bug: a Feature that
+    failed three times and was then fixed would be capped out forever,
+    and neither re-triggering nor clearing labels could ever release
+    it (the fix lands, but compliance halts before it looks).
+
+    The feature branch is already checked out in the project dir, so
+    take its HEAD commit time and count only feedback newer than it:
 
     ```bash
+    HEAD_TIME=$(git log -1 --format=%cI HEAD)
     gh issue view <N> --repo <active-repo> --json comments \
-      --jq '[.comments[] | select(.body | startswith("<!-- compliance-feedback:v1 -->"))] | length'
+      --jq --arg head "$HEAD_TIME" \
+        '[.comments[]
+          | select(.body | startswith("<!-- compliance-feedback:v1 -->"))
+          | select(.createdAt > $head)] | length'
     ```
 
-    Hold as `<feedback-count>`.
+    Hold as `<feedback-count>`. If `HEAD_TIME` cannot be determined
+    (no branch, detached tree), fall back to counting **all**
+    `compliance-feedback:v1` comments — the conservative
+    pre-progress-aware behaviour.
 
-    **Cap:** if `<feedback-count>` ≥ 3, the dev-session and
-    compliance-verify cycle has exceeded its permitted retries. Do
-    NOT continue verification. Instead:
+    **Stale-cap cleanup:** if `<feedback-count>` is **below** the cap
+    but a `needs-human-review` label is present, it is a leftover from
+    a prior cap that later work has superseded. Remove it and continue
+    — the pipeline has resumed:
+
+    ```bash
+    gh issue edit <N> --repo <active-repo> --remove-label "needs-human-review"
+    ```
+
+    **Cap:** if `<feedback-count>` ≥ 3, three FAIL cycles have
+    occurred with **no intervening progress** on the branch. The
+    dev-session and compliance-verify cycle has exceeded its permitted
+    retries. Do NOT continue verification. Instead:
 
     a. Post an escalation comment via `post-issue-comment`:
 


### PR DESCRIPTION
## Problem

After v3.0.4 (dev-session remediation fix #910), OpenBSS **#100** still loops to `needs-human-review`. v3.0.4 worked — the dev-session correctly entered the remediation path and confirmed AC-3 is on the branch. But a **second, deeper bug** pins it: the compliance **cycle cap never resets**.

`compliance-verify` step 3b counted **all** `compliance-feedback:v1` comments cumulatively. Once three accrued, the cap latched permanently — every run halted at step 3b **before** running the build/AC gates. A fix landing after the third FAIL could never be verified, and re-triggering / clearing labels couldn't release it.

**#100 evidence:** three feedback comments (09:26 / 09:38 / 09:53Z) were all written against the task-3 commit `1e0edd6`; the AC-3 fix landed at 10:38Z in `61be12b`. Compliance checked out `61be12b` (the correct HEAD — confirmed in the run log) but step 3b saw `feedback-count = 3` and escalated **without ever looking at the code**.

## Fix

Make the cap **progress-aware**: count only `compliance-feedback:v1` comments **newer than the branch's current HEAD commit time**. Feedback superseded by later work is not an unaddressed cycle. The cap now means *"three FAILs with no intervening progress,"* not *"three FAILs ever."*

- Falls back to the old cumulative count if HEAD time can't be determined.
- Also removes a stale `needs-human-review` label when proceeding below the cap, so a superseded escalation doesn't linger.

The workflow's "Fail if cycle cap reached" step is unchanged — it only mirrors the skill's `needs-human-review` decision, so fixing the skill fixes the latch end-to-end.

## Effect on #100

Next re-trigger: HEAD `61be12b` (10:38Z) is newer than all three feedbacks → effective count 0 → compliance proceeds, verifies AC-3 (now present), and passes.

Skill change made interactively per the Skill Editing Authority rule.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)