### PR TITLE
feat: wire Maven + GitHub Packages auth into the Java pipeline setup

### DIFF
--- a/.github/actions/setup-goose-env/action.yml
+++ b/.github/actions/setup-goose-env/action.yml
@@ -58,6 +58,24 @@ inputs:
       mistral; silently unused otherwise.
     required: false
     default: ''
+  project-pat:
+    description: >
+      PROJECT_PAT secret — a CLASSIC PAT carrying read:packages. Used to
+      authenticate Maven to the GitHub Packages registry (maven.pkg.github.com)
+      for Java projects that pull private artifacts (e.g. the io.openbss:* parent
+      POM). The fine-grained PIPELINE_PAT cannot authenticate to the legacy
+      Maven/npm Packages API, so a classic token is required here. Silently
+      unused for non-Java projects.
+    required: false
+    default: ''
+  maven-packages-server-id:
+    description: >
+      The <server> id written into ~/.m2/settings.xml, which MUST match the
+      <repository> id the project POM declares for GitHub Packages. Defaults to
+      the repo owner login lowercased (the OpenBSS convention, e.g. "openbss").
+      Override only if a POM uses a non-conventional repository id.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -161,6 +179,73 @@ runs:
       with:
         distribution: temurin
         java-version: '21'
+
+    # setup-java installs the JDK but not Maven itself. GitHub-hosted images ship
+    # Maven, but self-hosted runners generally do not — so the agent's mandatory
+    # `mvn clean verify` gate is unrunnable and every Java task blocks. Install a
+    # pinned Apache Maven into $HOME (no sudo/apt needed, works on any Linux
+    # runner) when it is absent, and add it to PATH for the recipe step.
+    - name: Install Maven (if absent)
+      if: steps.stacks.outputs.java == 'true'
+      shell: bash
+      run: |
+        if command -v mvn >/dev/null 2>&1; then
+          echo "✓ Maven already present: $(mvn -v | head -1)"
+          exit 0
+        fi
+        MAVEN_VERSION=3.9.9
+        echo "Maven not found — installing Apache Maven ${MAVEN_VERSION} to \$HOME/.local."
+        curl -fsSL "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" -o /tmp/apache-maven.tar.gz
+        mkdir -p "$HOME/.local/apache-maven"
+        tar -xzf /tmp/apache-maven.tar.gz -C "$HOME/.local/apache-maven" --strip-components=1
+        rm -f /tmp/apache-maven.tar.gz
+        echo "$HOME/.local/apache-maven/bin" >> "$GITHUB_PATH"
+        "$HOME/.local/apache-maven/bin/mvn" -v | head -1
+        echo "✓ Maven ${MAVEN_VERSION} installed."
+
+    # Java projects in this federation pull private artifacts (e.g. the
+    # io.openbss:* parent POM) from GitHub Packages. Maven never reads GH_TOKEN,
+    # and the fine-grained PIPELINE_PAT cannot authenticate to the legacy Maven
+    # Packages registry anyway — a CLASSIC token with read:packages is required.
+    # PROJECT_PAT is that token. Wire it in via ~/.m2/settings.xml so `mvn` can
+    # resolve private artifacts; without this the parent POM 401s and nothing
+    # compiles. The <server> id must match the POM's <repository> id (OpenBSS
+    # convention: owner login lowercased). The token is referenced as
+    # ${env.MAVEN_PACKAGES_TOKEN} — resolved by Maven at build time from the job
+    # env (exported below, masked) — so it is never written to disk in plaintext.
+    - name: Configure Maven for GitHub Packages
+      if: steps.stacks.outputs.java == 'true'
+      shell: bash
+      env:
+        PACKAGES_TOKEN: ${{ inputs.project-pat }}
+        OWNER: ${{ github.repository_owner }}
+        SERVER_ID_OVERRIDE: ${{ inputs.maven-packages-server-id }}
+      run: |
+        if [ -z "${PACKAGES_TOKEN}" ]; then
+          echo "::warning::PROJECT_PAT was not provided to setup-goose-env — Maven cannot authenticate to GitHub Packages. Private artifacts (e.g. io.openbss:* parent POM) will 401. Pass project-pat: \${{ secrets.PROJECT_PAT }} at the call site."
+        fi
+        SERVER_ID="${SERVER_ID_OVERRIDE:-$(printf '%s' "${OWNER}" | tr '[:upper:]' '[:lower:]')}"
+        mkdir -p "$HOME/.m2"
+        # Unquoted heredoc: ${SERVER_ID}/${OWNER} are expanded by the shell now;
+        # \${env.MAVEN_PACKAGES_TOKEN} is written literally for Maven to resolve.
+        cat > "$HOME/.m2/settings.xml" <<SETTINGSEOF
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+            <server>
+              <id>${SERVER_ID}</id>
+              <username>${OWNER}</username>
+              <password>\${env.MAVEN_PACKAGES_TOKEN}</password>
+            </server>
+          </servers>
+        </settings>
+        SETTINGSEOF
+        # Export the token to the job env (masked) so the recipe step's `mvn`
+        # resolves ${env.MAVEN_PACKAGES_TOKEN}. No token is written to settings.xml.
+        echo "::add-mask::${PACKAGES_TOKEN}"
+        echo "MAVEN_PACKAGES_TOKEN=${PACKAGES_TOKEN}" >> "$GITHUB_ENV"
+        echo "✓ Wrote ~/.m2/settings.xml for GitHub Packages server id '${SERVER_ID}'."
 
     # Write provider/model to the Goose config file so they are the defaults even
     # if the env vars are not inherited by a subprocess. The recipe run step also

