### PR TITLE
fix: setup-goose-env installs JDK 25 to match the fleet compile target

### DIFF
--- a/.github/actions/setup-goose-env/action.yml
+++ b/.github/actions/setup-goose-env/action.yml
@@ -169,16 +169,19 @@ runs:
         go-version-file: go.mod
         cache: false
 
-    # Install JDK only when the repo is actually a Java project. java-version
-    # is 21 (current LTS) as a pragmatic default; per-project version pinning
-    # can be added later via `java-version-file` (.java-version, etc.) if a
-    # project needs it.
+    # Install JDK only when the repo is actually a Java project. java-version is
+    # 25 (current LTS) — it MUST be at least the highest maven.compiler.release
+    # any consuming project targets, or the build fails at compile with
+    # "release version N not supported". The default reflects the release the
+    # projects using this framework actually compile to; per-project version
+    # pinning can be added later via `java-version-file` (.java-version, etc.)
+    # if a project ever diverges from that default.
     - name: Setup Java
       if: steps.stacks.outputs.java == 'true'
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
       with:
         distribution: temurin
-        java-version: '21'
+        java-version: '25'
 
     # setup-java installs the JDK but not Maven itself. GitHub-hosted images ship
     # Maven, but self-hosted runners generally do not — so the agent's mandatory


### PR DESCRIPTION
## Problem

`setup-goose-env` installs Temurin **JDK 21**, but the Java projects that run through the pipeline compile with `maven.compiler.release=25` (inherited from their shared parent POM). A Maven build then fails at compile with `release version 25 not supported` — the installed JDK is a major version behind the bytecode target it is asked to produce, so **dev-session build verification cannot compile Java projects at all**.

#912 closed the adjacent gaps in the same setup path — pinned Apache Maven install (self-hosted/ARC-friendly) and GitHub Packages auth for the private parent POM — but left the JDK one major version behind the release target.

## Fix

Pin the `Setup Java` step to `java-version: '25'` so the installed JDK is at least the highest `release` any consuming project targets. One line, plus an updated rationale comment. Per-project pinning via `java-version-file` remains available if a project ever diverges from the default.

## Scope / risk

- Only affects the conditional `Setup Java` step (runs only when `pom.xml`/Gradle is present). Non-Java repos are unaffected.
- Temurin 25 is GA and supported by `actions/setup-java@v5`.
- No change to the Maven/Packages-auth wiring from #912.

## Rollout

After merge + tag, domain repos pick this up by bumping `AGENTIC_FRAMEWORK_VERSION` to the new tag.

🤖 Generated with [gh-agentic](https://github.com/eddiecarpenter/gh-agentic)