--- a/.github/workflows/agentic-pipeline.yml
+++ b/.github/workflows/agentic-pipeline.yml
@@ -152,6 +152,7 @@ jobs:
           pipeline-pat: ${{ secrets.PIPELINE_PAT }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
+          project-pat: ${{ secrets.PROJECT_PAT }}
 
       # gh is available now (installed by setup-goose-env). Resolve the feature's
       # TARGET repo from the Target-repo field (#872).
@@ -355,6 +356,7 @@ jobs:
           pipeline-pat: ${{ secrets.PIPELINE_PAT }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
+          project-pat: ${{ secrets.PROJECT_PAT }}
 
       # gh is available now. Resolve the feature's TARGET repo from the Target-repo
       # field (#872), then the feature branch within it (paginated, against the
@@ -608,6 +610,7 @@ jobs:
           pipeline-pat: ${{ secrets.PIPELINE_PAT }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
+          project-pat: ${{ secrets.PROJECT_PAT }}
 
       # gh is available now. Resolve the feature's TARGET repo (#872) and the
       # feature branch within it (paginated, against the TARGET repo).
@@ -878,6 +881,7 @@ jobs:
           pipeline-pat: ${{ secrets.PIPELINE_PAT }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
+          project-pat: ${{ secrets.PROJECT_PAT }}
 
       # gh is available now. Resolve the TARGET repo from the feature number
       # embedded in the PR branch (feature/<N>-*) via the Target-repo field (#872).
@@ -992,6 +996,7 @@ jobs:
           pipeline-pat: ${{ secrets.PIPELINE_PAT }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
+          project-pat: ${{ secrets.PROJECT_PAT }}
 
       # PIPELINE_PAT: go-gh inside Goose needs to read Actions variables
       # (AGENTIC_PROJECT_ID). github.token does not propagate reliably through
@@ -1101,6 +1106,7 @@ jobs:
           pipeline-pat: ${{ secrets.PIPELINE_PAT }}
           claude-credentials-json: ${{ secrets.CLAUDE_CREDENTIALS_JSON }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
+          project-pat: ${{ secrets.PROJECT_PAT }}
 
       - name: Extract feature issue number
         id: feature

--- a/concepts/context-layers-and-roles.md
+++ b/concepts/context-layers-and-roles.md
@@ -1,0 +1,189 @@
+# concept: context layers and human roles
+
+This document defines **who provides what to the pipeline before the first line
+of code is designed** — the human roles in the first half of the pipeline, the
+layers of context they own, and the single rule that keeps a goal-seeking agent
+from dragging a human past their competence.
+
+Read `lean-pipeline.md` for why the autonomous stages are tool-lean, and
+`knowledge-plane.md` for where knowledge lives. This document is the companion
+for *the first half* — everything above the first judgment gate, where humans
+author and the agent facilitates.
+
+---
+
+## The two human contributions have opposite shapes
+
+With agentic workflows in the loop, the human stops being an author of every
+artefact and becomes the source of two things the agent cannot supply itself:
+
+- **Judgment is episodic and gated.** It happens at discrete, blocking points:
+  *approve the design/plan*, and *approve the code at merge*. Point-in-time,
+  yes/no, "this is right / redo it."
+- **Context is continuous and foundational.** It is the substrate every
+  autonomous step draws from — plan, design, implementation all read it. Not a
+  gate; an ambient input that must exist *before* the autonomous stages can be
+  trusted.
+
+This distinction is load-bearing. Judgment wants clean gates. Context wants a
+persistent, loadable home. The pipeline already has the gates; this concept
+closes the gap on the context.
+
+---
+
+## Role collapse — to two, not one
+
+Agentic workflows collapse the traditional delivery roles, but not all the way
+to a single person. Everything **technical** — solution architect, architect,
+developer — collapses into **the software engineer + the agent**, because those
+are the same kind of competence: technical judgment about how the system works
+and how to build it.
+
+**Product owner does not collapse into the engineer.** Business competence —
+what the market needs, what is worth prioritising, whether an outcome fits the
+customer — is a genuinely different faculty. It does not fuse into a technical
+head just because agentic workflows arrived. The one seam that survives the
+collapse is **business competence vs technical competence.**
+
+| Role | Competence | Degree in the pipeline | Faces the agent? |
+|---|---|---|---|
+| **Product owner** | Business — need, priority, outcome-fit | Low / bounded | **No** |
+| **Software engineer** | Technical — context, design, build judgment | Primary (the operator) | **Yes** |
+
+The engineer is the pipeline's **front door**. The product owner is a *source
+that feeds the engineer*, deliberately kept one step back from the agent — for
+the reason in the next section.
+
+---
+
+## Why the product owner stays one step back
+
+It is tempting to let the product owner define their requirement directly in the
+pipeline. This fails — not because the product owner is weak, but because it
+points a **goal-seeking agent at a human who cannot match its drive.**
+
+Endgoal-drive is the agent's asset *below* the first judgment gate — you want
+execution to run to done. *Above* the gate it is a **hazard**: "running with it"
+means the agent keeps escalating toward technical context and design decisions
+the product owner cannot supply *or judge*. Three failure modes, in increasing
+danger:
+
+1. The product owner blocks, overwhelmed.
+2. The agent fills the gap itself — context invented, not provided.
+3. Worst: the product owner **rubber-stamps agent-invented context they cannot
+   evaluate** — so unjudged context enters the pipeline wearing a human's
+   approval. That is more dangerous than no approval at all.
+
+The product owner's contribution is real, but it belongs **upstream of the
+facilitator** — delivered human-to-human (or via a bounded, non-agentic
+capture) to the engineer. The engineer receives the business need, brings the
+technical context layers, and is competent to keep pace with the agent's drive.
+
+> Point the goal-seeking agent only at the human who can match it.
+
+---
+
+## The context layers
+
+Context is layered, and each layer answers a different question. In the
+traditional world each layer had a different role owner. The roles collapse; the
+**layers do not** — they still have to exist as artefacts, because the layers
+are exactly what the agent reads to avoid inventing.
+
+| # | Layer | Old role | Answers | Home |
+|---|---|---|---|---|
+| 1 | Business / org context | Business analyst | Why the org cares; domain; constraints | `BRIEF.md` *(exists)* |
+| 2 | **Technical / solution context** | **Solution architect** | Tech landscape; existing systems; integration reality; NFRs; the sanctioned approach | **`SOLUTION_CONTEXT.md`** *(new — the missing layer)* |
+| 3 | Architectural design | Architect | How it maps into system structure | `ARCHITECTURE.md` *(exists)* |
+| 4 | The requirement | Business | The specific ask (what/why, no how) | Requirement issue *(exists)* |
+| 5 | Implementation plan | Developer | How to build *this* requirement | scoping + feature-design *(agent)* |
+| 6 | Implementation | Developer | The code | dev-session *(agent)* |
+
+Layers 1, 3, 4, 5, 6 already have homes. **Layer 2 — the technical/solution
+context the solution architect used to own — had none.** Its owning role
+collapsed into the engineer, but its output artefact was never re-homed. That
+missing middle is why implementation "lacked the bigger context and filled the
+blanks with its own ideas": the pipeline carried the requirement (4) and the
+structural design (3) but not the connective tissue between them.
+
+`SOLUTION_CONTEXT.md` closes that gap.
+
+---
+
+## `SOLUTION_CONTEXT.md` — the contract
+
+**Holds:** the durable, cross-requirement technical context an engineer would
+otherwise carry in their head — the technology landscape, the systems this
+work integrates with, the non-functional requirements, the sanctioned way to
+approach problems in this codebase, and the constraints that shape *how* things
+get built. It is the forward-looking design intent that precedes requirements,
+distinct from `ARCHITECTURE.md`, which is the backward-looking, current-state
+description assembled *after* features merge (see `knowledge-plane.md`).
+
+**Author:** the software engineer, with the agent facilitating — interview,
+challenge, structure, draft. Never authored by an autonomous stage.
+
+**Cadence:** rare and strategic, like `BRIEF.md` — a direct, human-driven PR.
+It changes when the technical landscape shifts, not per feature.
+
+**Distinguished from scoping:** durable, reusable technical context lives in
+`SOLUTION_CONTEXT.md`; requirement-specific "how" lives in the per-feature
+scoping artefact. Same kind of content, sorted by lifetime.
+
+**Load-or-stop rule (the guarded cliff):** `SOLUTION_CONTEXT.md` is loaded into
+every session and is a **required input** to the autonomous stages. The
+autonomous stages may **consume it but never author it.** A stage that cannot
+find the technical context it needs must **stop and ask — never invent.**
+Inventing context below the first gate is precisely the failure this concept
+exists to prevent.
+
+> Topology note: in single topology `SOLUTION_CONTEXT.md` lives at the repo
+> `docs/` root alongside `BRIEF.md` and `ARCHITECTURE.md`. The federation
+> homing (system tier vs domain tier, per `knowledge-plane.md`) is a scoping
+> decision for the build, not fixed here.
+
+---
+
+## The disposition inversion at the first gate
+
+Matching the right human to the pipeline is necessary but not sufficient. The
+agent's momentum must **change character** at the first judgment gate:
+
+- **Below gate 1 — drive to *done*.** Execution; momentum is the feature.
+- **Above gate 1 — drive to *"everything this human can competently give,"
+  then stop.*** Not drive-to-done. The agent elicits and structures, and when it
+  reaches the edge of the operator's competence it **flags the gap or hands to a
+  more competent human — it never fills it itself.**
+
+A goal-seeking agent left un-inverted above the context layer will *always* drag
+a human past their limit. So the first-half design is not only "which human" but
+"which human **and** an agent whose disposition is capped to that human's
+competence." This single inversion protects the human and closes the
+invented-context bug at the same time.
+
+---
+
+## The two judgment gates
+
+- **Gate 1 — design / plan approval.** The engineer judges the plan, either by
+  being in the loop through interactive design, or by reviewing the published
+  design rationale after a headless design run (the SAPAV pattern — see
+  `agent-rationale-as-artefact.md`).
+- **Gate 2 — code review at merge.** The engineer judges the code.
+
+The stretch of autonomous execution is, by definition, the span *between* two
+gates. That is why headless automation starts at gate 1 and no higher: you
+cannot push automation above the first gate without deleting the human's core
+contribution or merely relocating the gate.
+
+---
+
+## Cross-references
+
+- `lean-pipeline.md` — why the autonomous stages are tool-lean; the
+  facilitator-vs-executor boundary is the same boundary as autonomy.
+- `knowledge-plane.md` — where `BRIEF.md`, `ARCHITECTURE.md`, and (by extension)
+  `SOLUTION_CONTEXT.md` live and how they load into every session.
+- `agent-rationale-as-artefact.md` — the SAPAV pattern behind gate 1.
+- `delivery-philosophy.md` — the pipeline's scope and the deploy/release/enable
+  distinction.


### PR DESCRIPTION
## Problem

charging-backend feature **#149** blocks in the dev-session with `BUILD_FAILED_PERSISTENT`: its private parent POM `io.openbss:openbss-parent` lives in **GitHub Packages** (`maven.pkg.github.com/OpenBSS/openbss`) and the build can't authenticate → **401**, so nothing compiles.

Root cause (confirmed with the repo owner):
- `PIPELINE_PAT` (the pipeline's `GH_TOKEN`) is a **fine-grained** PAT — it **cannot** authenticate to the legacy Maven Packages registry at all.
- `PROJECT_PAT` is a **classic** PAT **with `read/write:packages`** — the correct credential — but it was only ever used for project-board mutations, never handed to Maven.
- `setup-goose-env` installed the **JDK** (`setup-java`) but **not Maven**, and self-hosted runners don't ship it.
- **Maven never reads `GH_TOKEN`** anyway — it authenticates via `~/.m2/settings.xml`, which nothing wrote.

## Change

`setup-goose-env`, for Java projects (`pom.xml` / `build.gradle` present):

1. **Installs Maven** — pinned Apache Maven 3.9.9 into `$HOME` when absent (no sudo/apt; works on self-hosted runners), added to PATH for the recipe step.
2. **Writes `~/.m2/settings.xml`** — a `<server>` whose id defaults to the **repo owner login lowercased** (the OpenBSS convention; matches the POM's `<repository><id>openbss</id>`), overridable via the new `maven-packages-server-id` input. Password is `${env.MAVEN_PACKAGES_TOKEN}` — resolved by Maven at build time from the **masked** job env, so **no token is written to disk**.

New inputs: `project-pat` (PROJECT_PAT) and `maven-packages-server-id`. All six `setup-goose-env` call sites now pass `project-pat: ${{ secrets.PROJECT_PAT }}` (already declared in the reusable `workflow_call` secrets and forwarded by the wrapper).

## Scope / caveats

- Clears the **GitHub Packages 401** and completes the **Java toolchain** (JDK + Maven).
- **Docker** is still required on the runner for Features whose ACs need Docker-backed integration tests (e.g. #149's tenant-isolation test) — that's runner-image provisioning, out of framework scope.
- Needs a **live pipeline run to validate** on the actual self-hosted runner (can't be exercised from unit tests). YAML validated with `yq`; full Go suite green.

Workflow/composite-action change made interactively per LOCALRULES.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)